### PR TITLE
chore: ignore local tooling directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 deps/baoyu-url-to-markdown/scripts/bun.lock
 .claude/
 .context/
+.gstack/
+.playwright-cli/


### PR DESCRIPTION
## Summary

- add `.gstack/` to `.gitignore`
- add `.playwright-cli/` to `.gitignore`

## Test plan

- [x] `git status --short` no longer shows these directories after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)