### PR TITLE
feat: publish llm-wiki-upgrade companion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2.4.0 (2026-04-15)
+
+### 新增
+
+- `platforms/claude/companions/llm-wiki-upgrade/SKILL.md`：Claude 安装后随附 `/llm-wiki-upgrade`，以后可以直接从命令入口更新 llm-wiki
+
+### 改进
+
+- `install.sh`：恢复 Claude 专属伴生命令安装与升级同步，GitHub 地址安装和 `/llm-wiki-upgrade` 两条路线现在共享同一套更新边界
+- `README.md`、`CLAUDE.md`、`platforms/claude/CLAUDE.md`：补充 `/llm-wiki-upgrade` 的使用说明，明确默认只更新核心主线
+
 ## v2.3.0 (2026-04-15)
 
 ### 改进

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ bash install.sh --platform claude
 bash install.sh --platform claude --with-optional-adapters
 ```
 
+安装完成后，还会一并带上 `/llm-wiki-upgrade`。以后要更新核心主线，可以直接让 Claude 执行这个命令。
+
 ## 推送前测试规则
 
 每次 `git push` 前必须验证，按改动范围选深度：

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ bash install.sh --platform openclaw
 - Codex: `~/.codex/skills/llm-wiki`（如果你旧环境还在用 `~/.Codex/skills`，安装器也会兼容）
 - OpenClaw: `~/.openclaw/skills/llm-wiki`
 
+如果你装的是 Claude Code，安装完成后还会一并带上 `/llm-wiki-upgrade`。以后要更新核心主线，可以直接让 Claude 执行这个命令。
+
 如果 OpenClaw 不是这一路径，也可以显式传入 `--target-dir <你的技能目录>/llm-wiki`。
 
 ### 更新
@@ -81,6 +83,8 @@ bash install.sh --upgrade --platform openclaw --target-dir <你的技能目录>/
 bash install.sh --upgrade --platform <你的平台> --with-optional-adapters
 ```
 
+如果你是在 Claude Code 里用默认安装目录，后续也可以直接执行 `/llm-wiki-upgrade` 完成这条“核心优先”的升级；需要自动提取能力时，再让它继续执行带 `--with-optional-adapters` 的升级。
+
 ## 来源边界
 
 这一步已经把安装输出、状态说明、文档和回归测试统一到同一份来源定义。仓库里的权威清单是 `scripts/source-registry.tsv`，URL 和文件路由也统一通过 `scripts/source-registry.sh` 读取。
@@ -108,6 +112,7 @@ bash install.sh --upgrade --platform <你的平台> --with-optional-adapters
 - **智能去重**：SHA256 缓存跳过未变化的素材，批量处理时不浪费 token
 - **智能素材路由**：根据 URL 域名自动选择最佳提取方式
 - **核心优先安装**：默认只准备知识库主线，网页 / X / 公众号 / YouTube / 知乎提取按需显式开启
+- **Claude 伴随升级命令**：安装后自带 `/llm-wiki-upgrade`，以后更新主线不用每次重新找仓库地址
 - **素材删除**：级联删除素材时自动清理关联页面、断链和缓存
 - **查询结果持久化**：有价值的综合回答可保存回知识库，越用越完整
 - **自动上下文注入**：SessionStart hook 让 agent 每次会话自动感知知识库（Claude Code）
@@ -142,6 +147,14 @@ bash install.sh --upgrade --platform <你的平台> --with-optional-adapters
 - OpenClaw: `bash install.sh --platform openclaw`
 
 只有在环境里明确只存在一个平台目录时，才建议用 `--platform auto`。
+
+### Claude Code 里可以直接用命令更新吗？
+
+可以。默认安装完成后，会一并带上 `/llm-wiki-upgrade`。
+
+这条命令默认只更新知识库核心主线，不会顺手刷新网页 / X / 微信公众号 / YouTube / 知乎自动提取能力。
+
+如果你需要这些自动提取能力，再让 Claude 继续执行带 `--with-optional-adapters` 的升级即可。
 
 ### 如果我想启用网页 / X / 微信公众号 / YouTube 自动提取怎么办？
 

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,14 @@ MANAGED_ITEMS=(
 
 DEP_SKILLS=()
 
+list_companion_skill_sources() {
+  case "$1" in
+    claude)
+      printf '%s\n' "platforms/claude/companions/llm-wiki-upgrade"
+      ;;
+  esac
+}
+
 # 微信工具 URL 从共享配置读取，与 adapter-state.sh 保持一致
 source "$SCRIPT_DIR/scripts/shared-config.sh"
 source "$SCRIPT_DIR/scripts/runtime-context.sh"
@@ -247,6 +255,28 @@ install_dependency_skills() {
   done
 }
 
+install_companion_skills() {
+  local platform="$1"
+  local skill_root="$2"
+  local skill_rel skill_source skill_target skill_name
+
+  while IFS= read -r skill_rel; do
+    [ -n "$skill_rel" ] || continue
+
+    skill_source="$SCRIPT_DIR/$skill_rel"
+    skill_name="$(basename "$skill_rel")"
+    skill_target="$skill_root/$skill_name"
+
+    if [ ! -d "$skill_source" ]; then
+      warn "$skill_name：仓库中未找到源文件，跳过"
+      continue
+    fi
+
+    copy_item "$skill_source" "$skill_target"
+    ok "$skill_name 已安装到 $skill_target"
+  done < <(list_companion_skill_sources "$platform")
+}
+
 install_bundle() {
   local target_dir="$1"
   local item source_path target_path
@@ -435,6 +465,17 @@ print_optional_adapter_hint() {
   echo "  $command"
 }
 
+print_claude_upgrade_hint() {
+  local platform="$1"
+
+  if [ "$platform" != "claude" ]; then
+    return 0
+  fi
+
+  echo ""
+  echo "提示：Claude Code 安装完成后，还可以直接用 /llm-wiki-upgrade 更新核心主线。"
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --platform)
@@ -558,6 +599,7 @@ if [ "$UPGRADE" -eq 1 ]; then
 
     run_cmd mkdir -p "$upgrade_target"
     install_bundle "$upgrade_target"
+    install_companion_skills "$upgrade_platform" "$upgrade_root"
     bootstrap_optional_adapters "$upgrade_root"
     ok "$upgrade_platform 的 llm-wiki 已更新"
   done
@@ -574,6 +616,7 @@ if [ "$UPGRADE" -eq 1 ]; then
   else
     print_optional_adapter_hint
   fi
+  print_claude_upgrade_hint "$PLATFORM"
 
   echo ""
   ok "llm-wiki 升级完成"
@@ -641,6 +684,7 @@ run_cmd mkdir -p "$SKILL_ROOT"
 run_cmd mkdir -p "$TARGET_SKILL_DIR"
 
 install_bundle "$TARGET_SKILL_DIR"
+install_companion_skills "$PLATFORM" "$SKILL_ROOT"
 bootstrap_optional_adapters "$SKILL_ROOT"
 print_source_boundary
 if [ "$WITH_OPTIONAL_ADAPTERS" -eq 1 ]; then
@@ -649,6 +693,7 @@ if [ "$WITH_OPTIONAL_ADAPTERS" -eq 1 ]; then
 else
   print_optional_adapter_hint
 fi
+print_claude_upgrade_hint "$PLATFORM"
 
 if [ "$INSTALL_HOOKS" -eq 1 ]; then
   register_claude_session_hook "$TARGET_SKILL_DIR"

--- a/platforms/claude/CLAUDE.md
+++ b/platforms/claude/CLAUDE.md
@@ -24,6 +24,8 @@ bash install.sh --platform claude --install-hooks
 
 默认安装位置：`~/.claude/skills/llm-wiki`
 
+安装完成后，还会一并带上 `/llm-wiki-upgrade`。以后要更新核心主线，可以直接让 Claude 执行这个命令；如果还要刷新网页 / X / 微信公众号 / YouTube / 知乎自动提取能力，再继续执行带 `--with-optional-adapters` 的升级。
+
 ## 兼容入口
 
 老用户仍然可以继续执行：

--- a/platforms/claude/companions/llm-wiki-upgrade/SKILL.md
+++ b/platforms/claude/companions/llm-wiki-upgrade/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: llm-wiki-upgrade
+version: 1.1.0
+description: |
+  升级 llm-wiki 到最新版本。从 GitHub 拉取最新代码并通过官方 install.sh 升级核心主线。
+  网页、X、微信公众号、YouTube、知乎自动提取依赖默认不刷新；需要时再显式开启。
+  触发词：upgrade llm-wiki、更新 llm-wiki、llm-wiki 升级、llm-wiki update
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# /llm-wiki-upgrade
+
+升级 llm-wiki skill 到最新版本。
+
+## 升级流程
+
+### Step 1：读取当前版本
+
+```bash
+SKILL_DIR="$HOME/.claude/skills/llm-wiki"
+OLD_VERSION=$(grep -m1 "^## v" "$SKILL_DIR/CHANGELOG.md" 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
+echo "CURRENT_VERSION=$OLD_VERSION"
+```
+
+如果 `SKILL_DIR` 不存在，告知用户尚未安装 llm-wiki，停止流程。
+
+### Step 2：Clone 最新版本到临时目录
+
+```bash
+TMP_DIR=$(mktemp -d)
+git clone --depth 1 https://github.com/sdyckjq-lab/llm-wiki-skill.git "$TMP_DIR/llm-wiki-skill" 2>&1
+echo "CLONE_EXIT=$?"
+```
+
+如果 clone 失败（`CLONE_EXIT` 非 0），告知用户网络问题，停止流程。
+
+### Step 3：读取新版本号
+
+```bash
+NEW_VERSION=$(grep -m1 "^## v" "$TMP_DIR/llm-wiki-skill/CHANGELOG.md" 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
+echo "NEW_VERSION=$NEW_VERSION"
+```
+
+如果 `OLD_VERSION == NEW_VERSION`，告知用户已是最新版本，清理临时目录后结束：
+
+```bash
+rm -rf "$TMP_DIR"
+```
+
+### Step 4：执行官方升级
+
+从临时目录（带 `.git`）执行 `install.sh --upgrade`。
+
+注意：默认升级只更新知识库核心主线，不主动刷新网页、X、微信公众号、YouTube、知乎自动提取所需的可选依赖。
+
+```bash
+bash "$TMP_DIR/llm-wiki-skill/install.sh" --upgrade --platform claude 2>&1
+echo "UPGRADE_EXIT=$?"
+```
+
+如果 `UPGRADE_EXIT` 非 0，告知用户升级失败，展示关键信息，清理临时目录后停止流程。
+
+### Step 5：清理临时目录
+
+```bash
+rm -rf "$TMP_DIR"
+```
+
+### Step 6：展示更新内容
+
+读取 `$HOME/.claude/skills/llm-wiki/CHANGELOG.md`，提取 `OLD_VERSION` 到 `NEW_VERSION` 之间的变更，提炼 3-5 条用户最关心的变化。
+
+如果新版包含“默认只装核心主线 / 可选提取器显式开启”这类变化，要明确告诉用户：
+
+- 现在默认升级不会主动刷新网页、X、微信公众号、YouTube、知乎自动提取能力
+- 如果用户需要这些自动提取能力，可以继续执行：
+
+```bash
+bash "$HOME/.claude/skills/llm-wiki/install.sh" --upgrade --platform claude --with-optional-adapters
+```
+
+输出格式：
+
+```text
+llm-wiki $NEW_VERSION 升级完成（从 $OLD_VERSION）
+
+更新内容：
+- [变化1]
+- [变化2]
+- ...
+
+如果需要开启或刷新网页 / X / 微信公众号 / YouTube / 知乎自动提取功能，可以告诉我执行带 --with-optional-adapters 的升级。
+```

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -136,12 +136,14 @@ exit 0"
     )" || fail "setup.sh should run successfully under bash 3.2"
 
     assert_path_exists "$tmp_dir/home/.claude/skills/llm-wiki/SKILL.md"
+    assert_path_exists "$tmp_dir/home/.claude/skills/llm-wiki-upgrade/SKILL.md"
     assert_path_exists "$tmp_dir/home/.claude/skills/llm-wiki/deps/baoyu-url-to-markdown"
     [ ! -d "$tmp_dir/home/.claude/skills/baoyu-url-to-markdown" ] || fail "Did not expect optional adapters to be enabled by default"
     [ ! -f "$tmp_dir/tool.log" ] || fail "Did not expect bun or uv to run for core-only setup"
 
     assert_text_contains "$output" "当前只准备了知识库核心主线"
     assert_text_contains "$output" "--with-optional-adapters"
+    assert_text_contains "$output" "/llm-wiki-upgrade"
 }
 
 test_install_with_optional_adapters_bootstraps_dependencies() {
@@ -237,7 +239,28 @@ exit 1'
     assert_path_exists "$tmp_dir/home/.openclaw/skills/llm-wiki/install.sh"
     assert_path_exists "$tmp_dir/home/.openclaw/skills/llm-wiki/scripts/source-registry.sh"
     assert_path_exists "$tmp_dir/home/.openclaw/skills/llm-wiki/deps/baoyu-url-to-markdown"
+    [ ! -d "$tmp_dir/home/.openclaw/skills/llm-wiki-upgrade" ] || fail "Did not expect Claude-only companion skill to be installed for OpenClaw"
     [ ! -d "$tmp_dir/home/.openclaw/skills/baoyu-url-to-markdown" ] || fail "Did not expect optional adapters to be enabled by default"
+}
+
+test_upgrade_refreshes_claude_companion_skill() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/home/.claude/skills/llm-wiki" "$tmp_dir/home/.claude/skills/llm-wiki-upgrade"
+    printf '# Changelog\n\n## v2.3.0 (2026-04-15)\n' > "$tmp_dir/home/.claude/skills/llm-wiki/CHANGELOG.md"
+    printf 'old\n' > "$tmp_dir/home/.claude/skills/llm-wiki-upgrade/SKILL.md"
+
+    output="$(
+        HOME="$tmp_dir/home" \
+        bash "$REPO_ROOT/install.sh" --upgrade --platform claude 2>&1
+    )" || fail "install.sh --upgrade should refresh the Claude companion skill"
+
+    assert_text_contains "$output" "/llm-wiki-upgrade"
+    assert_path_exists "$tmp_dir/home/.claude/skills/llm-wiki-upgrade/SKILL.md"
+    assert_file_contains "$tmp_dir/home/.claude/skills/llm-wiki-upgrade/SKILL.md" "--with-optional-adapters"
+    assert_file_contains "$tmp_dir/home/.claude/skills/llm-wiki-upgrade/SKILL.md" 'bash "$TMP_DIR/llm-wiki-skill/install.sh" --upgrade --platform claude'
 }
 
 test_init_fills_language_placeholder() {
@@ -486,6 +509,7 @@ exit 0'
 }
 
 test_platform_entries_mention_hook_and_wiki_context() {
+    assert_file_contains "$REPO_ROOT/platforms/claude/CLAUDE.md" "/llm-wiki-upgrade"
     assert_file_contains "$REPO_ROOT/platforms/claude/CLAUDE.md" "--install-hooks"
     assert_file_contains "$REPO_ROOT/platforms/codex/AGENTS.md" "优先查阅 wiki/index.md"
     assert_file_contains "$REPO_ROOT/platforms/openclaw/README.md" "--upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki"
@@ -495,6 +519,7 @@ test_root_entries_explain_core_only_optional_and_target_dir() {
     assert_file_contains "$REPO_ROOT/AGENTS.md" "--with-optional-adapters"
     assert_file_contains "$REPO_ROOT/AGENTS.md" "默认只准备知识库核心主线"
     assert_file_contains "$REPO_ROOT/AGENTS.md" "--target-dir <你的技能目录>/llm-wiki"
+    assert_file_contains "$REPO_ROOT/CLAUDE.md" "/llm-wiki-upgrade"
     assert_file_contains "$REPO_ROOT/CLAUDE.md" "--with-optional-adapters"
     assert_file_contains "$REPO_ROOT/CLAUDE.md" "默认只准备知识库核心主线"
 }
@@ -512,6 +537,7 @@ test_changelog_mentions_wiki_core_upgrades() {
     assert_file_contains "$REPO_ROOT/CHANGELOG.md" "purpose.md"
     assert_file_contains "$REPO_ROOT/CHANGELOG.md" "SessionStart hook"
     assert_file_contains "$REPO_ROOT/CHANGELOG.md" "delete 工作流"
+    assert_file_contains "$REPO_ROOT/CHANGELOG.md" "/llm-wiki-upgrade"
     assert_file_contains "$REPO_ROOT/CHANGELOG.md" "--with-optional-adapters"
     assert_file_contains "$REPO_ROOT/CHANGELOG.md" "核心主线"
 }
@@ -523,12 +549,19 @@ test_readme_sections() {
     assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform codex"
     assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform openclaw"
     assert_file_contains "$REPO_ROOT/README.md" "--with-optional-adapters"
+    assert_file_contains "$REPO_ROOT/README.md" "/llm-wiki-upgrade"
     assert_file_contains "$REPO_ROOT/README.md" "--target-dir <你的技能目录>/llm-wiki"
     assert_file_contains "$REPO_ROOT/README.md" "--upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki"
     assert_file_contains "$REPO_ROOT/README.md" "wechat-article-to-markdown"
     assert_file_not_contains "$REPO_ROOT/README.md" "bash setup.sh"
     assert_file_not_contains "$REPO_ROOT/README.md" "x-article-extractor"
     assert_file_not_contains "$REPO_ROOT/README.md" "baoyu-danger-x-to-markdown"
+}
+
+test_claude_upgrade_companion_source_exists() {
+    assert_path_exists "$REPO_ROOT/platforms/claude/companions/llm-wiki-upgrade/SKILL.md"
+    assert_file_contains "$REPO_ROOT/platforms/claude/companions/llm-wiki-upgrade/SKILL.md" "--with-optional-adapters"
+    assert_file_contains "$REPO_ROOT/platforms/claude/companions/llm-wiki-upgrade/SKILL.md" 'bash "$TMP_DIR/llm-wiki-skill/install.sh" --upgrade --platform claude'
 }
 
 test_uv_tool_install_failure_is_graceful() {
@@ -976,6 +1009,7 @@ test_install_auto_refuses_ambiguous_platforms
 test_upgrade_auto_refuses_ambiguous_installed_platforms
 test_upgrade_uses_explicit_target_dir
 test_upgrade_fails_when_explicit_target_dir_is_missing
+test_upgrade_refreshes_claude_companion_skill
 test_install_openclaw_copies_bundle
 test_init_fills_language_placeholder
 test_phase1_templates_exist
@@ -996,6 +1030,7 @@ test_root_entries_explain_core_only_optional_and_target_dir
 test_skill_md_phase5_lint_mentions_confidence_audit
 test_changelog_mentions_wiki_core_upgrades
 test_readme_sections
+test_claude_upgrade_companion_source_exists
 test_uv_tool_install_failure_is_graceful
 test_skill_md_routes_wechat_to_new_tool
 test_templates_have_no_empty_links


### PR DESCRIPTION
## Summary
- publish the Claude-only \ companion skill from the repo again
- install and refresh it together with Claude installs/upgrades without touching Codex/OpenClaw
- document the command and cover it with regression tests

## Verification
- bash tests/adapter-state.sh
- bash tests/regression.sh
- manual smoke test: Claude install creates \, and upgrade refreshes it