### PR TITLE
fix: make optional adapters opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,17 @@ bash install.sh --platform codex
 
 默认安装到 `~/.codex/skills/llm-wiki`。如果用户机器上还是旧的 `~/.Codex/skills`，安装器也会自动兼容。
 
+默认只准备知识库核心主线。如果这次要自动提取网页 / X / 微信公众号 / YouTube / 知乎，再执行：
+
+```bash
+bash install.sh --platform codex --with-optional-adapters
+```
+
 ## 重要提醒
 
 - 不要把这个仓库当成 Codex 专属仓库；Claude Code 和 OpenClaw 也共用同一套核心内容
 - 安装完成后，再按 [SKILL.md](SKILL.md) 的工作流继续做事
-- 如果 OpenClaw 使用的是自定义技能目录，可以改用 `--target-dir`
+- 如果 OpenClaw 使用的是自定义技能目录，可以改用 `--target-dir <你的技能目录>/llm-wiki`
 
 ## 使用顺序
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v2.3.0 (2026-04-15)
+
+### 改进
+
+- `install.sh`：默认安装和默认升级只准备知识库核心主线；网页、X/Twitter、微信公众号、YouTube、知乎提取改为显式追加 `--with-optional-adapters`
+- `README.md`、`AGENTS.md`、`CLAUDE.md`、平台入口：统一补充“核心默认可用、URL 自动提取按需开启”的说明，并澄清 `--target-dir` 需要传最终的 `llm-wiki` 目录
+
+### 修复
+
+- `install.sh`：修复 `--upgrade --target-dir <...>/llm-wiki` 被默认平台目录覆盖的问题，自定义技能目录现在会升级到正确位置
+- `install.sh`：目标目录不存在时，升级命令现在明确失败，不再误报“升级完成”
+- `scripts/adapter-state.sh` + `scripts/runtime-context.sh`：统一源码目录、已安装目录和升级目标目录的判断，避免状态检查在不同运行位置下漂移
+- `tests/regression.sh`、`tests/adapter-state.sh`：回归矩阵改成保护“核心默认可用、可选提取显式开启”的新边界
+
 ## v2.2.0 (2026-04-14)
 
 ### 新增

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ bash install.sh --platform claude
 
 > `setup.sh` 是 `install.sh --platform claude` 的兼容包装，老用户可以继续用。
 
+默认只准备知识库核心主线。如果这次要自动提取网页 / X / 微信公众号 / YouTube / 知乎，再执行：
+
+```bash
+bash install.sh --platform claude --with-optional-adapters
+```
+
 ## 推送前测试规则
 
 每次 `git push` 前必须验证，按改动范围选深度：

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 
 ## 前置条件
 
-- 你的 agent 能执行 shell 命令
-- 如果你要自动提取网页或公众号，Chrome 需要以调试模式启动
+- 核心主线前提：你的 agent 能执行 shell 命令，并能读写本地文件
+- 如果你要自动提取网页、X/Twitter 或知乎，Chrome 需要以调试模式启动
 - 如果你要自动提取微信公众号或 YouTube 字幕，机器上需要有 `uv`
-- `bun` 或 `npm` 二选一即可，安装网页提取依赖时会自动择一使用
+- 如果你要启用网页提取依赖，`bun` 或 `npm` 二选一即可
 
 ## 安装方式
 
@@ -51,9 +51,7 @@ bash install.sh --platform openclaw
 - Codex: `~/.codex/skills/llm-wiki`（如果你旧环境还在用 `~/.Codex/skills`，安装器也会兼容）
 - OpenClaw: `~/.openclaw/skills/llm-wiki`
 
-如果 OpenClaw 不是这一路径，也可以显式传入 `--target-dir <你的技能目录>`。
-
-旧的 Claude 安装方式仍然保留给现有用户：`bash setup.sh`。它现在只是统一安装器的兼容入口。
+如果 OpenClaw 不是这一路径，也可以显式传入 `--target-dir <你的技能目录>/llm-wiki`。
 
 ### 更新
 
@@ -66,10 +64,22 @@ bash install.sh --upgrade
 会自动完成：
 1. `git pull` 拉取最新代码
 2. 检测你已安装的平台（Claude / Codex / OpenClaw）
-3. 重新复制文件并安装依赖
+3. 重新复制核心文件
 4. 已有的 hook 配置不受影响
 
 如果装了多个平台，需要显式指定：`bash install.sh --upgrade --platform claude`。
+
+如果你是装在自定义目录里，升级时也把最终的技能目录一并传进来：
+
+```bash
+bash install.sh --upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki
+```
+
+如果你还需要刷新网页 / X / 微信公众号 / YouTube / 知乎的自动提取能力，再显式追加：
+
+```bash
+bash install.sh --upgrade --platform <你的平台> --with-optional-adapters
+```
 
 ## 来源边界
 
@@ -97,6 +107,7 @@ bash install.sh --upgrade
 - **对话结晶化**：把有价值的对话内容直接沉淀为知识库页面
 - **智能去重**：SHA256 缓存跳过未变化的素材，批量处理时不浪费 token
 - **智能素材路由**：根据 URL 域名自动选择最佳提取方式
+- **核心优先安装**：默认只准备知识库主线，网页 / X / 公众号 / YouTube / 知乎提取按需显式开启
 - **素材删除**：级联删除素材时自动清理关联页面、断链和缓存
 - **查询结果持久化**：有价值的综合回答可保存回知识库，越用越完整
 - **自动上下文注入**：SessionStart hook 让 agent 每次会话自动感知知识库（Claude Code）
@@ -132,13 +143,23 @@ bash install.sh --upgrade
 
 只有在环境里明确只存在一个平台目录时，才建议用 `--platform auto`。
 
+### 如果我想启用网页 / X / 微信公众号 / YouTube 自动提取怎么办？
+
+默认安装只准备知识库核心主线。
+
+需要自动提取 URL 类来源时，再按当前平台执行：
+
+- Claude Code: `bash install.sh --platform claude --with-optional-adapters`
+- Codex: `bash install.sh --platform codex --with-optional-adapters`
+- OpenClaw: `bash install.sh --platform openclaw --with-optional-adapters`
+
 ### 为什么 X / Twitter 提取还是失败？
 
-X / Twitter 现在走 `baoyu-url-to-markdown`。如果提取失败，通常是因为 Chrome 没有启动调试模式，或者当前 Chrome 会话没有登录 X。你也可以直接把内容复制粘贴给 agent 处理。
+X / Twitter 现在走 `baoyu-url-to-markdown`。如果还没启用可选提取器，先按当前平台重新运行安装命令，并追加 `--with-optional-adapters`。如果已经启用但仍然失败，通常是因为 Chrome 没有启动调试模式，或者当前 Chrome 会话没有登录 X。你也可以直接把内容复制粘贴给 agent 处理。
 
 ### 为什么公众号提取还是失败？
 
-公众号现在使用 `wechat-article-to-markdown`。如果机器上还没有 `uv`，安装器会提示并跳过这一项；补装 `uv` 后重新运行 `bash install.sh --platform <你的平台>` 即可。
+公众号现在使用 `wechat-article-to-markdown`。如果机器上还没有 `uv`，安装器会提示并跳过这一项；补装 `uv` 后重新运行 `bash install.sh --platform <你的平台> --with-optional-adapters` 即可。
 
 ## 目录结构
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -46,18 +46,22 @@ Scripts located in `scripts/` subdirectory.
 
 ## 依赖检查
 
-首次使用时，检查以下依赖是否已安装。如果缺失，提示用户运行安装：
+核心主线（本地文件、纯文本、已有知识库操作）默认不需要这些提取依赖。
+
+只有当用户给的是 URL 类来源，并且明确要自动提取网页 / X / 微信公众号 / YouTube / 知乎内容时，才检查以下可选依赖。
+
+如果缺失，提示用户运行：
 
 ```bash
-bash ${SKILL_DIR}/setup.sh
+bash ${SKILL_DIR}/install.sh --platform <当前平台> --with-optional-adapters
 ```
 
-依赖 skill / 工具：
+可选依赖 skill / 工具：
 - `baoyu-url-to-markdown` — 普通网页、X/Twitter、部分知乎提取
 - `wechat-article-to-markdown` — 微信公众号提取
 - `youtube-transcript` — YouTube 字幕提取
 
-即使部分依赖缺失，skill 仍可工作（用户可以手动粘贴文本内容）。
+即使这些依赖缺失，skill 仍可工作（用户可以直接提供本地文件、粘贴文本，或改走手动入口）。
 
 ## 外挂状态模型
 

--- a/docs/plans/2026-04-14-001-fix-optional-adapter-install-boundary-plan.md
+++ b/docs/plans/2026-04-14-001-fix-optional-adapter-install-boundary-plan.md
@@ -1,0 +1,323 @@
+---
+title: fix: Separate core install from optional adapter bootstrap
+type: fix
+status: completed
+date: 2026-04-14
+origin: docs/brainstorms/2026-04-06-project-cleanup-and-restructuring-requirements.md
+deepened: 2026-04-14
+---
+
+# fix: Separate core install from optional adapter bootstrap
+
+## Overview
+
+这份计划解决的是安装和升级路径把“可选提取器”误当成“默认前置”的问题。
+
+目标不是重做提取体系，也不是继续扩充安装器，而是把产品承诺重新收口到一个更稳的边界：
+
+- 默认安装和默认升级只保证知识库核心主线可用
+- 网页、X/Twitter、微信公众号、YouTube、知乎的自动提取改成显式启用
+- 依赖状态判断不再混淆源码目录、已安装目录和升级临时副本
+- 测试和文档改成保护这个新默认值，而不是继续把错误默认值锁死
+
+## Problem Frame
+
+Phase B 已经明确要求“核心主线独立成立，外挂只是可选进料能力”（见 origin: `docs/brainstorms/2026-04-06-project-cleanup-and-restructuring-requirements.md`）。当前实现虽然在说明里写了“PDF / 本地文件 / 纯文本不依赖外挂”，但安装和升级行为仍然把可选提取器放在默认主路径上：
+
+- `install.sh` 默认安装会复制 bundled 提取器、安装网页提取的 Node 依赖、再尝试安装公众号工具
+- `install.sh --upgrade` 也会重复执行同一套可选提取器链路
+- `SKILL.md` 的首次使用说明会先让 agent 检查这些提取器依赖，缺失时还会引导所有平台运行 `setup.sh`
+- `adapter-state.sh` 默认假设自己运行在已安装目录结构里，导致源码目录调试和升级排查时结论漂移
+- `tests/regression.sh` 当前把“默认安装必须把可选提取器都装上”写成了回归断言
+
+结果就是：只想处理本地文档和纯文本的用户，也会在拉最新版或重装时反复撞上可选依赖；一旦网络慢、源慢或环境不齐，体验就像“卡在依赖上”。
+
+## Requirements Trace
+
+- R1. 默认安装和默认升级必须只保证知识库核心主线可用，不得因为可选提取器缺失或安装缓慢阻断成功路径。
+- R2. 可选提取器必须改成显式启用，只有用户明确要用 URL 类自动提取时才进入对应安装链路。
+- R3. 共享说明和技能说明必须按当前平台给出正确的安装指令，不能再把 `setup.sh` 当成通用入口。
+- R4. 依赖状态判断必须能稳定区分源码目录、已安装目录和升级临时副本三种场景。
+- R5. 默认升级在存在多个已安装平台时必须避免误操作到非目标平台。
+- R6. 回归测试必须把“核心默认可用、可选功能按需开启”作为新的保护边界。
+
+## Scope Boundaries
+
+- 不重写网页、YouTube、公众号等提取器自身的实现。
+- 不改变核心知识库工作流的内容分析、页面生成和目录结构。
+- 不引入插件市场、自动发现系统或复杂的开关界面。
+- 不在这一轮做按单个来源细粒度选择提取器的复杂参数设计；先把“默认关闭，显式开启”立住。
+- 不要求老用户迁移已有知识库。
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `install.sh` 已经把安装动作集中在一个脚本里，并有 `--platform`、`--upgrade`、hook 注册等统一入口，适合继续收口默认路径。
+- `scripts/source-registry.sh` 和 `scripts/source-registry.tsv` 已经提供了来源与依赖的权威定义，适合继续作为“哪些属于可选提取器”的单一来源。
+- `scripts/adapter-state.sh` 已经承担状态分类，但路径解析还是局部猜测，没有和安装脚本共享运行场景定义。
+- `tests/adapter-state.sh` 已经有状态分类测试骨架，适合补成“源码 / 安装 / 升级临时副本”的矩阵。
+- `tests/regression.sh` 已经覆盖安装、升级入口和文档对齐，适合改成保护新的默认合同。
+
+### Institutional Learnings
+
+- `docs/plans/2026-04-06-002-phase-b-core-and-adapter-separation-plan.md` 已明确把“核心主线独立成立”作为底线。
+- `docs/solutions/integration-issues/unify-optional-adapter-states-and-fallback-paths-2026-04-06.md` 说明了可选提取器失败必须被清晰隔离，不能拖垮主线。
+- `.context/compound-engineering/todos/005-pending-p2-separate-source-and-installed-skill-paths.md` 已把本次 review 的核心问题收敛为“源码目录 vs 已安装目录未区分清楚”。
+- `docs/solutions/logic-errors/lint-runner-index-path-and-install-sync-2026-04-14.md` 提醒了这个仓库长期存在“源码改了，但已安装副本不同步”的高频风险，计划里必须把安装副本和运行副本一起考虑。
+
+### External References
+
+- 本次不需要额外外部资料。这里的问题是本仓库已经定下的边界没有被默认安装路径贯彻，仓库内现有计划、说明和测试已经足够定义正确方向。
+
+## Key Technical Decisions
+
+- 默认安装合同改为“核心优先，提取器显式开启”。
+  理由：这直接对应 R1/R2，也是用户反馈里最痛的点。只要默认路径仍然碰可选提取器，后续再怎么补文案和状态提示，体验都会继续被拖慢。
+
+- 新增显式开关 `--with-optional-adapters`，用于安装和升级时主动启用可选提取器链路。
+  理由：先解决“默认不该装”的问题，比一上来做按来源细粒度选择更稳。布尔开关足够表达“我要启用 URL 自动提取”，也更容易在文档和技能说明里讲清楚。
+
+- `setup.sh` 保留为 Claude 兼容入口，但只在 Claude 专属文档里出现；共享说明改为始终使用 `install.sh --platform <current-platform>`。
+  理由：这既保留向后兼容，也消除跨平台误导。
+
+- 引入共享的运行场景解析 helper，由安装脚本和 `adapter-state.sh` 一起使用。
+  理由：源码目录、已安装目录、升级临时副本的路径判断不能继续各写一套。共享 helper 比“在某个脚本里再补一个特判”更稳。
+
+- 保留 `llm-wiki` 包内的 `deps/` 作为可选提取器源码仓，但默认不把它们激活成目标平台下的已启用提取器。
+  理由：这样既能保持后续显式启用时不必重新拉源码，也能把“技能包里带着源码”和“当前平台已经启用这个提取器”明确分开。
+
+- 测试策略从“默认装全家桶”改为“两层保护”：默认核心路径 + 显式可选路径。
+  理由：没有测试护栏，新的默认合同很快又会被后续改动拉回旧路径。
+
+## Open Questions
+
+### Resolved During Planning
+
+- 默认安装和默认升级是否还要继续碰可选提取器？
+  结论：不要。默认只保证核心主线，提取器必须显式开启。
+
+- 是否需要本轮就设计按单个来源选择提取器的复杂参数？
+  结论：不需要。本轮先用 `--with-optional-adapters` 建立清晰边界，细粒度选择延后。
+
+- 源码目录和已安装目录的问题是补一个局部特判，还是立共享模型？
+  结论：立共享模型。否则安装脚本和状态脚本还会继续漂移。
+
+### Deferred to Implementation
+
+- `--with-optional-adapters` 是否需要在后续扩展成 `--optional-adapters=<list>`。
+  先不做；实现阶段只要保持内部结构可扩展即可。
+
+- 共享运行场景 helper 是独立成 `scripts/runtime-context.sh`，还是并入现有 `shared-config.sh`。
+  这里延后到实现时根据 shell 复用边界决定，但必须是两个脚本共用的一处逻辑。
+
+- 安装完成后是否需要新增独立的 `doctor` 或 `status --install` 类诊断入口。
+  本轮不做新命令，只先让现有安装输出和状态输出对齐。
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+### Behavior Matrix
+
+| 场景 | 默认行为 | 显式启用可选提取器后 |
+|---|---|---|
+| `bash install.sh --platform <x>` | 复制核心 skill、脚本、模板、平台入口；不触发 Node/uv/Chrome 相关安装 | 增加可选提取器复制与依赖安装 |
+| `bash install.sh --upgrade --platform <x>` | 拉最新代码并更新核心安装副本；不触发可选提取器安装 | 增加可选提取器刷新与依赖安装 |
+| 共享说明 / `SKILL.md` 首次使用 | 本地文件、纯文本直接进入主线；不提前检查提取器 | 只有用户给了 URL 且提取器缺失时，提示当前平台执行显式开关安装 |
+| `adapter-state.sh check` 在源码目录运行 | 读取源码目录的 bundled 依赖位置，不误报为未安装 | 同一状态模型，额外反映环境条件 |
+| `adapter-state.sh check` 在已安装目录 / 升级临时副本运行 | 读取目标 skill root 的 bundled 依赖位置 | 同一状态模型，额外反映环境条件 |
+
+### Shared Context Shape
+
+- `layout_mode`: `source_checkout` / `installed_skill` / `upgrade_target`
+- `bundle_root`: 当前 llm-wiki 本体所在根目录
+- `optional_adapter_root`: bundled 提取器应被检查或写入的目录
+- `platform`: `claude` / `codex` / `openclaw` / `unknown`
+
+所有安装和状态判断只读这组共享结果，不再各自从 `dirname "$PROJECT_ROOT"` 之类的局部推断出路径。
+
+## Implementation Units
+
+- [x] **Unit 1: 重定义安装与升级的默认合同**
+
+**Goal:** 把默认安装和默认升级从“顺手装可选提取器”改成“只保证核心主线”。
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `install.sh`
+- Modify: `README.md`
+- Modify: `platforms/claude/CLAUDE.md`
+- Modify: `platforms/codex/AGENTS.md`
+- Modify: `platforms/openclaw/README.md`
+- Test: `tests/regression.sh`
+
+**Approach:**
+- 在 `install.sh` 中拆开“核心 bundle 安装”和“可选提取器 bootstrap”两条路径。
+- 保留 `MANAGED_ITEMS` 对 `deps/` 的复制，让技能包内继续携带可选提取器源码；默认路径只跳过 sibling adapter 安装和额外依赖 bootstrap。
+- 为 `install` 和 `upgrade` 共用新增的显式开关 `--with-optional-adapters`。
+- 默认 `install` / `upgrade` 只执行核心路径；只有开关存在时才执行 bundled 提取器复制、Node 依赖安装、`uv tool install`。
+- 修正 `--upgrade --platform auto` 的行为：当检测到多个已安装平台时直接失败，避免在默认升级中误更新多个安装副本。
+- 保留现有 hook 行为，不让核心升级破坏 Claude 的 hook 配置。
+
+**Patterns to follow:**
+- `install.sh` 现有的 `--platform` / `--upgrade` 参数处理和统一输出风格
+- `README.md` 当前对多平台安装入口的表达方式
+
+**Test scenarios:**
+- Happy path: 仅有核心平台目录时，默认安装成功完成，并生成 `~/.<platform>/skills/llm-wiki` 核心副本。
+- Happy path: 显式传入 `--with-optional-adapters` 时，可选提取器链路才会执行。
+- Error path: 机器上同时存在多个平台安装且执行 `bash install.sh --upgrade` 时，脚本拒绝继续并提示必须显式指定平台。
+- Integration: Claude 已有 hook 配置时，核心升级后 hook 配置仍保持不变。
+
+**Verification:**
+- 默认安装和默认升级的输出不再包含可选提取器安装成功/失败作为成功路径必要条件。
+- 多平台升级不再出现“自动同时更新多个安装副本”的情况。
+
+- [x] **Unit 2: 建立共享运行场景解析**
+
+**Goal:** 让安装脚本和依赖状态脚本对“源码目录 / 已安装目录 / 升级临时副本”使用同一套路径模型。
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `scripts/runtime-context.sh`
+- Modify: `scripts/adapter-state.sh`
+- Modify: `install.sh`
+- Test: `tests/adapter-state.sh`
+- Test: `tests/regression.sh`
+
+**Approach:**
+- 抽出共享 helper，统一解析 `layout_mode`、`bundle_root`、`optional_adapter_root` 和 `platform`。
+- `install.sh` 在安装、升级和状态摘要调用里显式传递目标 root 或 mode，不再让 `adapter-state.sh` 自己猜。
+- `adapter-state.sh` 仍保留手动调用时的自动检测兜底，但优先消费调用方显式传入的上下文。
+- 源码目录模式下，bundled 提取器存在性应读取仓库内 `deps/`；已安装目录和升级目标模式下，应读取目标 skill root 下的 sibling 目录。
+- 源码目录模式需要明确区分“仓库里带着提取器源码”与“目标安装副本已经具备可运行条件”两件事，避免 `deps/.../node_modules` 这类残留再次制造“已经装好”的假象。
+- 状态输出里补足足够的诊断信息，帮助定位“源代码有、安装副本没有”这类问题，但不要把调试细节泄露到面向普通用户的默认说明里。
+
+**Patterns to follow:**
+- `scripts/shared-config.sh` 当前“多脚本共享单一配置”的做法
+- `tests/adapter-state.sh` 现有临时 skill root fixture 风格
+
+**Test scenarios:**
+- Happy path: 源码目录模式下检查 `web_article` 与 `youtube_video` 时，不再把 bundled 提取器误报成未安装。
+- Happy path: 已安装目录模式下，对同一来源的检查结果与真实安装状态一致。
+- Happy path: 升级临时目标模式下，状态脚本读取的是目标目录而不是当前源码目录。
+- Edge case: 仓库里存在历史残留的 `node_modules` 或其它提取器产物时，状态检查不会把源码目录误当成目标安装副本已就绪。
+- Error path: `classify-run` 在 preflight 为 `not_installed`、`env_unavailable`、`unsupported` 时，保留原状态而不是被覆盖成 `runtime_failed` 或 `empty_result`。
+
+**Verification:**
+- 同一组 fixture 在三种 mode 下的结论只随真实目录和环境变化，不再随脚本运行位置漂移。
+
+- [x] **Unit 3: 把共享说明和技能路由改成按需检查可选提取器**
+
+**Goal:** 让用户只有在真的用到 URL 自动提取时，才被引导去启用可选提取器。
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `README.md`
+- Modify: `setup.sh`
+- Modify: `platforms/claude/CLAUDE.md`
+- Modify: `platforms/codex/AGENTS.md`
+- Modify: `platforms/openclaw/README.md`
+- Test: `tests/adapter-state.sh`
+- Test: `tests/regression.sh`
+
+**Approach:**
+- 移除 `SKILL.md` 里“首次使用先检查所有提取器依赖”的默认前置描述，改成两层说明：
+  - 核心主线前置条件：能执行 shell、能读写本地文件
+  - URL 自动提取附加条件：仅当命中对应来源时再检查 Chrome / uv / 提取器
+- 统一将缺失提取器时的补装指令改成当前平台的 `bash install.sh --platform <current-platform> --with-optional-adapters`。
+- `setup.sh` 保留 Claude 兼容包装，但文档中只在 Claude 专属入口里提到，不再出现在共享说明和跨平台技能说明里。
+- README 的“更新”说明同步改成：默认升级更新核心；若需要重新拉起可选提取器，再显式加开关。
+
+**Patterns to follow:**
+- `README.md` 当前“共享说明 + 平台薄入口”结构
+- `SKILL.md` 当前按来源总表路由 URL / 文件 / 文本的组织方式
+
+**Test scenarios:**
+- Happy path: 只处理本地文件或纯文本时，技能说明不再要求先安装网页/YouTube/公众号提取器。
+- Happy path: 命中 URL 来源且提取器未启用时，说明会给出当前平台的显式补装指令。
+- Error path: Codex 或 OpenClaw 文档中不再把 `setup.sh` 当成通用补装动作。
+- Integration: README、平台入口和 `SKILL.md` 三处对于默认安装与显式启用的说法保持一致。
+
+**Verification:**
+- 共享说明与平台入口不会再把 Claude 专属命令误导给其他平台。
+- 本地文件 / 纯文本工作流在说明层面不再被可选提取器门槛污染。
+
+- [x] **Unit 4: 重写回归矩阵，锁住新的默认边界**
+
+**Goal:** 让测试保护“核心默认可用、可选功能显式开启”的新合同，并补齐升级与运行场景的回归缺口。
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** Unit 1, Unit 2, Unit 3
+
+**Files:**
+- Modify: `tests/regression.sh`
+- Modify: `tests/adapter-state.sh`
+
+**Approach:**
+- 将现有“默认安装应装上全部提取器”的断言改成：
+  - 默认安装只验证核心副本落地且不阻塞
+  - 显式 `--with-optional-adapters` 时才验证提取器被复制/安装
+- 为 `upgrade` 增加 fixture 化回归：
+  - 已安装副本存在时的核心升级
+  - 多平台存在时的 `--upgrade` 拒绝分支
+  - hook 配置保留
+- 为 `adapter-state` 增加三类运行场景矩阵和 preflight 保留断言。
+- 保持已有状态分类测试，但把它们改为围绕共享 context helper 组织，而不是只测单一路径。
+
+**Patterns to follow:**
+- `tests/regression.sh` 当前以临时 HOME 和 stub 二进制模拟安装环境的方式
+- `tests/adapter-state.sh` 当前以 `mktemp` skill root 组装小型 fixture 的方式
+
+**Test scenarios:**
+- Happy path: 默认安装在没有 `bun`、没有 `uv`、没有 Chrome 调试端口时仍能完成核心安装。
+- Happy path: 显式启用可选提取器时，网页提取 Node 依赖和公众号工具安装链路才会被执行。
+- Error path: 多平台已安装时执行默认升级，测试应看到脚本拒绝继续。
+- Integration: 从源码目录、已安装目录、升级目标目录分别运行状态检查，输出与真实目录状态一致。
+
+**Verification:**
+- 回归套件会在“谁把可选提取器重新塞回默认路径”这类改动上直接失败。
+
+## System-Wide Impact
+
+- **Interaction graph:** `install.sh`、`SKILL.md`、`README.md`、平台入口和测试会一起变化；任何一处继续保留旧默认值，都会把用户重新带回错误路径。
+- **Error propagation:** 默认路径不再把 Node、uv、Chrome 相关问题传播成安装失败；这些错误只在显式启用可选提取器后出现。
+- **State lifecycle risks:** 运行场景 helper 如果没有被所有调用方统一使用，源码目录和安装目录仍然会继续漂移。
+- **API surface parity:** 三个平台的安装口径必须保持一致；Claude 的兼容入口只能作为特例保留，不能重新溢出到共享说明。
+- **Integration coverage:** 仅靠单元化 shell 断言不够，必须补“默认安装 + 显式可选 + 升级 + 三种运行场景”的组合回归。
+- **Unchanged invariants:** 本地文件、纯文本和已初始化知识库的主线工作流保持不变；URL 自动提取仍然存在，只是从默认安装路径中移出。
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| 新增开关后，README / SKILL / 平台入口说法再次漂移 | 在 Unit 3 和 Unit 4 一起收口，用字符串断言和安装回归同时保护 |
+| 共享运行场景 helper 设计过重，反而扩大改动面 | 只抽路径和 mode 解析，不抽安装业务逻辑 |
+| 默认升级改成核心优先后，老用户以为可选提取器“被删了” | 在升级输出和 README 中明确写出“核心已更新；如需 URL 自动提取，再加显式开关” |
+| 现有兼容入口 `setup.sh` 被彻底边缘化后引起 Claude 老用户困惑 | 保留包装脚本不删，只调整它在文档中的出现位置 |
+
+## Documentation / Operational Notes
+
+- README 需要把“默认升级会安装依赖”改成“默认升级只更新核心”。
+- 平台薄入口要统一补一句：URL 自动提取属于可选功能，需要显式启用。
+- 安装输出建议把“核心已就绪”和“可选提取器状态”分开说，避免用户把可选问题误解成核心不可用。
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-06-project-cleanup-and-restructuring-requirements.md](/Users/kangjiaqi/Desktop/project/llm-wiki-skill/docs/brainstorms/2026-04-06-project-cleanup-and-restructuring-requirements.md)
+- Related plan: [docs/plans/2026-04-06-002-phase-b-core-and-adapter-separation-plan.md](/Users/kangjiaqi/Desktop/project/llm-wiki-skill/docs/plans/2026-04-06-002-phase-b-core-and-adapter-separation-plan.md)
+- Related solution: [docs/solutions/integration-issues/unify-optional-adapter-states-and-fallback-paths-2026-04-06.md](/Users/kangjiaqi/Desktop/project/llm-wiki-skill/docs/solutions/integration-issues/unify-optional-adapter-states-and-fallback-paths-2026-04-06.md)
+- Related solution: [docs/solutions/logic-errors/lint-runner-index-path-and-install-sync-2026-04-14.md](/Users/kangjiaqi/Desktop/project/llm-wiki-skill/docs/solutions/logic-errors/lint-runner-index-path-and-install-sync-2026-04-14.md)
+- Related todo: [.context/compound-engineering/todos/005-pending-p2-separate-source-and-installed-skill-paths.md](/Users/kangjiaqi/Desktop/project/llm-wiki-skill/.context/compound-engineering/todos/005-pending-p2-separate-source-and-installed-skill-paths.md)

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ TARGET_DIR=""
 INSTALL_HOOKS=0
 UNINSTALL_HOOKS=0
 UPGRADE=0
+WITH_OPTIONAL_ADAPTERS=0
 
 # 这些项目都在运行时会被读取或链接：
 # - 入口与说明文件：README / CLAUDE / AGENTS / CHANGELOG
@@ -37,6 +38,7 @@ DEP_SKILLS=()
 
 # 微信工具 URL 从共享配置读取，与 adapter-state.sh 保持一致
 source "$SCRIPT_DIR/scripts/shared-config.sh"
+source "$SCRIPT_DIR/scripts/runtime-context.sh"
 
 info()  { printf '\033[36m[信息]\033[0m %s\n' "$1"; }
 ok()    { printf '\033[32m[完成]\033[0m %s\n' "$1"; }
@@ -51,11 +53,13 @@ usage() {
   bash install.sh --install-hooks
   bash install.sh --uninstall-hooks
   bash install.sh --upgrade [--platform <claude|codex|openclaw|auto>]
+  bash install.sh --platform codex --with-optional-adapters
 
 选项：
   --platform         目标平台。默认 auto；只有检测到唯一平台时才会自动安装。
   --dry-run          只打印安装计划，不写入文件。
-  --target-dir       指定技能目标目录（主要给兼容入口内部调用）。
+  --target-dir       指定技能目标目录（直接传最终的 llm-wiki 目录）。
+  --with-optional-adapters  显式启用网页 / X / YouTube / 公众号等可选提取器安装。
   --install-hooks    注册 Claude Code 的 SessionStart hook。
   --uninstall-hooks  移除 Claude Code 的 SessionStart hook。
   --upgrade          拉取最新代码并更新已安装的 llm-wiki（保留 hook 配置）。
@@ -225,28 +229,6 @@ detect_available_platforms() {
   printf '%s\n' "${found[@]}"
 }
 
-resolve_skill_root() {
-  case "$1" in
-    claude)
-      printf '%s\n' "$HOME/.claude/skills"
-      ;;
-    codex)
-      if [ -d "$HOME/.codex/skills" ] || [ ! -d "$HOME/.Codex/skills" ]; then
-        printf '%s\n' "$HOME/.codex/skills"
-      else
-        printf '%s\n' "$HOME/.Codex/skills"
-      fi
-      ;;
-    openclaw)
-      printf '%s\n' "$HOME/.openclaw/skills"
-      ;;
-    *)
-      err "不支持的平台：$1"
-      exit 1
-      ;;
-  esac
-}
-
 install_dependency_skills() {
   local skill_root="$1"
   local dep dep_target dep_source
@@ -352,6 +334,19 @@ install_uv_tools() {
   fi
 }
 
+bootstrap_optional_adapters() {
+  local skill_root="$1"
+
+  if [ "$WITH_OPTIONAL_ADAPTERS" -ne 1 ]; then
+    return 0
+  fi
+
+  load_dependency_skills
+  install_dependency_skills "$skill_root"
+  install_node_deps "$skill_root"
+  install_uv_tools
+}
+
 check_environment() {
   echo ""
   echo "================================"
@@ -411,7 +406,7 @@ print_adapter_states() {
   echo ""
 
   output="$(
-    bash "$ADAPTER_STATE_SCRIPT" --skill-root "$SKILL_ROOT" summary-human 2>&1
+    bash "$ADAPTER_STATE_SCRIPT" --skill-root "$SKILL_ROOT" --layout-mode installed_skill summary-human 2>&1
   )" || {
     warn "无法生成外挂状态摘要"
     printf '%s\n' "$output"
@@ -419,6 +414,25 @@ print_adapter_states() {
   }
 
   printf '%s\n' "$output"
+}
+
+print_optional_adapter_hint() {
+  local command
+
+  command="bash install.sh"
+  if [ "$UPGRADE" -eq 1 ]; then
+    command="$command --upgrade"
+  fi
+  command="$command --platform ${PLATFORM}"
+  if [ -n "$TARGET_DIR" ]; then
+    command="$command --target-dir ${TARGET_DIR}"
+  fi
+  command="$command --with-optional-adapters"
+
+  echo ""
+  echo "提示：当前只准备了知识库核心主线。"
+  echo "如需网页 / X / 微信公众号 / YouTube / 知乎自动提取，再运行："
+  echo "  $command"
 }
 
 while [ $# -gt 0 ]; do
@@ -437,6 +451,10 @@ while [ $# -gt 0 ]; do
       [ $# -ge 2 ] || { err "--target-dir 需要一个值"; usage; exit 1; }
       TARGET_DIR="$2"
       shift 2
+      ;;
+    --with-optional-adapters)
+      WITH_OPTIONAL_ADAPTERS=1
+      shift
       ;;
     --install-hooks)
       INSTALL_HOOKS=1
@@ -468,10 +486,15 @@ if [ "$INSTALL_HOOKS" -eq 1 ] && [ "$UNINSTALL_HOOKS" -eq 1 ]; then
 fi
 
 if [ "$UPGRADE" -eq 1 ]; then
+  if [ -n "$TARGET_DIR" ] && [ "$PLATFORM" = "auto" ]; then
+    err "自定义目标目录升级时请显式传入 --platform"
+    exit 1
+  fi
+
   if [ "$PLATFORM" = "auto" ]; then
     detected_platforms=()
     for p in claude codex openclaw; do
-      skill_root_candidate="$(resolve_skill_root "$p")"
+      skill_root_candidate="$(resolve_platform_skill_root "$p")"
       [ -d "$skill_root_candidate/$SKILL_NAME" ] && detected_platforms+=("$p")
     done
 
@@ -481,12 +504,11 @@ if [ "$UPGRADE" -eq 1 ]; then
     fi
 
     if [ "${#detected_platforms[@]}" -gt 1 ]; then
-      if [ "$PLATFORM_EXPLICIT" -eq 0 ]; then
-        err "检测到多个已安装平台：${detected_platforms[*]}。请显式传入 --platform"
-        exit 1
-      fi
+      err "检测到多个已安装平台：${detected_platforms[*]}。升级时请显式传入 --platform"
+      exit 1
     fi
 
+    PLATFORM="${detected_platforms[0]}"
     UPGRADE_PLATFORMS=("${detected_platforms[@]}")
   else
     UPGRADE_PLATFORMS=("$PLATFORM")
@@ -513,11 +535,16 @@ if [ "$UPGRADE" -eq 1 ]; then
     warn "当前目录不是 git 仓库，跳过 git pull"
   fi
 
-  load_dependency_skills
+  upgrade_failures=0
 
   for upgrade_platform in "${UPGRADE_PLATFORMS[@]}"; do
-    upgrade_root="$(resolve_skill_root "$upgrade_platform")"
-    upgrade_target="$upgrade_root/$SKILL_NAME"
+    upgrade_root="$(resolve_platform_skill_root "$upgrade_platform")"
+    if [ -n "$TARGET_DIR" ]; then
+      upgrade_target="$TARGET_DIR"
+      upgrade_root="$(dirname "$upgrade_target")"
+    else
+      upgrade_target="$upgrade_root/$SKILL_NAME"
+    fi
 
     echo ""
     info "更新 $upgrade_platform 的 llm-wiki..."
@@ -525,19 +552,28 @@ if [ "$UPGRADE" -eq 1 ]; then
 
     if [ ! -d "$upgrade_target" ]; then
       err "$upgrade_platform 尚未安装 llm-wiki：$upgrade_target"
+      upgrade_failures=$((upgrade_failures + 1))
       continue
     fi
 
     run_cmd mkdir -p "$upgrade_target"
     install_bundle "$upgrade_target"
-    install_dependency_skills "$upgrade_root"
-    install_node_deps "$upgrade_root"
-    install_uv_tools
+    bootstrap_optional_adapters "$upgrade_root"
     ok "$upgrade_platform 的 llm-wiki 已更新"
   done
 
+  if [ "$upgrade_failures" -gt 0 ]; then
+    echo ""
+    err "llm-wiki 升级失败，请先确认目标目录存在且已完成安装"
+    exit 1
+  fi
+
   print_source_boundary
-  check_environment
+  if [ "$WITH_OPTIONAL_ADAPTERS" -eq 1 ]; then
+    check_environment
+  else
+    print_optional_adapter_hint
+  fi
 
   echo ""
   ok "llm-wiki 升级完成"
@@ -564,7 +600,7 @@ if [ "$PLATFORM" = "auto" ]; then
   fi
 fi
 
-SKILL_ROOT="$(resolve_skill_root "$PLATFORM")"
+SKILL_ROOT="$(resolve_platform_skill_root "$PLATFORM")"
 
 if { [ "$INSTALL_HOOKS" -eq 1 ] || [ "$UNINSTALL_HOOKS" -eq 1 ]; } && [ "$PLATFORM" != "claude" ]; then
   err "只有 Claude Code 支持 SessionStart hook"
@@ -592,8 +628,6 @@ if [ "$INSTALL_HOOKS" -eq 1 ] && [ "$PLATFORM_EXPLICIT" -eq 0 ] && [ -z "$TARGET
   exit 0
 fi
 
-load_dependency_skills
-
 echo ""
 echo "================================"
 echo "  llm-wiki 安装"
@@ -607,12 +641,14 @@ run_cmd mkdir -p "$SKILL_ROOT"
 run_cmd mkdir -p "$TARGET_SKILL_DIR"
 
 install_bundle "$TARGET_SKILL_DIR"
-install_dependency_skills "$SKILL_ROOT"
-install_node_deps "$SKILL_ROOT"
-install_uv_tools
+bootstrap_optional_adapters "$SKILL_ROOT"
 print_source_boundary
-check_environment
-print_adapter_states
+if [ "$WITH_OPTIONAL_ADAPTERS" -eq 1 ]; then
+  check_environment
+  print_adapter_states
+else
+  print_optional_adapter_hint
+fi
 
 if [ "$INSTALL_HOOKS" -eq 1 ]; then
   register_claude_session_hook "$TARGET_SKILL_DIR"

--- a/platforms/claude/CLAUDE.md
+++ b/platforms/claude/CLAUDE.md
@@ -10,6 +10,12 @@
 bash install.sh --platform claude
 ```
 
+如果你还需要网页 / X / 微信公众号 / YouTube / 知乎自动提取，再执行：
+
+```bash
+bash install.sh --platform claude --with-optional-adapters
+```
+
 如果你希望 Claude Code 在会话开始时自动感知当前知识库上下文，可以执行：
 
 ```bash
@@ -26,4 +32,4 @@ bash install.sh --platform claude --install-hooks
 bash setup.sh
 ```
 
-它现在会走同一套安装流程，不再单独维护另一份逻辑。
+它现在会走同一套安装流程，不再单独维护另一份逻辑。若需要自动提取 URL 类来源，再显式追加 `--with-optional-adapters`。

--- a/platforms/codex/AGENTS.md
+++ b/platforms/codex/AGENTS.md
@@ -12,6 +12,12 @@
 bash install.sh --platform codex
 ```
 
+如果你还需要网页 / X / 微信公众号 / YouTube / 知乎自动提取，再执行：
+
+```bash
+bash install.sh --platform codex --with-optional-adapters
+```
+
 默认安装位置：`~/.codex/skills/llm-wiki`
 
 如果用户环境仍然在用旧的 `~/.Codex/skills`，安装器会自动兼容。

--- a/platforms/openclaw/README.md
+++ b/platforms/openclaw/README.md
@@ -10,10 +10,22 @@
 bash install.sh --platform openclaw
 ```
 
+如果你还需要网页 / X / 微信公众号 / YouTube / 知乎自动提取，再执行：
+
+```bash
+bash install.sh --platform openclaw --with-optional-adapters
+```
+
 默认安装位置：`~/.openclaw/skills/llm-wiki`
 
 如果你的 OpenClaw 不是这个目录，改用：
 
 ```bash
 bash install.sh --platform openclaw --target-dir <你的技能目录>/llm-wiki
+```
+
+之后升级同一个自定义目录时，也传同样的目标目录：
+
+```bash
+bash install.sh --upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki
 ```

--- a/scripts/adapter-state.sh
+++ b/scripts/adapter-state.sh
@@ -9,36 +9,33 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SOURCE_REGISTRY_SCRIPT="$SCRIPT_DIR/source-registry.sh"
 # 微信工具 URL 从共享配置读取，与 install.sh 保持一致
 source "$SCRIPT_DIR/shared-config.sh"
+source "$SCRIPT_DIR/runtime-context.sh"
 SKILL_ROOT_OVERRIDE=""
+LAYOUT_MODE_OVERRIDE=""
 
 usage() {
   cat <<'EOF'
 用法：
-  bash scripts/adapter-state.sh [--skill-root <path>] check <source_id>
-  bash scripts/adapter-state.sh [--skill-root <path>] summary
-  bash scripts/adapter-state.sh [--skill-root <path>] summary-human
-  bash scripts/adapter-state.sh [--skill-root <path>] classify-run <source_id> <exit_code> <output_path>
+  bash scripts/adapter-state.sh [--skill-root <path>] [--layout-mode <source_checkout|installed_skill|upgrade_target>] check <source_id>
+  bash scripts/adapter-state.sh [--skill-root <path>] [--layout-mode <source_checkout|installed_skill|upgrade_target>] summary
+  bash scripts/adapter-state.sh [--skill-root <path>] [--layout-mode <source_checkout|installed_skill|upgrade_target>] summary-human
+  bash scripts/adapter-state.sh [--skill-root <path>] [--layout-mode <source_checkout|installed_skill|upgrade_target>] classify-run <source_id> <exit_code> <output_path>
 EOF
 }
 
-resolve_skill_root() {
-  if [ -n "$SKILL_ROOT_OVERRIDE" ]; then
-    printf '%s\n' "$SKILL_ROOT_OVERRIDE"
-    return 0
-  fi
-
-  printf '%s\n' "$(dirname "$PROJECT_ROOT")"
+resolve_optional_root() {
+  resolve_optional_adapter_root "$PROJECT_ROOT" "$SKILL_ROOT_OVERRIDE" "$LAYOUT_MODE_OVERRIDE"
 }
 
 dependency_installed() {
   local dependency_name="$1"
   local dependency_type="$2"
-  local skill_root
+  local optional_root
 
   case "$dependency_type" in
     bundled)
-      skill_root="$(resolve_skill_root)"
-      if [ -d "$skill_root/$dependency_name" ]; then
+      optional_root="$(resolve_optional_root)"
+      if [ -d "$optional_root/$dependency_name" ]; then
         return 0
       fi
       return 1
@@ -112,13 +109,13 @@ default_install_hint() {
 
   case "$source_id" in
     web_article|x_twitter|zhihu_article)
-      printf '%s\n' "重新运行当前平台的 llm-wiki 安装命令，确认 ${adapter_name} 已准备到技能目录"
+      printf '%s\n' "重新运行当前平台的 llm-wiki 安装命令，并追加 --with-optional-adapters，确认 ${adapter_name} 已准备到技能目录"
       ;;
     wechat_article)
       printf '%s\n' "先安装 uv，再执行：uv tool install ${WECHAT_TOOL_URL}"
       ;;
     youtube_video)
-      printf '%s\n' "重新运行当前平台的 llm-wiki 安装命令，确认 ${adapter_name} 已准备到技能目录"
+      printf '%s\n' "重新运行当前平台的 llm-wiki 安装命令，并追加 --with-optional-adapters，确认 ${adapter_name} 已准备到技能目录"
       ;;
     *)
       printf '%s\n' "-"
@@ -381,6 +378,11 @@ while [ $# -gt 0 ]; do
     --skill-root)
       [ $# -ge 2 ] || { usage; exit 1; }
       SKILL_ROOT_OVERRIDE="$2"
+      shift 2
+      ;;
+    --layout-mode)
+      [ $# -ge 2 ] || { usage; exit 1; }
+      LAYOUT_MODE_OVERRIDE="$2"
       shift 2
       ;;
     *)

--- a/scripts/runtime-context.sh
+++ b/scripts/runtime-context.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# 共享运行场景解析：供 install.sh 和 adapter-state.sh 复用
+
+resolve_platform_skill_root() {
+  case "$1" in
+    claude)
+      printf '%s\n' "$HOME/.claude/skills"
+      ;;
+    codex)
+      if [ -d "$HOME/.codex/skills" ] || [ ! -d "$HOME/.Codex/skills" ]; then
+        printf '%s\n' "$HOME/.codex/skills"
+      else
+        printf '%s\n' "$HOME/.Codex/skills"
+      fi
+      ;;
+    openclaw)
+      printf '%s\n' "$HOME/.openclaw/skills"
+      ;;
+    *)
+      echo "不支持的平台：$1" >&2
+      return 1
+      ;;
+  esac
+}
+
+detect_layout_mode() {
+  local bundle_root="$1"
+
+  if [ -e "$bundle_root/.git" ]; then
+    printf '%s\n' "source_checkout"
+    return 0
+  fi
+
+  printf '%s\n' "installed_skill"
+}
+
+resolve_layout_mode() {
+  local bundle_root="$1"
+  local override_mode="${2:-}"
+
+  if [ -n "$override_mode" ]; then
+    printf '%s\n' "$override_mode"
+    return 0
+  fi
+
+  detect_layout_mode "$bundle_root"
+}
+
+resolve_optional_adapter_root() {
+  local bundle_root="$1"
+  local skill_root_override="${2:-}"
+  local override_mode="${3:-}"
+  local layout_mode
+
+  if [ -n "$skill_root_override" ]; then
+    printf '%s\n' "$skill_root_override"
+    return 0
+  fi
+
+  layout_mode="$(resolve_layout_mode "$bundle_root" "$override_mode")"
+
+  case "$layout_mode" in
+    source_checkout)
+      printf '%s\n' "$bundle_root/deps"
+      ;;
+    installed_skill|upgrade_target)
+      printf '%s\n' "$(dirname "$bundle_root")"
+      ;;
+    *)
+      echo "未知运行模式：$layout_mode" >&2
+      return 1
+      ;;
+  esac
+}

--- a/tests/adapter-state.sh
+++ b/tests/adapter-state.sh
@@ -29,6 +29,15 @@ assert_text_contains() {
     fi
 }
 
+assert_text_not_contains() {
+    local text="$1"
+    local unexpected="$2"
+
+    if printf '%s' "$text" | grep -F -- "$unexpected" > /dev/null; then
+        fail "Expected output to not contain: $unexpected"
+    fi
+}
+
 make_stub() {
     local path="$1"
     local body="$2"
@@ -42,6 +51,18 @@ prepare_skill_root() {
 
     mkdir -p "$skill_root/baoyu-url-to-markdown"
     mkdir -p "$skill_root/youtube-transcript"
+}
+
+prepare_source_checkout() {
+    local repo_root="$1"
+
+    mkdir -p "$repo_root/scripts" "$repo_root/deps/baoyu-url-to-markdown" "$repo_root/deps/youtube-transcript"
+    : > "$repo_root/.git"
+    cp "$REPO_ROOT/scripts/adapter-state.sh" "$repo_root/scripts/adapter-state.sh"
+    cp "$REPO_ROOT/scripts/source-registry.sh" "$repo_root/scripts/source-registry.sh"
+    cp "$REPO_ROOT/scripts/source-registry.tsv" "$repo_root/scripts/source-registry.tsv"
+    cp "$REPO_ROOT/scripts/shared-config.sh" "$repo_root/scripts/shared-config.sh"
+    cp "$REPO_ROOT/scripts/runtime-context.sh" "$repo_root/scripts/runtime-context.sh"
 }
 
 test_bundled_adapters_are_not_treated_as_installed_from_repo_checkout() {
@@ -61,6 +82,26 @@ exit 1'
 
     assert_text_contains "$output" "not_installed"
     assert_text_contains "$output" "baoyu-url-to-markdown"
+}
+
+test_source_checkout_uses_repo_deps_for_bundled_adapters() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    prepare_source_checkout "$tmp_dir/repo"
+    mkdir -p "$tmp_dir/bin"
+
+    make_stub "$tmp_dir/bin/lsof" '#!/bin/sh
+exit 1'
+
+    output="$(
+        PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash "$tmp_dir/repo/scripts/adapter-state.sh" check web_article 2>&1
+    )" || fail "adapter-state should understand bundled deps from a source checkout"
+
+    assert_text_contains "$output" "env_unavailable"
+    assert_text_contains "$output" "Chrome"
 }
 
 test_adapter_state_distinguishes_not_installed_and_unsupported() {
@@ -158,6 +199,34 @@ exit 0'
     assert_text_contains "$output" "available"
 }
 
+test_classify_run_preserves_preflight_failures() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/bin" "$tmp_dir/skills"
+    printf 'body\n' > "$tmp_dir/full.txt"
+
+    make_stub "$tmp_dir/bin/uv" '#!/bin/sh
+exit 0'
+
+    output="$(
+        PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash "$REPO_ROOT/scripts/adapter-state.sh" --skill-root "$tmp_dir/skills" classify-run wechat_article 1 "$tmp_dir/full.txt" 2>&1
+    )" || fail "classify-run should preserve not_installed preflight state"
+
+    assert_text_contains "$output" "not_installed"
+    assert_text_not_contains "$output" "runtime_failed"
+
+    output="$(
+        PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash "$REPO_ROOT/scripts/adapter-state.sh" --skill-root "$tmp_dir/skills" classify-run xiaohongshu_post 1 "$tmp_dir/full.txt" 2>&1
+    )" || fail "classify-run should preserve unsupported preflight state"
+
+    assert_text_contains "$output" "unsupported"
+    assert_text_not_contains "$output" "runtime_failed"
+}
+
 test_install_reports_adapter_states_from_shared_model() {
     local tmp_dir output
     tmp_dir="$(mktemp -d)"
@@ -180,7 +249,7 @@ exit 0"
     output="$(
         HOME="$tmp_dir/home" \
         PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-        bash "$REPO_ROOT/install.sh" --platform claude 2>&1
+        bash "$REPO_ROOT/install.sh" --platform claude --with-optional-adapters 2>&1
     )" || fail "install.sh should surface adapter states"
 
     assert_text_contains "$output" "外挂状态"
@@ -194,12 +263,15 @@ test_skill_routes_ingest_and_status_through_adapter_state_model() {
     assert_file_contains "$REPO_ROOT/SKILL.md" "scripts/adapter-state.sh"
     assert_file_contains "$REPO_ROOT/SKILL.md" "not_installed / env_unavailable / runtime_failed / unsupported / empty_result"
     assert_file_contains "$REPO_ROOT/SKILL.md" "外挂状态"
+    assert_file_contains "$REPO_ROOT/SKILL.md" "--with-optional-adapters"
 }
 
 test_adapter_state_distinguishes_not_installed_and_unsupported
 test_bundled_adapters_are_not_treated_as_installed_from_repo_checkout
+test_source_checkout_uses_repo_deps_for_bundled_adapters
 test_adapter_state_distinguishes_env_unavailable
 test_adapter_state_distinguishes_runtime_failed_and_empty_result
+test_classify_run_preserves_preflight_failures
 test_install_reports_adapter_states_from_shared_model
 test_skill_routes_ingest_and_status_through_adapter_state_model
 

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -36,6 +36,15 @@ assert_text_contains() {
     fi
 }
 
+assert_text_not_contains() {
+    local text="$1"
+    local unexpected="$2"
+
+    if printf '%s' "$text" | grep -F -- "$unexpected" > /dev/null; then
+        fail "Expected output to not contain: $unexpected"
+    fi
+}
+
 assert_path_exists() {
     local path="$1"
 
@@ -108,6 +117,40 @@ test_setup_runs_on_bash_3_2() {
 
     mkdir -p "$tmp_dir/home/.claude/skills" "$tmp_dir/bin"
 
+    make_stub "$tmp_dir/bin/bun" "#!/bin/sh
+printf '%s\n' bun >> \"$tmp_dir/tool.log\"
+mkdir -p node_modules
+exit 0"
+
+    make_stub "$tmp_dir/bin/lsof" '#!/bin/sh
+exit 1'
+
+    make_stub "$tmp_dir/bin/uv" "#!/bin/sh
+printf '%s\n' uv >> \"$tmp_dir/tool.log\"
+exit 0"
+
+    output="$(
+        HOME="$tmp_dir/home" \
+        PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash "$REPO_ROOT/setup.sh" 2>&1
+    )" || fail "setup.sh should run successfully under bash 3.2"
+
+    assert_path_exists "$tmp_dir/home/.claude/skills/llm-wiki/SKILL.md"
+    assert_path_exists "$tmp_dir/home/.claude/skills/llm-wiki/deps/baoyu-url-to-markdown"
+    [ ! -d "$tmp_dir/home/.claude/skills/baoyu-url-to-markdown" ] || fail "Did not expect optional adapters to be enabled by default"
+    [ ! -f "$tmp_dir/tool.log" ] || fail "Did not expect bun or uv to run for core-only setup"
+
+    assert_text_contains "$output" "当前只准备了知识库核心主线"
+    assert_text_contains "$output" "--with-optional-adapters"
+}
+
+test_install_with_optional_adapters_bootstraps_dependencies() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/home/.claude/skills" "$tmp_dir/bin"
+
     make_stub "$tmp_dir/bin/bun" '#!/bin/sh
 mkdir -p node_modules
 exit 0'
@@ -124,17 +167,14 @@ exit 0"
     output="$(
         HOME="$tmp_dir/home" \
         PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-        bash "$REPO_ROOT/setup.sh" 2>&1
-    )" || fail "setup.sh should run successfully under bash 3.2"
+        bash "$REPO_ROOT/install.sh" --platform claude --with-optional-adapters 2>&1
+    )" || fail "install.sh should support explicit optional adapter bootstrap"
 
-    [ -d "$tmp_dir/home/.claude/skills/baoyu-url-to-markdown" ] || fail "Expected baoyu-url-to-markdown to be installed"
-    [ -d "$tmp_dir/home/.claude/skills/youtube-transcript" ] || fail "Expected youtube-transcript to be installed"
-    [ ! -d "$tmp_dir/home/.claude/skills/x-article-extractor" ] || fail "Did not expect x-article-extractor to be installed"
+    [ -d "$tmp_dir/home/.claude/skills/baoyu-url-to-markdown" ] || fail "Expected baoyu-url-to-markdown to be installed when explicitly enabled"
+    [ -d "$tmp_dir/home/.claude/skills/youtube-transcript" ] || fail "Expected youtube-transcript to be installed when explicitly enabled"
     assert_path_exists "$tmp_dir/bin/wechat-article-to-markdown"
     assert_file_contains "$tmp_dir/uv.log" "tool install git+https://github.com/jackwener/wechat-article-to-markdown.git"
-
     assert_text_contains "$output" "Chrome 调试端口 9222 未监听"
-    assert_text_contains "$output" "open -na \"Google Chrome\" --args --remote-debugging-port=9222"
     assert_text_contains "$output" "wechat-article-to-markdown 安装完成"
 }
 
@@ -152,6 +192,9 @@ test_install_dry_run_for_claude() {
 
     assert_text_contains "$output" "平台：claude"
     assert_text_contains "$output" "$tmp_dir/home/.claude/skills/llm-wiki"
+    assert_text_contains "$output" "--with-optional-adapters"
+    assert_text_not_contains "$output" "uv tool install"
+    assert_text_not_contains "$output" "bun install"
 }
 
 test_install_auto_refuses_ambiguous_platforms() {
@@ -193,7 +236,8 @@ exit 1'
     assert_path_exists "$tmp_dir/home/.openclaw/skills/llm-wiki/SKILL.md"
     assert_path_exists "$tmp_dir/home/.openclaw/skills/llm-wiki/install.sh"
     assert_path_exists "$tmp_dir/home/.openclaw/skills/llm-wiki/scripts/source-registry.sh"
-    assert_path_exists "$tmp_dir/home/.openclaw/skills/baoyu-url-to-markdown"
+    assert_path_exists "$tmp_dir/home/.openclaw/skills/llm-wiki/deps/baoyu-url-to-markdown"
+    [ ! -d "$tmp_dir/home/.openclaw/skills/baoyu-url-to-markdown" ] || fail "Did not expect optional adapters to be enabled by default"
 }
 
 test_init_fills_language_placeholder() {
@@ -444,6 +488,15 @@ exit 0'
 test_platform_entries_mention_hook_and_wiki_context() {
     assert_file_contains "$REPO_ROOT/platforms/claude/CLAUDE.md" "--install-hooks"
     assert_file_contains "$REPO_ROOT/platforms/codex/AGENTS.md" "优先查阅 wiki/index.md"
+    assert_file_contains "$REPO_ROOT/platforms/openclaw/README.md" "--upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki"
+}
+
+test_root_entries_explain_core_only_optional_and_target_dir() {
+    assert_file_contains "$REPO_ROOT/AGENTS.md" "--with-optional-adapters"
+    assert_file_contains "$REPO_ROOT/AGENTS.md" "默认只准备知识库核心主线"
+    assert_file_contains "$REPO_ROOT/AGENTS.md" "--target-dir <你的技能目录>/llm-wiki"
+    assert_file_contains "$REPO_ROOT/CLAUDE.md" "--with-optional-adapters"
+    assert_file_contains "$REPO_ROOT/CLAUDE.md" "默认只准备知识库核心主线"
 }
 
 test_skill_md_phase5_lint_mentions_confidence_audit() {
@@ -459,6 +512,8 @@ test_changelog_mentions_wiki_core_upgrades() {
     assert_file_contains "$REPO_ROOT/CHANGELOG.md" "purpose.md"
     assert_file_contains "$REPO_ROOT/CHANGELOG.md" "SessionStart hook"
     assert_file_contains "$REPO_ROOT/CHANGELOG.md" "delete 工作流"
+    assert_file_contains "$REPO_ROOT/CHANGELOG.md" "--with-optional-adapters"
+    assert_file_contains "$REPO_ROOT/CHANGELOG.md" "核心主线"
 }
 
 test_readme_sections() {
@@ -467,7 +522,11 @@ test_readme_sections() {
     assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform claude"
     assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform codex"
     assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform openclaw"
+    assert_file_contains "$REPO_ROOT/README.md" "--with-optional-adapters"
+    assert_file_contains "$REPO_ROOT/README.md" "--target-dir <你的技能目录>/llm-wiki"
+    assert_file_contains "$REPO_ROOT/README.md" "--upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki"
     assert_file_contains "$REPO_ROOT/README.md" "wechat-article-to-markdown"
+    assert_file_not_contains "$REPO_ROOT/README.md" "bash setup.sh"
     assert_file_not_contains "$REPO_ROOT/README.md" "x-article-extractor"
     assert_file_not_contains "$REPO_ROOT/README.md" "baoyu-danger-x-to-markdown"
 }
@@ -492,12 +551,70 @@ exit 1'
     output="$(
         HOME="$tmp_dir/home" \
         PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-        bash "$REPO_ROOT/install.sh" --platform claude 2>&1
-    )" || fail "install.sh should keep going when uv tool install fails"
+        bash "$REPO_ROOT/install.sh" --platform claude --with-optional-adapters 2>&1
+    )" || fail "install.sh should keep going when optional adapter bootstrap fails"
 
     assert_text_contains "$output" "wechat-article-to-markdown 安装失败"
     assert_text_contains "$output" "llm-wiki 已准备完成"
     assert_path_exists "$tmp_dir/home/.claude/skills/llm-wiki/SKILL.md"
+}
+
+test_upgrade_auto_refuses_ambiguous_installed_platforms() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/home/.claude/skills/llm-wiki" "$tmp_dir/home/.codex/skills/llm-wiki"
+
+    if output="$(
+        HOME="$tmp_dir/home" \
+        bash "$REPO_ROOT/install.sh" --upgrade --platform auto 2>&1
+    )"; then
+        fail "install.sh --upgrade --platform auto should fail when multiple installs exist"
+    fi
+
+    assert_text_contains "$output" "检测到多个已安装平台"
+    assert_text_contains "$output" "--platform"
+}
+
+test_upgrade_uses_explicit_target_dir() {
+    local tmp_dir output custom_target
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    custom_target="$tmp_dir/custom/llm-wiki"
+    mkdir -p "$tmp_dir/home/.openclaw/skills" "$custom_target"
+    printf 'stale\n' > "$custom_target/README.md"
+
+    output="$(
+        HOME="$tmp_dir/home" \
+        bash "$REPO_ROOT/install.sh" --upgrade --platform openclaw --target-dir "$custom_target" 2>&1
+    )" || fail "install.sh --upgrade should support explicit target directories"
+
+    assert_text_contains "$output" "目标目录：$custom_target"
+    assert_text_contains "$output" "llm-wiki 升级完成"
+    assert_path_exists "$custom_target/install.sh"
+    assert_file_contains "$custom_target/README.md" "llm-wiki - 多平台知识库构建 Skill"
+    [ ! -d "$tmp_dir/home/.openclaw/skills/llm-wiki" ] || fail "Did not expect upgrade to write into the default OpenClaw skill path"
+}
+
+test_upgrade_fails_when_explicit_target_dir_is_missing() {
+    local tmp_dir output custom_target
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    custom_target="$tmp_dir/custom/llm-wiki"
+    mkdir -p "$tmp_dir/home/.openclaw/skills"
+
+    if output="$(
+        HOME="$tmp_dir/home" \
+        bash "$REPO_ROOT/install.sh" --upgrade --platform openclaw --target-dir "$custom_target" 2>&1
+    )"; then
+        fail "install.sh --upgrade should fail when the explicit target directory is missing"
+    fi
+
+    assert_text_contains "$output" "尚未安装 llm-wiki"
+    assert_text_contains "$output" "升级失败"
 }
 
 test_skill_md_routes_wechat_to_new_tool() {
@@ -753,6 +870,7 @@ test_install_prints_source_boundary_from_registry() {
     assert_registry_labels_present_in_text "$output" "core_builtin"
     assert_registry_labels_present_in_text "$output" "optional_adapter"
     assert_registry_labels_present_in_text "$output" "manual_only"
+    assert_text_contains "$output" "--with-optional-adapters"
 }
 
 test_install_warns_when_managed_source_is_missing() {
@@ -852,8 +970,12 @@ test_init_creates_synthesis_sessions_subdir() {
 }
 
 test_setup_runs_on_bash_3_2
+test_install_with_optional_adapters_bootstraps_dependencies
 test_install_dry_run_for_claude
 test_install_auto_refuses_ambiguous_platforms
+test_upgrade_auto_refuses_ambiguous_installed_platforms
+test_upgrade_uses_explicit_target_dir
+test_upgrade_fails_when_explicit_target_dir_is_missing
 test_install_openclaw_copies_bundle
 test_init_fills_language_placeholder
 test_phase1_templates_exist
@@ -870,6 +992,7 @@ test_hook_session_start_outputs_context_when_wiki_exists
 test_hook_session_start_returns_empty_json_without_wiki
 test_install_registers_and_uninstalls_session_start_hook
 test_platform_entries_mention_hook_and_wiki_context
+test_root_entries_explain_core_only_optional_and_target_dir
 test_skill_md_phase5_lint_mentions_confidence_audit
 test_changelog_mentions_wiki_core_upgrades
 test_readme_sections


### PR DESCRIPTION
## Summary
- make install and upgrade default to the wiki core path only
- require --with-optional-adapters for web/X/WeChat/YouTube/Zhihu extraction support
- fix upgrade so explicit --target-dir paths are updated correctly and fail clearly when missing
- sync README, entry docs, changelog, and regression coverage to the new install boundary

## Verification
- bash tests/adapter-state.sh
- bash tests/regression.sh