### PR TITLE
feat(graph): weighted edges, Louvain communities, and insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v3.0.3 (2026-04-21)
+
+### 新增
+
+- 图谱 2.0 第一段：`build-graph-data.sh` 现在会生成边权重、来源信号可用性、Louvain 社区和规则 insights，输出稳定写入 `wiki/graph-data.json`
+- wash 图谱前端新增强弱边视觉分层、邻居强度指示和 Insights 面板，离线 HTML 可以直接查看惊人连接 / 知识缺口 / 桥节点
+- 新增 `scripts/graph-analysis.js` 和 3 组 graph 回归，覆盖 helper 算法、Node/helper 失败路径、Insights 面板接线
+
+### 改进
+
+- `templates/source-template.md` 补齐 `sources: []` 契约，图谱权重可用来源重叠信号，不再靠旧的平面连线
+- 图谱搜索改为预计算索引，避免每次输入都重新扫描全文内容
+- 图谱基础构建运行时要求现在显式为 `jq` + `node`
+
 ## v3.0.2 (2026-04-21)
 
 ### 修复

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 把碎片化的信息变成持续积累、互相链接的知识库
 
-[![version](https://img.shields.io/badge/v3.0.2-卡片式图谱-E8D5B5?style=flat-square&labelColor=3a3026&color=E8D5B5)](https://github.com/sdyckjq-lab/llm-wiki-skill/releases)
+[![version](https://img.shields.io/badge/v3.0.3-图谱分析引擎-E8D5B5?style=flat-square&labelColor=3a3026&color=E8D5B5)](https://github.com/sdyckjq-lab/llm-wiki-skill/releases)
 [![license](https://img.shields.io/badge/MIT-license-5a6e5c?style=flat-square&labelColor=3a3026)](LICENSE)
 [![platforms](https://img.shields.io/badge/Claude·Codex·OpenClaw-多平台-7a96a6?style=flat-square&labelColor=3a3026)]
 
@@ -24,7 +24,7 @@
 <img src="docs/assets/graph-demo.gif" width="100%" alt="知识图谱演示">
 </div>
 
-水彩卡片风交互式知识图谱 — 双击 HTML 文件即可在浏览器中探索。搜索、过滤、节点展开、社区聚类，全部离线运行，不依赖服务器。
+水彩卡片风交互式知识图谱 — 双击 HTML 文件即可在浏览器中探索。搜索、过滤、节点展开、边权重、Insights 面板、社区聚类，全部离线运行，不依赖服务器。
 
 ---
 
@@ -56,7 +56,7 @@ bash install.sh --platform openclaw
 
 | | 功能 | 说明 |
 |---|---|---|
-| 🗺️ | **水彩卡片风知识图谱** | 自包含 HTML，双击即可浏览；搜索、过滤、社区聚类，离线运行 |
+| 🗺️ | **水彩卡片风知识图谱** | 自包含 HTML，双击即可浏览；搜索、过滤、边权重、Insights、社区聚类，离线运行 |
 | ✨ | **图谱阅读体验打磨** | 顶栏 GitHub 入口、长标签安全截断、小地图/相邻节点可折叠，宽屏按钮直接显示文字 |
 | 📦 | **零配置初始化** | 一句话创建完整知识库，自动生成目录结构、模板和研究方向页 |
 | 🔗 | **结构化 Wiki** | 自动生成实体页、主题页、素材摘要，用 `[[双向链接]]` 互相关联 |
@@ -144,7 +144,7 @@ bash install.sh --upgrade --platform openclaw --target-dir <你的技能目录>/
 
 ### 前置条件
 
-- 核心：agent 能执行 shell 命令、读写本地文件即可
+- 核心：agent 能执行 shell 命令、读写本地文件即可；图谱构建额外需要 `jq` + `node`
 - 可选：微信公众号提取需要 `uv`；网页提取需要 `bun` 或 `npm`；需要登录态的内容可开启 Chrome 调试端口 9222
 
 </details>

--- a/SKILL.md
+++ b/SKILL.md
@@ -394,6 +394,7 @@ bash ${SKILL_DIR}/scripts/adapter-state.sh classify-run <source_id> <exit_code> 
 
 8. **生成素材摘要页**（`wiki/sources/{日期}-{短标题}.md`）：
    - 参考 `templates/source-template.md` 的格式
+   - frontmatter 里保留 `sources: []` 字段；如果这次 ingest 有明确来源，按实际 raw/source 引用填入
    - 包含：基本信息、核心观点、关键概念、与其他素材的关联、原文精彩摘录
    - 对 Step 1 中标记为 `INFERRED` 或 `AMBIGUOUS` 的关系，用 HTML 注释保留置信度：
      ```markdown
@@ -459,6 +460,7 @@ bash ${SKILL_DIR}/scripts/adapter-state.sh classify-run <source_id> <exit_code> 
    - 仍然先运行 `bash ${SKILL_DIR}/scripts/cache.sh check "<raw 文件路径>"`
    - 如果缓存命中（`HIT` 或 `HIT(repaired)`），直接复用已有结果
 3. **生成简化摘要页**（`wiki/sources/`）：
+   - frontmatter 里写入 `sources: []`
    - 只包含基本信息和核心观点
    - 不写"原文精彩摘录"部分
    - **写入 source 页面时同样使用 `create-source-page.sh`**（自动更新缓存）
@@ -938,10 +940,16 @@ bash ${SKILL_DIR}/scripts/adapter-state.sh classify-run <source_id> <exit_code> 
 
    脚本会扫描 `wiki/{entities,topics,sources,comparisons,synthesis,queries}/*.md`，
    解析同行 `[[双向链接]]` 与 `<!-- confidence: EXTRACTED|INFERRED|AMBIGUOUS -->` 注释，
-   做主题社区聚类，并写入 `wiki/graph-data.json`（>2MB 自动降级，单节点只留 500 行）。
-   依赖 `jq`（`brew install jq`）。
+   调用本地 Node helper 计算 3 信号边权重（共引强度 / 来源重叠 / 类型亲和度）、Louvain 社区和规则 insights，
+   并写入 `wiki/graph-data.json`（内容 >2MB 自动降级，单节点只留 500 行；图规模超预算时 insights 自动降级）。
+   依赖 `jq` + `node`（如缺失可运行 `brew install jq node`）。
 
-2c. **生成交互式图谱 HTML**（wash 水彩卡片风）：
+2c. **图谱运行时说明**：
+   - 图谱基础构建现在依赖 `jq` + `node`
+   - 不需要额外 `npm install`
+   - `node` 只用于运行随仓库分发的本地预构建 helper
+
+2d. **生成交互式图谱 HTML**（wash 水彩卡片风）：
 
    ```bash
    bash scripts/build-graph-html.sh "$WIKI_ROOT"
@@ -949,16 +957,27 @@ bash ${SKILL_DIR}/scripts/adapter-state.sh classify-run <source_id> <exit_code> 
 
    生成 `wiki/knowledge-graph.html`。脚本把 `graph-data.json`（已做 `</script>` 转义）
    内嵌进 `<script id="graph-data" type="application/json">`，使用本地 `d3` + `roughjs` +
-   `marked` + `purify`，离线双击即可打开。包含搜索框、关系类型筛选、节点抽屉、
-   社区聚类等交互功能。
+   `marked` + `purify`，离线双击即可打开。包含搜索框、关系类型筛选、边权重可视化、
+   邻居强度指示、Insights 面板、节点抽屉和社区聚类等交互功能。
 
-3. **向用户展示结果**（按 `WIKI_LANG` 切换语言）：
+3. **读取 insights 并向用户展示结果**（按 `WIKI_LANG` 切换语言）：
+
+   先读取 insights：
+   ```bash
+   jq '.insights' "$WIKI_ROOT/wiki/graph-data.json"
+   ```
 
    **zh**：
    ```
    知识图谱已生成！
 
    共 {N} 个节点，{M} 条关联
+
+   图谱洞察：
+   - 惊人连接：{from} ↔ {to}（跨社区，权重 {weight}）{如有}
+   - 桥节点：{node}（连接 {count} 个社区）{如有}
+   - 知识缺口：{node}（度数 {degree}，建议补充素材）{如有}
+   - 稀疏社区：{community}（密度 {density}）{如有}
 
    查看方式：
    - 交互式（推荐）：双击 wiki/knowledge-graph.html
@@ -970,7 +989,8 @@ bash ${SKILL_DIR}/scripts/adapter-state.sh classify-run <source_id> <exit_code> 
    孤立页面（未纳入图谱）：
    - [[某页面]]（建议添加到相关实体页或主题页）
    ```
-   （英文版按「输出语言规则」生成，结构相同。）
+
+   （英文版按「输出语言规则」生成，结构相同。各洞察类别为空时省略该行。）
 
 ---
 
@@ -1054,6 +1074,7 @@ bash ${SKILL_DIR}/scripts/adapter-state.sh classify-run <source_id> <exit_code> 
    - 关键决策和原因
    - 值得记录的结论
 3. 生成 `wiki/synthesis/sessions/{主题}-{日期}.md`，格式参考 `templates/synthesis-template.md`
+   - 本轮不要求 crystallize 页面补 `sources`，默认不参与 graph source overlap
 4. 更新 `log.md`（记录本次结晶化操作）
 
 > MVP 版本不自动创建 entity 页面，不自动更新 index.md。

--- a/TODOS.md
+++ b/TODOS.md
@@ -38,3 +38,19 @@
 - **Cons**：AI 推断每次 graph 要读全部实体页，100+ 节点时 token 消耗明显；深色模式要双份 CSS；演化指标要引入历史数据目录和对比逻辑。
 - **Context**：Phase 1（2026-04-17 设计文档 approved，含 Eng Review Addenda + Design Review Addenda）只复用 ingest 已有的 confidence 数据，不重新调 AI。
 - **Depends on / blocked by**：Phase 1（交互式图谱 MVP）落地并有至少一位真实用户反馈。
+
+## Graph 2.0 deferred follow-ups
+
+- **What**：给 graph 工作流加第二阶段 deep-analysis，读取候选边后做 LLM 语义分析，并把结果稳定写入 `insights.llm_surprises`。
+- **Why**：当前阶段只能靠公式和规则看图，做不到“看起来没直接关系但语义上很值得挖”的洞察。
+- **Pros**：真正把 agent skill 的优势打出来，形成和竞品最不一样的能力。
+- **Cons**：需要 prompt 设计、失败路径、结果 merge 和成本控制，不能混进当前主实现。
+- **Context**：本次 `/plan-eng-review` 已明确把 deep-analysis 从图谱 2.0 第一段交付拿掉，防止把最不稳定的模型编排绑进主实现；完成来源契约、权重、Louvain、Insights 主线后再进入第二阶段更稳。
+- **Depends on / blocked by**：先完成本轮的来源契约、权重、Louvain、Insights 主线，并验证 `graph-data.json` 的新结构稳定。
+
+- **What**：在 lint / status 一类工作流里增加“缺 `sources` 的页面提示”，明确哪些旧页面当前没有参与 source signal 计算。
+- **Why**：本次评审已决定缺来源时该信号不计入总分，如果没有提示，用户只会看到某些边不像预期那么强，却不知道是数据不全。
+- **Pros**：让图谱结果更可解释，也给后续补齐来源留一个清晰入口。
+- **Cons**：会多一条工作流输出，解释文案要写清楚，避免变成噪音。
+- **Context**：本轮图谱 2.0 方案把兼容层限制为“无 `sources` 视为空数组，不猜正文来源”，因此提示机制是最温和的补救。
+- **Depends on / blocked by**：依赖本轮 sources 契约、`graph-data.json` 新字段和 lint/status 输出设计。

--- a/docs/competitive-analysis-nashsu-2026-04-21.md
+++ b/docs/competitive-analysis-nashsu-2026-04-21.md
@@ -265,6 +265,6 @@ problem_type: strategy
 每个阶段完成后：
 
 1. **回归测试**：`bash tests/regression.sh` 确保不破坏现有功能
-2. **图谱验证**：用 `~/Desktop/llm-wiki-cowork-test/raw-input/` 的 3 篇文章测试图谱生成
+2. **图谱验证**：用 `raw-input/` 目录下的 3 篇文章测试图谱生成
 3. **推送前检查**：按 CLAUDE.md 中的三层测试规则执行
 4. **竞品对照**：对同一组素材，比较双方图谱的洞察质量

--- a/docs/competitive-analysis-nashsu-2026-04-21.md
+++ b/docs/competitive-analysis-nashsu-2026-04-21.md
@@ -1,0 +1,270 @@
+---
+module: competitive-analysis
+tags: [竞品分析, 知识图谱, 路线图]
+problem_type: strategy
+---
+
+# 竞品分析报告：llm-wiki-skill vs nashsu/llm_wiki
+
+> 日期：2026-04-21
+> 竞品仓库：https://github.com/nashsu/llm_wiki （~2000 星）
+> 我方仓库：https://github.com/sdyckjq-lab/llm-wiki-skill （~1000 星）
+
+## Context
+
+- **我方**：llm-wiki-skill（~1000 星），AI agent 技能插件，运行在 Claude Code/Codex/OpenClaw 内部，纯 Shell + Markdown 架构，借助宿主 agent 的 LLM 能力
+- **竞品**：nashsu/llm_wiki（~2000 星），Tauri v2 桌面应用（Rust 后端 + React 前端），自带 LLM 客户端，有完整 GUI
+
+两者都基于 Karpathy llm-wiki 方法论，核心架构一致（三层架构：raw → wiki → schema），但技术路线和产品形态完全不同。本次分析聚焦于功能差距、知识图谱对比、以及我方未来迭代方向。
+
+---
+
+## 一、产品形态对比
+
+| 维度 | 我方（llm-wiki-skill） | 竞品（nashsu/llm_wiki） |
+|------|----------------------|------------------------|
+| 形态 | Agent 技能（skill），运行在宿主 agent 内 | 独立桌面应用（Tauri v2） |
+| 技术栈 | Shell + Markdown 模板 | Rust 后端 + React 19 + TypeScript + Vite |
+| LLM 来源 | 宿主 agent 的 LLM | 自带 LLM 客户端（支持 OpenAI/Anthropic/Google/Ollama/Custom） |
+| 界面 | 无 GUI，纯对话交互 | 三栏式 GUI（知识树 + 聊天 + 预览） |
+| 安装方式 | `bash install.sh --platform claude` | 下载 .dmg/.msi/.deb 安装包 |
+| 离线图谱 | 自包含 HTML，双击即开（内嵌 D3 + rough.js） | 应用内 sigma.js 渲染，需启动应用 |
+| 多平台 | Claude Code / Codex / OpenClaw | macOS / Windows / Linux 桌面 |
+
+**结论**：产品形态不同，不存在直接替代关系。我方优势在于零安装门槛（已有 agent 就能用），竞品优势在于完整 GUI 体验。
+
+---
+
+## 二、功能逐项对比
+
+### 2.1 Ingest（消化素材）
+
+| 特性 | 我方 | 竞品 | 差距评估 |
+|------|------|------|---------|
+| 两步式处理 | Step 1 结构化分析(JSON) + Step 2 页面生成 | Step 1 分析 + Step 2 生成（FILE block 解析） | **相当** |
+| 格式验证 | `validate-step1.sh` 脚本校验 JSON | FILE block 正则解析 | **我方更严格** |
+| 置信度标注 | EXTRACTED / INFERRED / AMBIGUOUS / UNVERIFIED 四级 | 无 | **我方独有** |
+| 隐私自查 | 每次消化前自查清单 | 无 | **我方独有** |
+| 内容分级 | >1000字完整 / ≤1000字简化 | 统一处理 | **我方更细致** |
+| SHA256 缓存 | 有（含自愈、回滚、原子写入） | 有（基于文件内容哈希） | **相当** |
+| 持久化队列 | 无（依赖宿主 agent 管理） | 有（串行处理、崩溃恢复、3次重试） | **竞品领先** |
+| 文件夹导入 | batch-ingest 工作流，每5个暂停 | 递归导入保留目录结构，文件夹路径作为分类上下文 | **竞品在分类上有亮点** |
+| 进度可视化 | 纯文本反馈 | Activity Panel 实时进度条 | **竞品领先**（但我方受限于无 GUI） |
+| 自动嵌入 | 无 | ingest 后自动生成向量嵌入 | **竞品领先** |
+| 溯源标记 | source 页面 + 缓存 | 每个页面 frontmatter `sources: []` | **竞品更细粒度** |
+| 语言守护 | 全局 WIKI_LANG 切换 | 每个文件独立检测语言，拒绝语言错误的文件 | **竞品更安全** |
+| 来源可溯 | 缓存关联 raw → source 页面 | `sources: []` 数组在 frontmatter 中 | **竞品更系统化** |
+
+### 2.2 知识图谱（重点对比）
+
+| 特性 | 我方 | 竞品 | 差距评估 |
+|------|------|------|---------|
+| 图谱库 | D3.js 力导向 + rough.js 手绘 | sigma.js + graphology + ForceAtlas2 | **技术路线不同** |
+| 视觉风格 | 水彩卡片风（4种变体：wash/paper/vellum/blueprint） | 标准网络图（节点+边） | **我方视觉更独特** |
+| 离线能力 | 自包含 HTML，双击即开 | 需启动桌面应用 | **我方更便携** |
+| 社区检测 | 主题页→社区，按度数选 top-30 | **Louvain 算法** 自动聚类 + 凝聚度评分 | **竞品算法更成熟** |
+| 边权重 | 无（统一 `-->` 箭头） | **4信号相关度模型**（直接链接×3、来源重叠×4、Adamic-Adar×1.5、类型亲和×1） | **竞品显著领先** |
+| 边渲染 | 手绘风格贝塞尔曲线 | 粗细/颜色按权重变化 | **竞品信息量更大** |
+| 图谱洞察 | 无 | **惊人连接 + 知识缺口 + 桥节点** | **竞品独有，价值极高** |
+| 惊人连接 | 无 | 跨社区边、跨类型连接、边缘↔枢纽耦合，复合惊喜评分 | **竞品独有** |
+| 知识缺口 | 无 | 孤立节点、稀疏社区、桥节点检测，一键触发深度研究 | **竞品独有** |
+| 交互 | 搜索/过滤/节点抽屉/小地图/缩放 | Hover 邻居高亮/点击打开页面/缩放控制/Insight 高亮 | **各有所长** |
+| 节点详情 | 抽屉面板（Markdown 渲染 + wikilink 导航） | 点击打开预览面板 | **我方更丰富** |
+| 位置缓存 | 无（每次重新布局） | 有（避免重布局跳动） | **竞品体验更好** |
+| 凝聚度 | 无 | 每个社区计算实际边/可能边比率，<0.15 标记警告 | **竞品独有** |
+
+**竞品图谱核心实现细节**（深入代码分析）：
+
+- **相关度模型**（`graph-relevance.ts`，313 行）：4 信号加权计算，每个节点维护 `outLinks`、`inLinks`、`sources`，Adamic-Adar 用 `1 / Math.log(Math.max(degree, 2))` 权重化共同邻居贡献
+- **Louvain 聚类**（`wiki-graph.ts`，305 行）：graphology-communities-louvain 算法，社区凝聚度 = 实际内部边数 / 可能边数
+- **图谱洞察**（`graph-insights.ts`，193 行）：惊人连接（跨社区+3、跨类型+2、边缘-枢纽+2、弱连接+1，阈值≥3）、知识缺口（孤立节点 degree≤1、稀疏社区 cohesion<0.15 且≥3 节点、桥节点连接≥3 社区）
+- **可视化**（`graph-view.tsx`，883 行）：sigma.js WebGL 渲染 + ForceAtlas2 布局，150 次迭代，位置缓存避免重布局，边粗细 0.5-4 按权重归一化
+
+### 2.3 检索与查询
+
+| 特性 | 我方 | 竞品 | 差距评估 |
+|------|------|------|---------|
+| 基础搜索 | Grep 关键词搜索 | 分词搜索（英文分词+去停用词、中文 CJK bigram） | **竞品更智能** |
+| 向量搜索 | 无 | LanceDB + 任意 OpenAI 兼容嵌入端点 | **竞品独有** |
+| 图谱扩展 | 无 | Top 搜索结果→种子节点→2跳遍历+衰减 | **竞品独有** |
+| 上下文预算 | 无 | 可配置 4K→1M token（60% wiki / 20% 对话 / 5% index / 15% system） | **竞品独有** |
+| 语义搜索 | 无 | 余弦相似度 ANN 检索，recall 从 58.2% 提升到 71.4% | **竞品独有** |
+| 多轮对话 | 依赖宿主 agent | 独立多会话持久化，可配置历史深度 | **形态差异** |
+
+### 2.4 深度研究（Deep Research）
+
+| 特性 | 我方 | 竞品 |
+|------|------|------|
+| 网络搜索 | 无 | Tavily API，多查询并行 |
+| LLM 综合 | 无 | 自动综合搜索结果为 wiki 页面 |
+| 自动消化 | 无 | 研究结果自动 ingest 提取实体/概念 |
+| 图谱联动 | 无 | 从图谱洞察一键触发，LLM 生成领域感知的搜索主题 |
+| 确认流程 | 无 | 可编辑的研究主题和搜索查询确认对话框 |
+| 并发控制 | 无 | 3 并发任务队列 |
+
+**竞品深度研究实现细节**（`deep-research.ts`，244 行）：
+
+- 多查询并行搜索 → URL 去重合并 → LLM 综合为 wiki 页面（带 `[[wikilink]]` 交叉引用） → 保存到 `wiki/queries/research-{slug}-{date}.md` → 自动 ingest 提取实体/概念
+- 图谱联动：点击知识缺口的"Deep Research"按钮 → LLM 读取 overview.md + purpose.md 生成领域感知的搜索主题（`optimize-research-topic.ts`） → 用户可编辑确认 → 开始研究
+
+### 2.5 审核系统（Review）
+
+| 特性 | 我方 | 竞品 |
+|------|------|------|
+| 异步审核 | 无 | LLM 在 ingest 中标记需人工判断的条目 |
+| 预定义动作 | 无 | Create Page / Skip（防止 LLM 幻觉任意动作） |
+| 搜索查询 | 无 | ingest 时预生成优化的 web 搜索查询 |
+| 自动清扫 | 无 | sweep-reviews：基于规则匹配 + LLM 语义判断自动解决 |
+
+### 2.6 文件格式支持
+
+| 格式 | 我方 | 竞品 |
+|------|------|------|
+| PDF | 有 | 有（Rust pdf-extract） |
+| Markdown/文本 | 有 | 有 |
+| DOCX | 无 | 有（docx-rs） |
+| PPTX | 无 | 有（ZIP + XML） |
+| XLSX/XLS/ODS | 无 | 有（calamine） |
+| 图片预览 | 无 | 有 |
+| 视频/音频 | 无 | 有（内置播放器） |
+| 网页 | 有（baoyu-url-to-markdown） | 有（Chrome 扩展 Readability.js） |
+| X/Twitter | 有（baoyu） | 有（Chrome 扩展） |
+| 微信公众号 | 有（wechat-article-to-markdown） | 无 |
+| YouTube | 有（youtube-transcript） | 无 |
+| 知乎 | 有（baoyu） | 无 |
+| 小红书 | 手动粘贴 | 无 |
+
+### 2.7 其他功能
+
+| 特性 | 我方 | 竞品 |
+|------|------|------|
+| Chrome 扩展 | 无 | 有（Manifest V3，Readability.js + Turndown.js） |
+| KaTeX 数学 | 无 | 有（remark-math + rehype-katex + Milkdown） |
+| 思维链显示 | 无 | 有（`<thinkining>` 块折叠显示） |
+| 场景模板 | 无 | 有（研究/阅读/个人成长/商业/通用） |
+| 对话结晶化 | 有（crystallize 工作流） | Save to Wiki（类似但更集成） |
+| 删除级联 | 有（delete 工作流 + 缓存失效） | 有（3方法匹配 + 共享页面保留） |
+| SessionStart Hook | 有（自动感知知识库） | 无（依赖应用启动） |
+
+---
+
+## 三、核心差距总结
+
+### 我方独有的优势
+1. **置信度标注体系** — 四级标注 + 可追溯，竞品完全没有
+2. **水彩卡片风图谱** — 视觉独特性，自包含离线 HTML
+3. **隐私自查** — 消化前敏感信息检查
+4. **中国素材源** — 微信公众号、知乎、小红书、YouTube
+5. **零门槛安装** — 一句话安装，不需要下载桌面应用
+6. **多 agent 平台** — Claude Code / Codex / OpenClaw 通用
+7. **Ingest 格式验证** — `validate-step1.sh` 独立脚本校验
+
+### 我方的核心差距（按优先级排序）
+
+**P0 — 决定性差距（严重影响产品竞争力）**
+
+1. **图谱相关度模型**：我方图谱只有 wikilink 连接，没有边权重、没有来源重叠分析、没有 Adamic-Adar 共同邻居计算。图谱是"平"的，所有连接看起来一样重要。
+   - 竞品做法：4 信号相关度模型（`graph-relevance.ts`），每条边都有权重分数
+   - 实现难度：中等。需要读取 frontmatter `sources` 字段做来源重叠，实现 Adamic-Adar。可在 `build-graph-data.sh` 中扩展。
+
+2. **图谱洞察**：没有"惊人连接"和"知识缺口"检测。图谱只是可视化工具，不是分析工具。
+   - 竞品做法：`graph-insights.ts`（193 行），自动检测跨社区连接、孤立节点、稀疏社区、桥节点
+   - 实现难度：中等。纯算法，不依赖 GUI。可在 `graph-wash.js` 中实现或在 `build-graph-data.sh` 中计算。
+
+3. **深度研究（Deep Research）**：完全没有网络搜索+自动研究能力。
+   - 竞品做法：`deep-research.ts`（244 行），Tavily API 搜索 → LLM 综合 → 自动 ingest
+   - 实现难度：高。需要接入搜索 API，设计新的工作流。但作为 agent skill 可以利用宿主 agent 的搜索能力。
+
+**P1 — 重要差距（影响日常使用体验）**
+
+4. **向量语义搜索**：检索只靠关键词匹配，没有语义理解能力。
+   - 竞品做法：LanceDB（Rust 嵌入式向量库） + 任意 OpenAI 兼容嵌入端点
+   - 实现难度：高。需要引入向量数据库。但作为 agent skill，可以利用宿主 agent 的语义理解能力来弥补。
+
+5. **来源溯源系统**：我方的溯源不够系统化，每个 wiki 页面没有标准化的 `sources: []` frontmatter 字段。
+   - 竞品做法：每个页面 frontmatter 都有 `sources: ["file.pdf"]` 字段
+   - 实现难度：低。主要是在模板中增加 `sources` 字段，在 ingest 中写入。**这是相关度模型和图谱洞察的基础前置依赖。**
+
+6. **Louvain 社区检测**：我方用简单的"主题页→社区"策略，不如图论算法准确。
+   - 竞品做法：graphology-communities-louvain 算法 + 凝聚度评分
+   - 实现难度：中等。在 `build-graph-data.sh` 中用 awk 或引入简单聚类算法。
+
+**P2 — 锦上添花**
+
+7. **持久化 Ingest 队列**：批量消化时没有崩溃恢复能力。
+8. **语言守护**：没有 per-file 语言检测和拒绝机制。
+9. **DOCX/PPTX/XLSX 支持**：缺少 Office 文档格式支持。
+10. **数学渲染**：没有 KaTeX/LaTeX 支持。
+11. **审核系统**：没有异步审核队列。
+
+---
+
+## 四、未来迭代方向建议
+
+基于差距分析，建议按以下优先级推进：
+
+### 第一阶段：巩固图谱核心竞争力（图谱 2.0）
+
+目标：把图谱从可视化工具升级为知识分析工具。
+
+1. **来源溯源字段**（前置依赖）
+   - 在所有页面模板中增加 `sources: []` frontmatter 字段
+   - 在 ingest 工作流中自动填充
+   - 这是后续相关度模型的基础
+
+2. **4 信号相关度模型**
+   - 直接链接（已有 wikilink）
+   - 来源重叠（基于 `sources: []` 字段）
+   - Adamic-Adar 共同邻居
+   - 类型亲和度
+   - 在 `build-graph-data.sh` 中计算，输出到 `graph-data.json` 的 `edges[].weight`
+
+3. **图谱洞察模块**
+   - 在 `build-graph-data.sh` 或独立脚本中计算：
+     - 惊人连接（跨社区边、跨类型、边缘-枢纽耦合）
+     - 知识缺口（孤立节点、稀疏社区、桥节点）
+   - 输出到 `graph-data.json` 的 `insights` 字段
+   - 在 `graph-wash.js` 中增加 Insights 面板 UI
+
+4. **凝聚度评分 + Louvain 社区检测**
+   - 升级社区检测算法
+   - 计算每个社区的凝聚度
+   - 在图谱中标记低凝聚度社区
+
+### 第二阶段：深度研究能力
+
+1. **Deep Research 工作流**
+   - 新增 SKILL.md 工作流定义
+   - 利用宿主 agent 的搜索能力（Claude Code 的 WebSearch、Codex 的内置搜索）
+   - 或接入搜索 API（Tavily / Serper / Bing）
+   - 研究结果自动 ingest
+   - 与图谱洞察联动（从知识缺口触发研究）
+
+2. **检索管线优化**
+   - 结构化搜索（带权重的分词搜索）
+   - 图谱扩展检索（种子节点 + 2 跳遍历）
+   - 上下文预算控制
+
+### 第三阶段：体验打磨
+
+1. **审核系统** — Ingest 中标记需审核条目，在 lint 工作流中展示和处理
+2. **Office 文档支持** — DOCX 提取（可利用 pandoc 或 Python docx），PPTX / XLSX 基础支持
+3. **数学渲染** — 图谱 HTML 中的 KaTeX 渲染
+
+### 不建议跟进的方向
+
+- **独立 GUI 应用**：我方定位是 agent skill，做 GUI 会偏离核心定位
+- **Chrome 扩展**：投入产出比低，baoyu-url-to-markdown 已覆盖网页提取
+- **向量数据库**：作为 agent skill，宿主 agent 的语义理解能力已够用，引入 LanceDB 过度复杂
+- **多对话持久化**：宿主 agent 已有此能力
+
+---
+
+## 五、实施验证方式
+
+每个阶段完成后：
+
+1. **回归测试**：`bash tests/regression.sh` 确保不破坏现有功能
+2. **图谱验证**：用 `~/Desktop/llm-wiki-cowork-test/raw-input/` 的 3 篇文章测试图谱生成
+3. **推送前检查**：按 CLAUDE.md 中的三层测试规则执行
+4. **竞品对照**：对同一组素材，比较双方图谱的洞察质量

--- a/scripts/build-graph-data.sh
+++ b/scripts/build-graph-data.sh
@@ -16,9 +16,26 @@ shopt -s nullglob
 WIKI_ROOT="${1:-.}"
 DEFAULT_OUTPUT="$WIKI_ROOT/wiki/graph-data.json"
 OUTPUT="${2:-$DEFAULT_OUTPUT}"
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$SKILL_DIR/scripts/graph-analysis.js"
+MAX_CONTENT_BYTES=$((2 * 1024 * 1024))
+MAX_CONTENT_LINES=500
+MAX_INSIGHT_NODES=250
+MAX_INSIGHT_EDGES=1000
 
 command -v jq >/dev/null 2>&1 || {
   echo "ERROR: jq 未安装。运行 brew install jq" >&2
+  exit 1
+}
+
+command -v node >/dev/null 2>&1 || {
+  echo "ERROR: node 未安装。图谱 2.0 构建需要 node 运行时。运行 brew install node" >&2
+  exit 1
+}
+
+[ -f "$HELPER" ] || {
+  echo "ERROR: 找不到图谱分析 helper：$HELPER" >&2
+  echo "       重装 skill 可修复（bash install.sh --platform claude）" >&2
   exit 1
 }
 
@@ -32,22 +49,18 @@ WIKI_DIR="$WIKI_ROOT/wiki"
 TMPDIR=$(mktemp -d -t llm-wiki-graph.XXXXXX)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# ─── 1. 构建时间戳 ────────────────────────────────────────────
 if [ "${LLM_WIKI_TEST_MODE:-0}" = "1" ]; then
   BUILD_DATE="2026-01-01T00:00:00Z"
 else
   BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
-# ─── 2. wiki_title（优先 purpose.md 第一个 # 标题，否则用目录名）───
 WIKI_TITLE=""
 if [ -f "$WIKI_ROOT/purpose.md" ]; then
   WIKI_TITLE=$(awk '/^# / { sub(/^# +/, ""); print; exit }' "$WIKI_ROOT/purpose.md")
 fi
 [ -n "$WIKI_TITLE" ] || WIKI_TITLE=$(basename "$(cd "$WIKI_ROOT" && pwd)")
 
-# ─── 3. 扫描所有 md 节点 ──────────────────────────────────────
-# nodes.tsv 字段：id<TAB>label<TAB>type<TAB>abs_path
 NODES_TSV="$TMPDIR/nodes.tsv"
 : > "$NODES_TSV"
 
@@ -56,7 +69,6 @@ scan_kind() {
   local dir="$WIKI_DIR/$subdir"
   [ -d "$dir" ] || return 0
   local f id label
-  # 用 find + sort 保证跨平台稳定顺序（macOS/Linux 默认 glob 顺序不同）
   while IFS= read -r f; do
     [ -f "$f" ] || continue
     id=$(basename "$f" .md)
@@ -69,15 +81,16 @@ scan_kind() {
   done < <(find "$dir" -type f -name '*.md' | LC_ALL=C sort)
 }
 
-scan_kind entities    entity
-scan_kind topics      topic
-scan_kind sources     source
+scan_kind entities entity
+scan_kind topics topic
+scan_kind sources source
 scan_kind comparisons comparison
-scan_kind synthesis   synthesis
-scan_kind queries     query
+scan_kind synthesis synthesis
+scan_kind queries query
 
 if [ ! -s "$NODES_TSV" ]; then
-  # 空图谱：输出合法 JSON（footer.html 的 EMPTY 状态会接管）
+  mkdir -p "$(dirname "$OUTPUT")"
+  OUTPUT_TMP="$TMPDIR/graph-data.empty.json"
   jq -n \
     --arg build_date "$BUILD_DATE" \
     --arg wiki_title "$WIKI_TITLE" \
@@ -87,26 +100,38 @@ if [ ! -s "$NODES_TSV" ]; then
         wiki_title: $wiki_title,
         total_nodes: 0,
         total_edges: 0,
-        initial_view: []
+        initial_view: [],
+        degraded: false,
+        insights_degraded: false
       },
       nodes: [],
-      edges: []
-    }' > "$OUTPUT"
+      edges: [],
+      insights: {
+        surprising_connections: [],
+        isolated_nodes: [],
+        bridge_nodes: [],
+        sparse_communities: [],
+        meta: {
+          degraded: false,
+          node_count: 0,
+          edge_count: 0,
+          max_insight_nodes: 250,
+          max_insight_edges: 1000
+        }
+      }
+    }' > "$OUTPUT_TMP"
+  mv "$OUTPUT_TMP" "$OUTPUT"
   echo "空图谱已写入：${OUTPUT}（wiki/ 下无可纳入节点）"
   exit 0
 fi
 
-# ─── 4. 扫描每个节点内的 [[wikilink]] ─────────────────────────
-# edges_raw.tsv 字段：from_id<TAB>from_line<TAB>to_target<TAB>line_has_confidence_kind
 EDGES_RAW="$TMPDIR/edges_raw.tsv"
 : > "$EDGES_RAW"
 
-# 用 awk 同行解析 [[link]] 和 <!-- confidence: X -->
 while IFS=$'\t' read -r id label type path; do
   awk -v src="$id" '
     {
       line = $0
-      # 提取同行 confidence 注释（若有）
       conf = ""
       if (match(line, /<!--[[:space:]]*confidence:[[:space:]]*[A-Z]+[[:space:]]*-->/)) {
         kind_str = substr(line, RSTART, RLENGTH)
@@ -114,14 +139,12 @@ while IFS=$'\t' read -r id label type path; do
           conf = substr(kind_str, RSTART, RLENGTH)
         }
       }
-      # 逐个抓 [[...]]
       rest = line
       while (match(rest, /\[\[[^]]+\]\]/)) {
-        inner = substr(rest, RSTART+2, RLENGTH-4)
-        rest  = substr(rest, RSTART+RLENGTH)
-        # 处理 [[target|label]] — 只取 target
+        inner = substr(rest, RSTART + 2, RLENGTH - 4)
+        rest  = substr(rest, RSTART + RLENGTH)
         n = index(inner, "|")
-        if (n > 0) inner = substr(inner, 1, n-1)
+        if (n > 0) inner = substr(inner, 1, n - 1)
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", inner)
         if (inner == "" || inner == src) continue
         print src "\t" NR "\t" inner "\t" conf
@@ -130,16 +153,9 @@ while IFS=$'\t' read -r id label type path; do
   ' "$path" >> "$EDGES_RAW"
 done < "$NODES_TSV"
 
-# ─── 5. 建立有效节点 id 的集合（死链不纳入 edges） ────────────
 VALID_IDS="$TMPDIR/valid_ids.txt"
 cut -f1 "$NODES_TSV" | sort -u > "$VALID_IDS"
 
-# ─── 6. 生成 edges.tsv（from<TAB>to<TAB>type） ──────────────
-# 规则：
-#   - 若同行 confidence 注释存在 → type = 该注释值
-#   - 否则 type = EXTRACTED
-#   - 死链（to 不在 VALID_IDS）丢弃
-#   - 同 from+to 的重复边按首次出现保留（优先取有 confidence 的那条）
 EDGES_TSV="$TMPDIR/edges.tsv"
 awk -F'\t' -v valids="$VALID_IDS" '
   BEGIN {
@@ -167,88 +183,36 @@ awk -F'\t' -v valids="$VALID_IDS" '
   }
 ' "$EDGES_RAW" > "$EDGES_TSV"
 
-# ─── 7. 社区聚类（topic 页 → 其链接到的节点属于该 topic 社区）
-# 对每个节点：遍历所有 topic，选 link 次数最多的那个作为 primary community
-COMMUNITY_TSV="$TMPDIR/community.tsv"
-awk -F'\t' '
-  NR==FNR { if ($3 == "topic") topics[$1] = 1; next }
-  {
-    if (topics[$1]) {
-      # 这是 topic → target 的链接
-      print $3 "\t" $1  # node_id, topic_id
-    }
-  }
-' "$NODES_TSV" "$EDGES_RAW" > "$COMMUNITY_TSV"
-
-NODE_COMMUNITY="$TMPDIR/node_community.tsv"
-awk -F'\t' '
-  { count[$1 "|" $2]++ }
-  END {
-    for (key in count) {
-      split(key, parts, "|")
-      node = parts[1]; topic = parts[2]; n = count[key]
-      if (n > best[node] || (n == best[node] && topic < best_topic[node])) {
-        best[node] = n
-        best_topic[node] = topic
-      }
-    }
-    for (n in best_topic) print n "\t" best_topic[n]
-  }
-' "$COMMUNITY_TSV" > "$NODE_COMMUNITY"
-
-# 给每个 topic 自己分配社区 id = 自己
-awk -F'\t' '$3 == "topic" { print $1 "\t" $1 }' "$NODES_TSV" >> "$NODE_COMMUNITY"
-
-# 去重
-sort -u "$NODE_COMMUNITY" -o "$NODE_COMMUNITY"
-
-# ─── 8. 决定是否降级（总 content > 2MB 截 500 行/节点）────────
 TOTAL_SIZE=0
 while IFS=$'\t' read -r id label type path; do
   sz=$(wc -c < "$path" 2>/dev/null || echo 0)
   TOTAL_SIZE=$((TOTAL_SIZE + sz))
 done < "$NODES_TSV"
+
 DEGRADE=0
-if [ "$TOTAL_SIZE" -gt $((2 * 1024 * 1024)) ]; then
+if [ "$TOTAL_SIZE" -gt "$MAX_CONTENT_BYTES" ]; then
   DEGRADE=1
 fi
 
-# ─── 9. 组装 nodes 数组（每个节点一行 JSON） ──────────────────
 NODES_JSONL="$TMPDIR/nodes.jsonl"
 : > "$NODES_JSONL"
-
 while IFS=$'\t' read -r id label type path; do
-  # 查社区
-  community=$(awk -F'\t' -v n="$id" '$1 == n { print $2; exit }' "$NODE_COMMUNITY")
-  # 读 content
-  if [ "$DEGRADE" = "1" ]; then
-    content=$(head -500 "$path")
-  else
-    content=$(cat "$path")
-  fi
   abs_path=$(cd "$(dirname "$path")" && pwd)/$(basename "$path")
-
   jq -n \
     --arg id "$id" \
     --arg label "$label" \
     --arg type "$type" \
-    --arg community "$community" \
-    --arg content "$content" \
     --arg source_path "$abs_path" \
     '{
       id: $id,
       label: $label,
       type: $type,
-      community: ($community | if . == "" then null else . end),
-      content: $content,
       source_path: $source_path
     }' >> "$NODES_JSONL"
 done < "$NODES_TSV"
 
-# ─── 10. 组装 edges 数组 ──────────────────────────────────────
 EDGES_JSONL="$TMPDIR/edges.jsonl"
 : > "$EDGES_JSONL"
-
 idx=0
 while IFS=$'\t' read -r from to etype; do
   idx=$((idx + 1))
@@ -260,54 +224,82 @@ while IFS=$'\t' read -r from to etype; do
     '{id: $id, from: $from, to: $to, type: $etype}' >> "$EDGES_JSONL"
 done < "$EDGES_TSV"
 
-# ─── 11. 按 TEST_MODE 排序（稳定 diff）────────────────────────
-# TEST_MODE 下还要给 edge 重新按 sorted 顺序赋连续 id，避免 scan 顺序影响
 if [ "${LLM_WIKI_TEST_MODE:-0}" = "1" ]; then
-  jq -s 'sort_by(.id)' "$NODES_JSONL" > "$TMPDIR/nodes.sorted.json"
+  jq -s 'sort_by(.id)' "$NODES_JSONL" > "$TMPDIR/nodes.raw.json"
   jq -s 'sort_by(.from, .to, .type)
          | to_entries
          | map(.value + {id: ("e" + ((.key + 1) | tostring))})' \
-         "$EDGES_JSONL" > "$TMPDIR/edges.sorted.json"
+    "$EDGES_JSONL" > "$TMPDIR/edges.raw.json"
 else
-  jq -s '.' "$NODES_JSONL" > "$TMPDIR/nodes.sorted.json"
-  jq -s '.' "$EDGES_JSONL" > "$TMPDIR/edges.sorted.json"
+  jq -s '.' "$NODES_JSONL" > "$TMPDIR/nodes.raw.json"
+  jq -s '.' "$EDGES_JSONL" > "$TMPDIR/edges.raw.json"
 fi
 
-# ─── 12. U2 算法：initial_view top 30 ────────────────────────
-# 步骤：按社区分组 → 每社区取度数最高 1 个 → 不足 30 按全图度数降序补齐
-INITIAL_VIEW=$(
-  jq \
-    --argjson nodes "$(cat "$TMPDIR/nodes.sorted.json")" \
-    '
-    # $nodes 是节点数组；输入是 edges 数组
-    . as $edges
-    | ($nodes | map(.id) | length) as $total_nodes
-    | (
-        # 计算每个节点的 degree
-        reduce $edges[] as $e (
-          {}; .[$e.from] = (.[$e.from] // 0) + 1 | .[$e.to] = (.[$e.to] // 0) + 1
-        )
-      ) as $deg
-    | ($nodes | group_by(.community // "_")) as $groups
-    | (
-        [ $groups[] | max_by(($deg[.id] // 0)) | .id ]
-      ) as $reps
-    | (
-        $nodes
-        | sort_by(- ($deg[.id] // 0))
-        | map(.id)
-        | map(select(. as $x | $reps | index($x) | not))
-      ) as $rest
-    | ($reps + $rest)[0:30]
-    ' \
-    "$TMPDIR/edges.sorted.json"
-)
+ANALYSIS_JSON="$TMPDIR/analysis.json"
+if ! node "$HELPER" \
+  "$TMPDIR/nodes.raw.json" \
+  "$TMPDIR/edges.raw.json" \
+  "$ANALYSIS_JSON" \
+  "$DEGRADE" \
+  "$MAX_CONTENT_LINES" \
+  "$MAX_INSIGHT_NODES" \
+  "$MAX_INSIGHT_EDGES"; then
+  echo "ERROR: 图谱分析 helper 执行失败：$HELPER" >&2
+  exit 1
+fi
 
-# ─── 13. 最终组装 ────────────────────────────────────────────
+jq -e '
+  (.nodes | type) == "array" and
+  (.edges | type) == "array" and
+  (.insights | type) == "object" and
+  (.insights.surprising_connections | type) == "array" and
+  (.insights.isolated_nodes | type) == "array" and
+  (.insights.bridge_nodes | type) == "array" and
+  (.insights.sparse_communities | type) == "array"
+' "$ANALYSIS_JSON" > /dev/null 2>&1 || {
+  echo "ERROR: 图谱分析 helper 返回坏 JSON：$ANALYSIS_JSON" >&2
+  exit 1
+}
+
+if [ "${LLM_WIKI_TEST_MODE:-0}" = "1" ]; then
+  jq '.nodes | sort_by(.id)' "$ANALYSIS_JSON" > "$TMPDIR/nodes.sorted.json"
+  jq '.edges | sort_by(.from, .to, .type)
+       | to_entries
+       | map(.value + {id: ("e" + ((.key + 1) | tostring))})' "$ANALYSIS_JSON" > "$TMPDIR/edges.sorted.json"
+else
+  jq '.nodes' "$ANALYSIS_JSON" > "$TMPDIR/nodes.sorted.json"
+  jq '.edges' "$ANALYSIS_JSON" > "$TMPDIR/edges.sorted.json"
+fi
+
+INITIAL_VIEW=$(jq \
+  --argjson nodes "$(cat "$TMPDIR/nodes.sorted.json")" \
+  '
+  . as $edges
+  | (
+      reduce $edges[] as $e (
+        {};
+        .[$e.from] = (.[$e.from] // 0) + 1 |
+        .[$e.to] = (.[$e.to] // 0) + 1
+      )
+    ) as $deg
+  | ($nodes | group_by(.community // "_")) as $groups
+  | ([ $groups[] | max_by(($deg[.id] // 0)) | .id ]) as $reps
+  | (
+      $nodes
+      | sort_by(- ($deg[.id] // 0))
+      | map(.id)
+      | map(select(. as $x | $reps | index($x) | not))
+    ) as $rest
+  | ($reps + $rest)[0:30]
+  ' \
+  "$TMPDIR/edges.sorted.json")
+
 NODE_COUNT=$(jq 'length' "$TMPDIR/nodes.sorted.json")
 EDGE_COUNT=$(jq 'length' "$TMPDIR/edges.sorted.json")
+INSIGHTS_DEGRADED=$(jq '.insights.meta.degraded == true' "$ANALYSIS_JSON")
 
 mkdir -p "$(dirname "$OUTPUT")"
+OUTPUT_TMP="$TMPDIR/graph-data.final.json"
 
 jq -n \
   --arg build_date "$BUILD_DATE" \
@@ -317,7 +309,9 @@ jq -n \
   --argjson initial_view "$INITIAL_VIEW" \
   --argjson nodes "$(cat "$TMPDIR/nodes.sorted.json")" \
   --argjson edges "$(cat "$TMPDIR/edges.sorted.json")" \
+  --argjson insights "$(jq '.insights' "$ANALYSIS_JSON")" \
   --argjson degraded "$DEGRADE" \
+  --argjson insights_degraded "$INSIGHTS_DEGRADED" \
   '{
     meta: {
       build_date: $build_date,
@@ -325,15 +319,20 @@ jq -n \
       total_nodes: $total_nodes,
       total_edges: $total_edges,
       initial_view: $initial_view,
-      degraded: ($degraded == 1)
+      degraded: ($degraded == 1),
+      insights_degraded: $insights_degraded
     },
     nodes: $nodes,
-    edges: $edges
-  }' > "$OUTPUT"
+    edges: $edges,
+    insights: $insights
+  }' > "$OUTPUT_TMP"
+
+mv "$OUTPUT_TMP" "$OUTPUT"
 
 echo "图谱数据已生成：$OUTPUT"
 echo "  节点：$NODE_COUNT"
 echo "  关联：$EDGE_COUNT"
 echo "  初始视图：$(echo "$INITIAL_VIEW" | jq 'length') 个节点"
-[ "$DEGRADE" = "1" ] && echo "  ⚠ 降级模式：内嵌内容 > 2MB，每节点仅保留前 500 行"
+[ "$DEGRADE" = "1" ] && echo "  ⚠ 降级模式：内嵌内容 > 2MB，每节点仅保留前 ${MAX_CONTENT_LINES} 行"
+[ "$INSIGHTS_DEGRADED" = "true" ] && echo "  ⚠ 洞察降级：图规模超出预算，仅保留基础权重与社区"
 exit 0

--- a/scripts/graph-analysis.js
+++ b/scripts/graph-analysis.js
@@ -1,0 +1,720 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function roundNumber(value, digits = 3) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function clamp01(value) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function sortedPairKey(a, b) {
+  return a < b ? `${a}\t${b}` : `${b}\t${a}`;
+}
+
+function sortedUnique(values) {
+  return Array.from(new Set(values)).sort();
+}
+
+function extractFrontmatter(text) {
+  if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
+    return { hasFrontmatter: false, frontmatter: "", body: text };
+  }
+
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/);
+  if (!match) {
+    return { hasFrontmatter: false, frontmatter: "", body: text };
+  }
+
+  return {
+    hasFrontmatter: true,
+    frontmatter: match[1],
+    body: match[2]
+  };
+}
+
+function normalizeSourceToken(token) {
+  const trimmed = String(token || "").trim();
+  if (!trimmed) return null;
+
+  let value = trimmed;
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1).trim();
+  }
+
+  return value || null;
+}
+
+function parseInlineSources(raw) {
+  const trimmed = raw.trim();
+  if (trimmed === "[]") return { ok: true, values: [] };
+  if (!(trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+    return { ok: false, values: [] };
+  }
+
+  const inner = trimmed.slice(1, -1).trim();
+  if (!inner) return { ok: true, values: [] };
+
+  const values = inner
+    .split(",")
+    .map(normalizeSourceToken)
+    .filter(Boolean);
+
+  return { ok: true, values };
+}
+
+function parseSourcesFrontmatter(frontmatter) {
+  const lines = frontmatter.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^sources:\s*(.*)$/);
+    if (!match) continue;
+
+    const rest = match[1].trim();
+    if (rest) {
+      if (!rest.startsWith("[")) {
+        const single = normalizeSourceToken(rest);
+        return {
+          hasField: true,
+          parsed: Boolean(single),
+          sources: single ? [single] : [],
+          signalAvailable: Boolean(single)
+        };
+      }
+
+      const parsedInline = parseInlineSources(rest);
+      return {
+        hasField: true,
+        parsed: parsedInline.ok,
+        sources: parsedInline.ok ? sortedUnique(parsedInline.values) : [],
+        signalAvailable: parsedInline.ok && parsedInline.values.length > 0
+      };
+    }
+
+    const collected = [];
+    let parsed = true;
+    let consumed = 0;
+
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const line = lines[cursor];
+      if (!line.trim()) {
+        consumed += 1;
+        continue;
+      }
+      if (/^[^\s-]/.test(line)) break;
+      const itemMatch = line.match(/^\s*-\s*(.+)$/);
+      if (!itemMatch) {
+        parsed = false;
+        consumed += 1;
+        continue;
+      }
+      const token = normalizeSourceToken(itemMatch[1]);
+      if (token) collected.push(token);
+      consumed += 1;
+    }
+
+    index += consumed;
+    return {
+      hasField: true,
+      parsed,
+      sources: parsed ? sortedUnique(collected) : [],
+      signalAvailable: parsed && collected.length > 0
+    };
+  }
+
+  return { hasField: false, parsed: false, sources: [], signalAvailable: false };
+}
+
+function normalizeBody(text, degraded, maxLines) {
+  const { body } = extractFrontmatter(text);
+  const normalized = body.replace(/^\s+/, "").replace(/\s+$/, "");
+  if (!degraded) return normalized;
+  return normalized.split(/\r?\n/).slice(0, maxLines).join("\n").replace(/\s+$/, "");
+}
+
+function loadNodeDetails(nodes, degraded, maxLines) {
+  const byId = {};
+
+  for (const node of nodes) {
+    const raw = fs.readFileSync(node.source_path, "utf8");
+    const frontmatter = extractFrontmatter(raw);
+    const parsedSources = parseSourcesFrontmatter(frontmatter.frontmatter);
+    const normalizedNode = {
+      ...node,
+      content: normalizeBody(raw, degraded, maxLines),
+      _signals: {
+        sources: parsedSources.sources,
+        sourceSignalAvailable: parsedSources.signalAvailable,
+        sourceFieldPresent: parsedSources.hasField,
+        sourceFieldParsed: parsedSources.parsed
+      }
+    };
+    byId[node.id] = normalizedNode;
+  }
+
+  return byId;
+}
+
+function buildInlinks(edges) {
+  const inlinks = new Map();
+
+  for (const edge of edges) {
+    if (!inlinks.has(edge.to)) inlinks.set(edge.to, new Set());
+    inlinks.get(edge.to).add(edge.from);
+  }
+
+  return inlinks;
+}
+
+function intersectionCount(setA, setB) {
+  if (!setA || !setB) return 0;
+  let small = setA;
+  let large = setB;
+  if (setB.size < setA.size) {
+    small = setB;
+    large = setA;
+  }
+
+  let count = 0;
+  for (const value of small) {
+    if (large.has(value)) count += 1;
+  }
+  return count;
+}
+
+function typeAffinity(typeA, typeB) {
+  const pair = [typeA || "other", typeB || "other"].sort().join(":");
+  switch (pair) {
+    case "entity:entity":
+    case "entity:topic":
+      return 1;
+    case "topic:topic":
+      return 0.8;
+    case "entity:source":
+      return 0.6;
+    case "source:source":
+      return 0.3;
+    default:
+      return 0.5;
+  }
+}
+
+function computePairMetrics(nodesById, edges) {
+  const inlinks = buildInlinks(edges);
+  const pairMetrics = new Map();
+
+  for (const edge of edges) {
+    const pairKey = sortedPairKey(edge.from, edge.to);
+    if (pairMetrics.has(pairKey)) continue;
+
+    const fromNode = nodesById[edge.from];
+    const toNode = nodesById[edge.to];
+    if (!fromNode || !toNode) continue;
+
+    const fromInlinks = inlinks.get(edge.from) || new Set();
+    const toInlinks = inlinks.get(edge.to) || new Set();
+    const sharedInlinks = intersectionCount(fromInlinks, toInlinks);
+    const coCitation = sharedInlinks / Math.max(fromInlinks.size, toInlinks.size, 1);
+    const affinity = typeAffinity(fromNode.type, toNode.type);
+
+    const signals = [coCitation, affinity];
+    let sourceOverlap = null;
+    const sourceSignalAvailable = Boolean(
+      fromNode._signals.sourceSignalAvailable && toNode._signals.sourceSignalAvailable
+    );
+
+    if (sourceSignalAvailable) {
+      const fromSources = new Set(fromNode._signals.sources);
+      const toSources = new Set(toNode._signals.sources);
+      const overlap = intersectionCount(fromSources, toSources);
+      const minSize = Math.min(fromSources.size, toSources.size);
+      sourceOverlap = minSize > 0 ? overlap / minSize : 0;
+      signals.push(sourceOverlap);
+    }
+
+    const weight = clamp01(signals.reduce((sum, value) => sum + value, 0) / signals.length);
+
+    pairMetrics.set(pairKey, {
+      weight: roundNumber(weight),
+      signals: {
+        co_citation: roundNumber(coCitation),
+        source_overlap: sourceOverlap == null ? null : roundNumber(sourceOverlap),
+        type_affinity: roundNumber(affinity)
+      },
+      source_signal_available: sourceSignalAvailable
+    });
+  }
+
+  return pairMetrics;
+}
+
+function buildUndirectedGraph(nodeIds, pairMetrics) {
+  const adjacency = new Map();
+  const degrees = new Map();
+
+  for (const nodeId of nodeIds) {
+    adjacency.set(nodeId, new Map());
+    degrees.set(nodeId, 0);
+  }
+
+  for (const [pairKey, metrics] of pairMetrics.entries()) {
+    const [left, right] = pairKey.split("\t");
+    if (!adjacency.has(left) || !adjacency.has(right)) continue;
+    const weight = metrics.weight;
+    adjacency.get(left).set(right, weight);
+    adjacency.get(right).set(left, weight);
+    degrees.set(left, degrees.get(left) + weight);
+    degrees.set(right, degrees.get(right) + weight);
+  }
+
+  return { adjacency, degrees };
+}
+
+function runLocalMove(graph) {
+  const nodes = Array.from(graph.nodes.keys()).sort();
+  const communities = new Map();
+  const totals = new Map();
+  let moved = false;
+
+  for (const nodeId of nodes) {
+    communities.set(nodeId, nodeId);
+    totals.set(nodeId, graph.degrees.get(nodeId) || 0);
+  }
+
+  if (graph.m2 === 0) {
+    return { communities, changed: false };
+  }
+
+  let changedInPass = true;
+  let passCount = 0;
+  while (changedInPass && passCount < 50) {
+    passCount++;
+    changedInPass = false;
+
+    for (const nodeId of nodes) {
+      const degree = graph.degrees.get(nodeId) || 0;
+      const currentCommunity = communities.get(nodeId);
+      const neighborCommunities = new Map();
+
+      for (const [neighborId, weight] of graph.nodes.get(nodeId).entries()) {
+        const communityId = communities.get(neighborId);
+        neighborCommunities.set(communityId, (neighborCommunities.get(communityId) || 0) + weight);
+      }
+
+      totals.set(currentCommunity, (totals.get(currentCommunity) || 0) - degree);
+      if ((neighborCommunities.get(currentCommunity) || 0) === 0) {
+        neighborCommunities.set(currentCommunity, 0);
+      }
+
+      let bestCommunity = currentCommunity;
+      let bestGain = 0;
+
+      const candidates = Array.from(neighborCommunities.keys()).sort();
+      for (const communityId of candidates) {
+        const inWeight = neighborCommunities.get(communityId) || 0;
+        const gain = inWeight - ((totals.get(communityId) || 0) * degree) / graph.m2;
+        if (gain > bestGain + 1e-9) {
+          bestGain = gain;
+          bestCommunity = communityId;
+        }
+      }
+
+      communities.set(nodeId, bestCommunity);
+      totals.set(bestCommunity, (totals.get(bestCommunity) || 0) + degree);
+
+      if (bestCommunity !== currentCommunity) {
+        changedInPass = true;
+        moved = true;
+      }
+    }
+  }
+
+  return { communities, changed: moved };
+}
+
+function aggregateGraph(graph, communities) {
+  const communityIds = sortedUnique(Array.from(communities.values()));
+  const aggregatedNodes = new Map();
+  const aggregatedDegrees = new Map();
+  const members = new Map();
+
+  for (const communityId of communityIds) {
+    aggregatedNodes.set(communityId, new Map());
+    aggregatedDegrees.set(communityId, 0);
+    members.set(communityId, []);
+  }
+
+  for (const [nodeId, communityId] of communities.entries()) {
+    members.get(communityId).push(...(graph.members.get(nodeId) || [nodeId]));
+  }
+
+  for (const [nodeId, neighbors] of graph.nodes.entries()) {
+    const sourceCommunity = communities.get(nodeId);
+    for (const [neighborId, weight] of neighbors.entries()) {
+      if (nodeId > neighborId) continue;
+      const targetCommunity = communities.get(neighborId);
+      const current = aggregatedNodes.get(sourceCommunity).get(targetCommunity) || 0;
+      aggregatedNodes.get(sourceCommunity).set(targetCommunity, current + weight);
+      if (sourceCommunity !== targetCommunity) {
+        const mirrored = aggregatedNodes.get(targetCommunity).get(sourceCommunity) || 0;
+        aggregatedNodes.get(targetCommunity).set(sourceCommunity, mirrored + weight);
+      }
+    }
+  }
+
+  for (const [communityId, neighbors] of aggregatedNodes.entries()) {
+    let degree = 0;
+    for (const [neighborId, weight] of neighbors.entries()) {
+      degree += neighborId === communityId ? weight * 2 : weight;
+    }
+    aggregatedDegrees.set(communityId, degree);
+  }
+
+  return {
+    nodes: aggregatedNodes,
+    degrees: aggregatedDegrees,
+    members,
+    m2: Array.from(aggregatedDegrees.values()).reduce((sum, value) => sum + value, 0)
+  };
+}
+
+function runLouvain(nodeIds, pairMetrics) {
+  const baseGraph = buildUndirectedGraph(nodeIds, pairMetrics);
+  let graph = {
+    nodes: baseGraph.adjacency,
+    degrees: baseGraph.degrees,
+    members: new Map(nodeIds.map((nodeId) => [nodeId, [nodeId]])),
+    m2: Array.from(baseGraph.degrees.values()).reduce((sum, value) => sum + value, 0)
+  };
+
+  let bestMembers = graph.members;
+
+  while (true) {
+    const phase = runLocalMove(graph);
+    const nextGraph = aggregateGraph(graph, phase.communities);
+    bestMembers = nextGraph.members;
+
+    if (!phase.changed || nextGraph.nodes.size === graph.nodes.size) {
+      break;
+    }
+
+    graph = nextGraph;
+  }
+
+  const finalCommunities = new Map();
+  for (const [communityId, members] of bestMembers.entries()) {
+    for (const nodeId of members) {
+      finalCommunities.set(nodeId, communityId);
+    }
+  }
+
+  return finalCommunities;
+}
+
+function buildDirectedDegree(edges) {
+  const degree = new Map();
+  for (const edge of edges) {
+    degree.set(edge.from, (degree.get(edge.from) || 0) + 1);
+    degree.set(edge.to, (degree.get(edge.to) || 0) + 1);
+  }
+  return degree;
+}
+
+function chooseCommunityLabels(nodeIds, communityAssignments, nodesById, edges) {
+  const groups = new Map();
+  const degree = buildDirectedDegree(edges);
+
+  for (const nodeId of nodeIds) {
+    const communityId = communityAssignments.get(nodeId) || nodeId;
+    if (!groups.has(communityId)) groups.set(communityId, []);
+    groups.get(communityId).push(nodeId);
+  }
+
+  const labeledAssignments = new Map();
+
+  for (const members of groups.values()) {
+    members.sort();
+    if (members.length === 1) {
+      labeledAssignments.set(members[0], null);
+      continue;
+    }
+
+    const memberNodes = members.map((memberId) => nodesById[memberId]);
+    const topics = memberNodes.filter((node) => node && node.type === "topic");
+    const candidates = topics.length ? topics : memberNodes;
+    candidates.sort((left, right) => {
+      const degreeDiff = (degree.get(right.id) || 0) - (degree.get(left.id) || 0);
+      if (degreeDiff !== 0) return degreeDiff;
+      return left.id.localeCompare(right.id);
+    });
+
+    const label = candidates[0] ? candidates[0].id : members[0];
+    for (const memberId of members) {
+      labeledAssignments.set(memberId, label);
+    }
+  }
+
+  return labeledAssignments;
+}
+
+function buildInsights(nodesById, edges, pairMetrics, communityAssignments, options) {
+  const directedDegree = buildDirectedDegree(edges);
+  const undirectedPairs = new Map();
+  const adjacency = new Map();
+
+  for (const nodeId of Object.keys(nodesById)) {
+    adjacency.set(nodeId, new Set());
+  }
+
+  for (const edge of edges) {
+    const pairKey = sortedPairKey(edge.from, edge.to);
+    if (!undirectedPairs.has(pairKey)) {
+      undirectedPairs.set(pairKey, {
+        from: pairKey.split("\t")[0],
+        to: pairKey.split("\t")[1],
+        weight: pairMetrics.get(pairKey)?.weight || 0
+      });
+    }
+    adjacency.get(edge.from)?.add(edge.to);
+    adjacency.get(edge.to)?.add(edge.from);
+  }
+
+  const isolatedNodes = Object.values(nodesById)
+    .filter((node) => (directedDegree.get(node.id) || 0) <= 1)
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((node) => ({
+      id: node.id,
+      label: node.label,
+      degree: directedDegree.get(node.id) || 0,
+      community: communityAssignments.get(node.id) || null
+    }));
+
+  const bridgeNodes = [];
+  for (const node of Object.values(nodesById).sort((left, right) => left.id.localeCompare(right.id))) {
+    const ownCommunity = communityAssignments.get(node.id) || null;
+    const connectedCommunities = sortedUnique(
+      Array.from(adjacency.get(node.id) || [])
+        .map((neighborId) => communityAssignments.get(neighborId) || null)
+        .filter((c) => c && c !== ownCommunity)
+    );
+
+    if (connectedCommunities.length >= 2) {
+      bridgeNodes.push({
+        id: node.id,
+        label: node.label,
+        community: ownCommunity,
+        connected_communities: connectedCommunities,
+        community_count: connectedCommunities.length
+      });
+    }
+  }
+
+  const communityMembers = new Map();
+  for (const node of Object.values(nodesById)) {
+    const communityId = communityAssignments.get(node.id) || null;
+    if (!communityId) continue;
+    if (!communityMembers.has(communityId)) communityMembers.set(communityId, []);
+    communityMembers.get(communityId).push(node.id);
+  }
+
+  const sparseCommunities = [];
+  for (const [communityId, members] of Array.from(communityMembers.entries()).sort((left, right) => left[0].localeCompare(right[0]))) {
+    if (members.length < 3) continue;
+
+    const memberSet = new Set(members);
+    let internalEdges = 0;
+    for (const pair of undirectedPairs.values()) {
+      if (memberSet.has(pair.from) && memberSet.has(pair.to)) internalEdges += 1;
+    }
+
+    const possibleEdges = (members.length * (members.length - 1)) / 2;
+    const density = possibleEdges === 0 ? 0 : internalEdges / possibleEdges;
+    if (density < 0.15) {
+      sparseCommunities.push({
+        id: communityId,
+        label: nodesById[communityId]?.label || communityId,
+        node_count: members.length,
+        density: roundNumber(density),
+        members: members.sort(),
+        internal_edges: internalEdges
+      });
+    }
+  }
+
+  const surprisingConnections = Array.from(undirectedPairs.values())
+    .filter((pair) => {
+      const fromCommunity = communityAssignments.get(pair.from) || null;
+      const toCommunity = communityAssignments.get(pair.to) || null;
+      return fromCommunity && toCommunity && fromCommunity !== toCommunity && pair.weight >= 0.75;
+    })
+    .sort((left, right) => {
+      if (right.weight !== left.weight) return right.weight - left.weight;
+      if (left.from !== right.from) return left.from.localeCompare(right.from);
+      return left.to.localeCompare(right.to);
+    })
+    .slice(0, 8)
+    .map((pair) => ({
+      from: pair.from,
+      to: pair.to,
+      weight: pair.weight,
+      from_community: communityAssignments.get(pair.from) || null,
+      to_community: communityAssignments.get(pair.to) || null
+    }));
+
+  const degraded = options.nodeCount > options.maxInsightNodes || options.edgeCount > options.maxInsightEdges;
+  if (degraded) {
+    return {
+      surprising_connections: [],
+      isolated_nodes: isolatedNodes,
+      bridge_nodes: [],
+      sparse_communities: [],
+      meta: {
+        degraded: true,
+        node_count: options.nodeCount,
+        edge_count: options.edgeCount,
+        max_insight_nodes: options.maxInsightNodes,
+        max_insight_edges: options.maxInsightEdges
+      }
+    };
+  }
+
+  return {
+    surprising_connections: surprisingConnections,
+    isolated_nodes: isolatedNodes,
+    bridge_nodes: bridgeNodes,
+    sparse_communities: sparseCommunities,
+    meta: {
+      degraded: false,
+      node_count: options.nodeCount,
+      edge_count: options.edgeCount,
+      max_insight_nodes: options.maxInsightNodes,
+      max_insight_edges: options.maxInsightEdges
+    }
+  };
+}
+
+function analyzeGraph(nodes, edges, options = {}) {
+  const degraded = options.degraded === true;
+  const maxLines = options.maxLines || 500;
+  const maxInsightNodes = options.maxInsightNodes || 250;
+  const maxInsightEdges = options.maxInsightEdges || 1000;
+
+  const nodesById = loadNodeDetails(nodes, degraded, maxLines);
+  const pairMetrics = computePairMetrics(nodesById, edges);
+  const nodeIds = nodes.map((node) => node.id);
+  const communityAssignments = chooseCommunityLabels(
+    nodeIds,
+    runLouvain(nodeIds, pairMetrics),
+    nodesById,
+    edges
+  );
+
+  const analyzedNodes = nodes.map((node) => ({
+    id: node.id,
+    label: node.label,
+    type: node.type,
+    community: communityAssignments.get(node.id) || null,
+    content: nodesById[node.id].content
+  }));
+
+  const analyzedEdges = edges.map((edge) => {
+    const pairKey = sortedPairKey(edge.from, edge.to);
+    const metrics = pairMetrics.get(pairKey) || {
+      weight: 0,
+      signals: { co_citation: 0, source_overlap: null, type_affinity: 0.5 },
+      source_signal_available: false
+    };
+
+    return {
+      id: edge.id,
+      from: edge.from,
+      to: edge.to,
+      type: edge.type,
+      weight: metrics.weight,
+      source_signal_available: metrics.source_signal_available,
+      signals: metrics.signals
+    };
+  });
+
+  const insights = buildInsights(nodesById, analyzedEdges, pairMetrics, communityAssignments, {
+    nodeCount: analyzedNodes.length,
+    edgeCount: analyzedEdges.length,
+    maxInsightNodes,
+    maxInsightEdges
+  });
+
+  return { nodes: analyzedNodes, edges: analyzedEdges, insights };
+}
+
+function main(argv) {
+  if (argv.length < 7) {
+    console.error("Usage: node graph-analysis.js <nodes.json> <edges.json> <output.json> <degraded:0|1> <max-lines> <max-insight-nodes> <max-insight-edges>");
+    process.exit(1);
+  }
+
+  const timer = setTimeout(() => {
+    console.error("ERROR: graph analysis timed out (120s)");
+    process.exit(2);
+  }, 120_000);
+  timer.unref();
+
+  const [, , nodesPath, edgesPath, outputPath, degradedRaw, maxLinesRaw, maxInsightNodesRaw, maxInsightEdgesRaw] = argv;
+
+  for (const p of [nodesPath, edgesPath]) {
+    if (!fs.existsSync(p)) {
+      console.error(`ERROR: File not found: ${p}`);
+      process.exit(1);
+    }
+  }
+
+  const analyzed = analyzeGraph(readJson(nodesPath), readJson(edgesPath), {
+    degraded: degradedRaw === "1",
+    maxLines: Number(maxLinesRaw) || 500,
+    maxInsightNodes: Number(maxInsightNodesRaw) || 250,
+    maxInsightEdges: Number(maxInsightEdgesRaw) || 1000
+  });
+
+  writeJson(outputPath, analyzed);
+  clearTimeout(timer);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (error) {
+    const code = error && error.code;
+    if (code === "ENOENT") {
+      console.error(`ERROR: File not found: ${error.path || "(unknown)"}`);
+    } else if (error instanceof SyntaxError) {
+      console.error(`ERROR: Invalid JSON in input: ${error.message}`);
+    } else {
+      console.error(`ERROR: ${error && error.message ? error.message : String(error)}`);
+    }
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  analyzeGraph,
+  buildInsights,
+  chooseCommunityLabels,
+  computePairMetrics,
+  extractFrontmatter,
+  normalizeBody,
+  parseSourcesFrontmatter,
+  runLouvain,
+  typeAffinity
+};

--- a/templates/graph-styles/wash/graph-wash.js
+++ b/templates/graph-styles/wash/graph-wash.js
@@ -5,7 +5,12 @@
   "use strict";
 
   const dataEl = document.getElementById("graph-data");
-  const DATA = dataEl ? JSON.parse(dataEl.textContent) : window.SAMPLE_GRAPH;
+  let DATA;
+  try {
+    DATA = dataEl ? JSON.parse(dataEl.textContent) : window.SAMPLE_GRAPH;
+  } catch (_) {
+    DATA = { meta: {}, nodes: [], edges: [], insights: { surprising_connections: [], isolated_nodes: [], bridge_nodes: [], sparse_communities: [], meta: { degraded: true } } };
+  }
   const svg = d3.select("#canvas");
   const svgNode = svg.node();
   const mmSvg = d3.select("#minimap-svg");
@@ -13,6 +18,8 @@
   const minimapToggle = document.getElementById("minimap-toggle");
   const drawerNeighbors = document.getElementById("dr-neighbors");
   const drawerNeighborsHeading = drawerNeighbors ? drawerNeighbors.querySelector("h4") : null;
+  const insightsBody = document.getElementById("insights-body");
+  const insightsMeta = document.getElementById("insights-meta");
 
   // ---------- state ----------
   const state = {
@@ -23,6 +30,14 @@
     links: [],
     visibleLinks: [],
     communities: {},
+    insights: {
+      surprising_connections: [],
+      isolated_nodes: [],
+      bridge_nodes: [],
+      sparse_communities: [],
+      meta: { degraded: false }
+    },
+    searchIndex: [],
     tweaks: Object.assign(
       { variant: "wash", sizeMode: "uniform", bubbleMode: "wash", nodeStyle: "card" },
       window.__TWEAKS || {}
@@ -120,21 +135,26 @@
 
   // ---------- Prepare data ----------
   function prepareData() {
-    state.nodes = DATA.nodes.map((n, i) => Object.assign({}, n, {
+    state.nodes = (DATA.nodes || []).map((n, i) => Object.assign({}, n, {
       idx: i,
       degree: 0
     }));
-    state.links = DATA.edges.map(e => Object.assign({}, e, {
-      source: e.from, target: e.to
+    state.links = (DATA.edges || []).map(e => Object.assign({}, e, {
+      weight: clampWeight(e.weight),
+      signals: normalizeSignals(e.signals),
+      source_signal_available: e.source_signal_available === true,
+      source: e.from,
+      target: e.to
     }));
-    // compute degree
+    state.insights = normalizeInsights(DATA.insights);
+
     const byId = {};
     state.nodes.forEach(n => { byId[n.id] = n; });
     state.links.forEach(l => {
       if (byId[l.source]) byId[l.source].degree++;
       if (byId[l.target]) byId[l.target].degree++;
     });
-    // communities
+
     const commMap = {};
     state.nodes.forEach(n => {
       const c = n.community == null ? "_none" : String(n.community);
@@ -144,7 +164,6 @@
     state.communities = commMap;
     state.byId = byId;
 
-    // community colors
     const palette = state.variantTokens.commPalette;
     const commKeys = Object.keys(commMap).filter(k => k !== "_none");
     commKeys.forEach((k, i) => {
@@ -156,9 +175,68 @@
       const c = n.community == null ? "_none" : String(n.community);
       n.commColor = commMap[c].color;
     });
+
+    state.searchIndex = state.nodes.map(n => ({
+      node: n,
+      haystack: `${(n.label || n.id || "").toLowerCase()}\n${(n.content || "").slice(0, 500).toLowerCase()}`
+    }));
   }
 
   // ---------- Node geometry ----------
+  function clampWeight(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return 0.5;
+    return Math.max(0, Math.min(1, numeric));
+  }
+
+  function normalizeSignals(signals) {
+    const safe = signals && typeof signals === "object" ? signals : {};
+    return {
+      co_citation: Number.isFinite(Number(safe.co_citation)) ? Number(safe.co_citation) : 0,
+      source_overlap: Number.isFinite(Number(safe.source_overlap)) ? Number(safe.source_overlap) : null,
+      type_affinity: Number.isFinite(Number(safe.type_affinity)) ? Number(safe.type_affinity) : 0.5
+    };
+  }
+
+  function normalizeInsights(insights) {
+    const safe = insights && typeof insights === "object" ? insights : {};
+    return {
+      surprising_connections: Array.isArray(safe.surprising_connections) ? safe.surprising_connections : [],
+      isolated_nodes: Array.isArray(safe.isolated_nodes) ? safe.isolated_nodes : [],
+      bridge_nodes: Array.isArray(safe.bridge_nodes) ? safe.bridge_nodes : [],
+      sparse_communities: Array.isArray(safe.sparse_communities) ? safe.sparse_communities : [],
+      meta: safe.meta && typeof safe.meta === "object" ? safe.meta : { degraded: false }
+    };
+  }
+
+  function edgeStrokeWidth(edge) {
+    return 0.6 + clampWeight(edge.weight) * 2.5;
+  }
+
+  function edgeOpacity(edge) {
+    return 0.2 + clampWeight(edge.weight) * 0.55;
+  }
+
+  function edgeRoughness(edge) {
+    return 2.2 - clampWeight(edge.weight) * 1.2;
+  }
+
+  function edgeHaloOpacity(edge) {
+    return clampWeight(edge.weight) >= 0.6 ? 0.14 + clampWeight(edge.weight) * 0.12 : 0;
+  }
+
+  function edgeStrengthSize(edge) {
+    return 6 + clampWeight(edge.weight) * 8;
+  }
+
+  function shouldShowEndpointDot(edge) {
+    return clampWeight(edge.weight) > 0.4;
+  }
+
+  function shouldShowBlur(edge) {
+    return clampWeight(edge.weight) >= 0.6 && edge._blurRank < 14;
+  }
+
   function nodeRadius(n) {
     const mode = state.tweaks.sizeMode;
     if (mode === "uniform") return 18;
@@ -167,7 +245,6 @@
       if (n.type === "source") return 14;
       return 18;
     }
-    // degree
     return 12 + Math.sqrt(n.degree) * 4;
   }
 
@@ -446,15 +523,34 @@
   }
 
   function renderEdges() {
-    const vis = visibleLinks();
+    const vis = visibleLinks()
+      .slice()
+      .sort((left, right) => clampWeight(right.weight) - clampWeight(left.weight));
+    vis.forEach((edge, index) => { edge._blurRank = index; });
     state.visibleLinks = vis;
-    const sel = edgeLayer.selectAll("path.edge")
+
+    const groups = edgeLayer.selectAll("g.edge-wrap")
       .data(vis, d => d.id);
-    sel.exit().remove();
-    sel.enter().append("path")
+    groups.exit().remove();
+
+    const enter = groups.enter().append("g").attr("class", "edge-wrap");
+    enter.append("path").attr("class", "edge-halo");
+    enter.append("path")
       .attr("class", "edge")
+      .attr("data-type", d => d.type || "EXTRACTED");
+
+    const merged = enter.merge(groups);
+    merged.select(".edge")
       .attr("data-type", d => d.type || "EXTRACTED")
-      .merge(sel);
+      .style("stroke-width", d => edgeStrokeWidth(d))
+      .style("opacity", d => edgeOpacity(d));
+
+    merged.select(".edge-halo")
+      .attr("data-type", d => d.type || "EXTRACTED")
+      .style("stroke", d => edgeBaseColor(d))
+      .style("stroke-width", d => edgeStrokeWidth(d) + 3.2)
+      .style("opacity", d => shouldShowBlur(d) ? edgeHaloOpacity(d) : 0)
+      .style("filter", d => shouldShowBlur(d) ? "blur(3px)" : "none");
   }
 
   function renderNodes() {
@@ -536,24 +632,32 @@
       .style("fill", d => nodeStrokeColor(d));
   }
 
+  function edgeBaseColor(edge) {
+    if ((edge.type || "EXTRACTED") === "INFERRED") return state.variantTokens.edgeInferred;
+    if ((edge.type || "EXTRACTED") === "AMBIGUOUS") return state.variantTokens.edgeAmbiguous;
+    return state.variantTokens.edgeExtracted;
+  }
+
   function nodeStrokeColor(n) {
     if (state.tweaks.sizeMode === "type" || state.tweaks.bubbleMode === "color") {
-      // prefer community color when bubble off
       return n.commColor;
     }
-    // type-based color by default
     if (n.type === "topic") return state.variantTokens.topic;
     if (n.type === "source") return state.variantTokens.source;
     return n.commColor;
   }
 
   function tick() {
-    // update edges (reuse existing elements)
-    edgeLayer.selectAll("path.edge")
-      .attr("d", d => {
-        const s = d.source, t = d.target;
-        if (s.x == null || t.x == null) return "";
-        return roughEdgePath(s.x, s.y, t.x, t.y, d.id ? d.id.charCodeAt(d.id.length - 1) : 0);
+    edgeLayer.selectAll("g.edge-wrap")
+      .each(function (d) {
+        const s = d.source;
+        const t = d.target;
+        if (s.x == null || t.x == null) return;
+
+        const wrap = d3.select(this);
+        const path = roughEdgePath(s.x, s.y, t.x, t.y, (d.id ? d.id.charCodeAt(d.id.length - 1) : 0) + edgeRoughness(d));
+        wrap.select(".edge").attr("d", path);
+        wrap.select(".edge-halo").attr("d", path);
       });
 
     nodeLayer.selectAll("g.node-group")
@@ -588,7 +692,7 @@
         }
       });
 
-    renderBlobs();
+    if (simulation.alpha() < 0.15) renderBlobs();
     renderMinimap();
   }
 
@@ -919,8 +1023,8 @@
     state.links.forEach(l => {
       const s = l.source.id || l.source;
       const t = l.target.id || l.target;
-      if (s === id) neighbors.push({ other: state.byId[t], direction: "→", type: l.type });
-      else if (t === id) neighbors.push({ other: state.byId[s], direction: "←", type: l.type });
+      if (s === id) neighbors.push({ other: state.byId[t], direction: "→", type: l.type, weight: l.weight });
+      else if (t === id) neighbors.push({ other: state.byId[s], direction: "←", type: l.type, weight: l.weight });
     });
     const nb = document.getElementById("nb-list");
     nb.innerHTML = "";
@@ -929,13 +1033,15 @@
     }
     neighbors.forEach(o => {
       if (!o.other) return;
+      const weight = clampWeight(o.weight);
       const el = document.createElement("div");
       el.className = "nb-item";
       el.innerHTML = `
         <span class="nb-item__arrow">${o.direction}</span>
         <span class="nb-item__type" style="background:${o.other.commColor || '#999'}"></span>
         <span class="nb-item__name">${escapeHtml(o.other.label || o.other.id)}</span>
-        <span class="nb-item__rel" data-rel="${o.type || 'EXTRACTED'}">${o.type || 'EXTRACTED'}</span>
+        <span class="nb-item__strength" style="width:${edgeStrengthSize(o)}px;height:${edgeStrengthSize(o)}px;background:${edgeBaseColor(o)}"></span>
+        <span class="nb-item__rel" data-rel="${o.type || 'EXTRACTED'}">${weight.toFixed(2)}</span>
       `;
       el.addEventListener("click", () => {
         selectNode(o.other.id, true);
@@ -966,6 +1072,99 @@
     t.setAttribute("data-show", "1");
     clearTimeout(toastTimer);
     toastTimer = setTimeout(() => t.setAttribute("data-show", "0"), 1800);
+  }
+
+  function focusNode(nodeId) {
+    const hit = state.byId[nodeId];
+    if (!hit) return;
+    selectNode(hit.id, true);
+    svg.transition().duration(450).call(zoomBehavior.translateTo, hit.x, hit.y);
+  }
+
+  function renderInsights() {
+    if (!insightsBody || !insightsMeta) return;
+
+    const sections = [
+      {
+        title: "惊人连接",
+        items: state.insights.surprising_connections,
+        render(item) {
+          return {
+            title: `${item.from} ↔ ${item.to}`,
+            meta: `跨社区强边 · 权重 ${clampWeight(item.weight).toFixed(2)}`,
+            onClick() { focusNode(item.from); }
+          };
+        }
+      },
+      {
+        title: "知识缺口",
+        items: state.insights.isolated_nodes,
+        render(item) {
+          return {
+            title: item.label || item.id,
+            meta: `孤立节点 · 度数 ${item.degree}`,
+            onClick() { focusNode(item.id); }
+          };
+        }
+      },
+      {
+        title: "桥节点",
+        items: state.insights.bridge_nodes,
+        render(item) {
+          return {
+            title: item.label || item.id,
+            meta: `连接 ${item.community_count} 个社区`,
+            onClick() { focusNode(item.id); }
+          };
+        }
+      },
+      {
+        title: "稀疏社区",
+        items: state.insights.sparse_communities,
+        render(item) {
+          return {
+            title: item.label || item.id,
+            meta: `密度 ${Number(item.density || 0).toFixed(2)} · ${item.node_count} 个节点`,
+            onClick() { focusNode(item.id); }
+          };
+        }
+      }
+    ];
+
+    const totalItems = sections.reduce((sum, section) => sum + section.items.length, 0);
+    const degraded = state.insights.meta && state.insights.meta.degraded === true;
+    insightsMeta.textContent = degraded ? `${totalItems} 项 · 已降级` : `${totalItems} 项`;
+    insightsBody.innerHTML = "";
+
+    sections.forEach(section => {
+      const wrap = document.createElement("section");
+      wrap.className = "insights-panel__section";
+      wrap.innerHTML = `<div class="insights-panel__section-title">${escapeHtml(section.title)}</div>`;
+
+      if (!section.items.length) {
+        const empty = document.createElement("div");
+        empty.className = "insights-panel__empty";
+        empty.textContent = "暂无。";
+        wrap.appendChild(empty);
+        insightsBody.appendChild(wrap);
+        return;
+      }
+
+      section.items.forEach(item => {
+        const view = section.render(item);
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "insight-item";
+        button.innerHTML = `
+          <span class="insight-item__title">${escapeHtml(view.title)}</span>
+          <span class="insight-item__meta">${escapeHtml(view.meta)}</span>
+        `;
+        button.addEventListener("click", view.onClick);
+        wrap.appendChild(button);
+      });
+
+      insightsBody.appendChild(wrap);
+    });
   }
 
   // ---------- Search ----------
@@ -1005,10 +1204,9 @@
     input.addEventListener("input", () => {
       const q = input.value.trim().toLowerCase();
       if (!q) { dd.setAttribute("data-open", "0"); return; }
-      results = state.nodes.filter(n =>
-        (n.label || n.id).toLowerCase().includes(q) ||
-        (n.content || "").toLowerCase().includes(q)
-      );
+      results = state.searchIndex
+        .filter(entry => entry.haystack.includes(q))
+        .map(entry => entry.node);
       activeIdx = 0;
       render();
     });
@@ -1292,6 +1490,7 @@
   setupSearch();
   setupTweaks();
   setupEditMode();
+  renderInsights();
   updateFooter();
 
   // Auto-select a node after stabilization for visual polish (comment out if not wanted)

--- a/templates/graph-styles/wash/header.html
+++ b/templates/graph-styles/wash/header.html
@@ -498,6 +498,99 @@ html, body {
   display: inline-block;
 }
 
+/* insights panel */
+.insights-panel {
+  position: absolute;
+  left: 28px;
+  top: 20px;
+  width: 290px;
+  max-height: min(52vh, 420px);
+  display: flex;
+  flex-direction: column;
+  background: rgba(255, 252, 243, 0.92);
+  backdrop-filter: blur(4px);
+  border: 1.5px solid var(--paper-ink-faint);
+  border-radius: var(--radius);
+  box-shadow: 2px 3px 0 rgba(43, 38, 32, 0.06);
+  z-index: 5;
+  transform: rotate(-0.25deg);
+  overflow: hidden;
+}
+.insights-panel__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px dashed rgba(117, 100, 84, 0.35);
+  background: rgba(244, 236, 219, 0.86);
+}
+.insights-panel__title {
+  font-family: var(--font-hand);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--paper-ink);
+}
+.insights-panel__meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--paper-ink-dim);
+}
+.insights-panel__body {
+  padding: 12px 14px 14px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.insights-panel__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.insights-panel__section-title {
+  font-family: var(--font-hand);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--paper-ink-dim);
+}
+.insights-panel__empty {
+  padding: 8px 2px;
+  color: var(--paper-ink-faint);
+  font-family: var(--font-hand);
+  line-height: 1.5;
+}
+.insight-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px dashed rgba(117, 100, 84, 0.35);
+  border-radius: 6px;
+  background: rgba(255, 248, 234, 0.65);
+  color: var(--paper-ink);
+  cursor: pointer;
+  text-align: left;
+  transition: background 120ms, border-color 120ms, transform 120ms;
+}
+.insight-item:hover {
+  background: var(--paper-warm);
+  border-color: rgba(117, 100, 84, 0.55);
+  transform: translateY(-1px);
+}
+.insight-item__title {
+  font-family: var(--font-text);
+  font-size: 13px;
+  font-weight: 600;
+}
+.insight-item__meta {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--paper-ink-dim);
+  line-height: 1.45;
+}
+
 /* zoom controls */
 .zoom-ctrl {
   position: absolute;
@@ -846,6 +939,14 @@ html, body {
   flex-shrink: 0;
 }
 .nb-item__name { flex: 1; }
+.nb-item__strength {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(90, 110, 92, 0.35);
+  box-shadow: 0 0 0 1px rgba(43, 38, 32, 0.08);
+  flex-shrink: 0;
+}
 .nb-item__rel {
   font-family: var(--font-mono);
   font-size: 10px;
@@ -874,15 +975,20 @@ html, body {
   pointer-events: none;
 }
 
-.edge-group .edge {
+.edge-group .edge,
+.edge-group .edge-halo {
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
   transition: opacity 200ms, stroke-width 200ms;
 }
-.edge[data-type="EXTRACTED"] { stroke: var(--edge-extracted); stroke-width: 1.4; }
-.edge[data-type="INFERRED"]  { stroke: var(--edge-inferred);  stroke-width: 1.3; stroke-dasharray: 5 4; }
-.edge[data-type="AMBIGUOUS"] { stroke: var(--edge-ambiguous); stroke-width: 1.2; stroke-dasharray: 1.5 3.5; }
+.edge-group .edge-halo {
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
+.edge[data-type="EXTRACTED"] { stroke: var(--edge-extracted); }
+.edge[data-type="INFERRED"]  { stroke: var(--edge-inferred); stroke-dasharray: 5 4; }
+.edge[data-type="AMBIGUOUS"] { stroke: var(--edge-ambiguous); stroke-dasharray: 1.5 3.5; }
 .edge--dim { opacity: 0.12; }
 .edge--hi  { stroke-width: 2.4; }
 
@@ -1149,6 +1255,14 @@ body[data-variant="wash"] {
 
   <main class="canvas-wrap">
     <svg id="canvas" tabindex="0" role="img" aria-label="知识图谱"></svg>
+
+    <aside class="insights-panel" id="insights-panel" aria-label="图谱洞察">
+      <div class="insights-panel__head">
+        <div class="insights-panel__title">Insights</div>
+        <div class="insights-panel__meta" id="insights-meta">0 项</div>
+      </div>
+      <div class="insights-panel__body" id="insights-body"></div>
+    </aside>
 
     <div class="legend">
       <div class="legend__title">图例</div>

--- a/templates/source-template.md
+++ b/templates/source-template.md
@@ -2,6 +2,7 @@
 tags: [素材摘要]
 created: {{DATE}}
 updated: {{DATE}}
+sources: []
 source_type: {{TYPE}}
 source_path: {{RAW_PATH}}
 ---

--- a/tests/expected/graph-data-empty.json
+++ b/tests/expected/graph-data-empty.json
@@ -4,8 +4,23 @@
     "wiki_title": "graph-data-empty-wiki",
     "total_nodes": 0,
     "total_edges": 0,
-    "initial_view": []
+    "initial_view": [],
+    "degraded": false,
+    "insights_degraded": false
   },
   "nodes": [],
-  "edges": []
+  "edges": [],
+  "insights": {
+    "surprising_connections": [],
+    "isolated_nodes": [],
+    "bridge_nodes": [],
+    "sparse_communities": [],
+    "meta": {
+      "degraded": false,
+      "node_count": 0,
+      "edge_count": 0,
+      "max_insight_nodes": 250,
+      "max_insight_edges": 1000
+    }
+  }
 }

--- a/tests/expected/graph-data-sample.json
+++ b/tests/expected/graph-data-sample.json
@@ -5,23 +5,24 @@
     "total_nodes": 8,
     "total_edges": 13,
     "initial_view": [
-      "paper",
+      "Attention",
       "Transformer",
       "GPT",
-      "Attention",
       "arch",
       "Decoder",
       "Encoder",
-      "finetune"
+      "finetune",
+      "paper"
     ],
-    "degraded": false
+    "degraded": false,
+    "insights_degraded": false
   },
   "nodes": [
     {
       "id": "Attention",
       "label": "Attention",
       "type": "entity",
-      "community": "arch",
+      "community": "Attention",
       "content": "# Attention\n\n注意力机制是 Transformer 的核心。参见 [[Transformer]]。"
     },
     {
@@ -70,7 +71,7 @@
       "id": "paper",
       "label": "Attention Is All You Need",
       "type": "source",
-      "community": null,
+      "community": "Attention",
       "content": "# Attention Is All You Need\n\n原始论文提出了自注意力机制。\n\n- [[Attention]] <!-- confidence: EXTRACTED -->"
     }
   ],
@@ -79,79 +80,207 @@
       "id": "e1",
       "from": "Attention",
       "to": "Transformer",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.733,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0.2,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e2",
       "from": "Decoder",
       "to": "Transformer",
-      "type": "INFERRED"
+      "type": "INFERRED",
+      "weight": 0.733,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0.2,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e3",
       "from": "Encoder",
       "to": "Transformer",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.733,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0.2,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e4",
       "from": "GPT",
       "to": "Transformer",
-      "type": "AMBIGUOUS"
+      "type": "AMBIGUOUS",
+      "weight": 0.333,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0,
+        "source_overlap": 0,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e5",
       "from": "Transformer",
       "to": "Attention",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.733,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0.2,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e6",
       "from": "Transformer",
       "to": "Decoder",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.733,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0.2,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e7",
       "from": "Transformer",
       "to": "Encoder",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.733,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0.2,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e8",
       "from": "arch",
       "to": "Attention",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.667,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e9",
       "from": "arch",
       "to": "Decoder",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.667,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e10",
       "from": "arch",
       "to": "Encoder",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.667,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e11",
       "from": "arch",
       "to": "Transformer",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.667,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e12",
       "from": "finetune",
       "to": "GPT",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.667,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0,
+        "source_overlap": 1,
+        "type_affinity": 1
+      }
     },
     {
       "id": "e13",
       "from": "paper",
       "to": "Attention",
-      "type": "EXTRACTED"
+      "type": "EXTRACTED",
+      "weight": 0.533,
+      "source_signal_available": true,
+      "signals": {
+        "co_citation": 0,
+        "source_overlap": 1,
+        "type_affinity": 0.6
+      }
     }
-  ]
+  ],
+  "insights": {
+    "surprising_connections": [],
+    "isolated_nodes": [
+      {
+        "id": "finetune",
+        "label": "微调技术",
+        "degree": 1,
+        "community": "finetune"
+      },
+      {
+        "id": "paper",
+        "label": "Attention Is All You Need",
+        "degree": 1,
+        "community": "Attention"
+      }
+    ],
+    "bridge_nodes": [
+      {
+        "id": "Transformer",
+        "label": "Transformer",
+        "community": "arch",
+        "connected_communities": [
+          "Attention",
+          "finetune"
+        ],
+        "community_count": 2
+      }
+    ],
+    "sparse_communities": [],
+    "meta": {
+      "degraded": false,
+      "node_count": 8,
+      "edge_count": 13,
+      "max_insight_nodes": 250,
+      "max_insight_edges": 1000
+    }
+  }
 }

--- a/tests/fixtures/graph-data-sample-wiki/wiki/entities/Attention.md
+++ b/tests/fixtures/graph-data-sample-wiki/wiki/entities/Attention.md
@@ -1,3 +1,7 @@
+---
+sources: ["attention-is-all-you-need.pdf"]
+---
+
 # Attention
 
 注意力机制是 Transformer 的核心。参见 [[Transformer]]。

--- a/tests/fixtures/graph-data-sample-wiki/wiki/entities/Decoder.md
+++ b/tests/fixtures/graph-data-sample-wiki/wiki/entities/Decoder.md
@@ -1,3 +1,7 @@
+---
+sources: ["attention-is-all-you-need.pdf"]
+---
+
 # Decoder
 
 解码器组件。与 [[Transformer]] <!-- confidence: INFERRED --> 的解码端对应。

--- a/tests/fixtures/graph-data-sample-wiki/wiki/entities/Encoder.md
+++ b/tests/fixtures/graph-data-sample-wiki/wiki/entities/Encoder.md
@@ -1,3 +1,7 @@
+---
+sources: ["attention-is-all-you-need.pdf"]
+---
+
 # Encoder
 
 编码器组件。属于 [[Transformer]] 架构的一部分。

--- a/tests/fixtures/graph-data-sample-wiki/wiki/entities/GPT.md
+++ b/tests/fixtures/graph-data-sample-wiki/wiki/entities/GPT.md
@@ -1,3 +1,7 @@
+---
+sources: ["gpt-series-overview.pdf"]
+---
+
 # GPT
 
 GPT 系列基于 [[Transformer]] <!-- confidence: AMBIGUOUS --> 的解码器架构。

--- a/tests/fixtures/graph-data-sample-wiki/wiki/entities/Transformer.md
+++ b/tests/fixtures/graph-data-sample-wiki/wiki/entities/Transformer.md
@@ -1,3 +1,7 @@
+---
+sources: ["attention-is-all-you-need.pdf"]
+---
+
 # Transformer
 
 Transformer 是一种基于自注意力机制的序列到序列模型架构。

--- a/tests/fixtures/graph-data-sample-wiki/wiki/sources/paper.md
+++ b/tests/fixtures/graph-data-sample-wiki/wiki/sources/paper.md
@@ -1,3 +1,7 @@
+---
+sources: ["attention-is-all-you-need.pdf"]
+---
+
 # Attention Is All You Need
 
 原始论文提出了自注意力机制。

--- a/tests/fixtures/graph-data-sample-wiki/wiki/topics/arch.md
+++ b/tests/fixtures/graph-data-sample-wiki/wiki/topics/arch.md
@@ -1,3 +1,7 @@
+---
+sources: ["attention-is-all-you-need.pdf"]
+---
+
 # 深度学习架构
 
 本主题涵盖深度学习的核心架构组件。

--- a/tests/fixtures/graph-data-sample-wiki/wiki/topics/finetune.md
+++ b/tests/fixtures/graph-data-sample-wiki/wiki/topics/finetune.md
@@ -1,3 +1,7 @@
+---
+sources: ["gpt-series-overview.pdf"]
+---
+
 # 微调技术
 
 本主题涵盖模型微调相关技术。

--- a/tests/graph-analysis-helper.regression-1.sh
+++ b/tests/graph-analysis-helper.regression-1.sh
@@ -79,6 +79,58 @@ EOF
     rm -rf "$tmp_dir"
 }
 
+test_single_node_graph_louvain_returns_safely() {
+    local output
+    output="$(node - <<'NODE' "$HELPER"
+const helper = require(process.argv[2]);
+const result = helper.runLouvain(["Solo"], new Map());
+console.log(JSON.stringify(Object.fromEntries(result)));
+NODE
+)"
+    [ "$output" = '{"Solo":"Solo"}' ] || fail "Expected single-node Louvain to return solo assignment, got: $output"
+}
+
+test_parse_sources_yaml_multiline() {
+    local output
+    output="$(node - <<'NODE' "$HELPER"
+const helper = require(process.argv[2]);
+const fm = [
+  "title: Test",
+  "sources:",
+  "  - paper_a.pdf",
+  "  - paper_b.pdf",
+  "  - \"quoted.pdf\""
+].join("\n");
+const result = helper.parseSourcesFrontmatter(fm);
+console.log(JSON.stringify(result));
+NODE
+)"
+    local has_field parsed signal sources
+    has_field="$(printf '%s' "$output" | jq -r '.hasField')"
+    parsed="$(printf '%s' "$output" | jq -r '.parsed')"
+    signal="$(printf '%s' "$output" | jq -r '.signalAvailable')"
+    sources="$(printf '%s' "$output" | jq -r '.sources | join(",")')"
+    [ "$has_field" = "true" ] || fail "Expected hasField=true for YAML multiline, got: $has_field"
+    [ "$parsed" = "true" ] || fail "Expected parsed=true for YAML multiline, got: $parsed"
+    [ "$signal" = "true" ] || fail "Expected signalAvailable=true, got: $signal"
+    [ "$sources" = "paper_a.pdf,paper_b.pdf,quoted.pdf" ] || fail "Unexpected sources: $sources"
+}
+
+test_node_helper_bad_json_exits_with_error() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+
+    printf 'not json' > "$tmp_dir/bad.json"
+    printf '[]' > "$tmp_dir/edges.json"
+
+    if output="$(node "$HELPER" "$tmp_dir/bad.json" "$tmp_dir/edges.json" "$tmp_dir/out.json" 0 500 250 1000 2>&1)"; then
+        fail "graph-analysis.js should fail on invalid JSON input"
+    fi
+
+    assert_text_contains "$output" "Invalid JSON"
+    rm -rf "$tmp_dir"
+}
+
 test_helper_reports_sparse_and_bridge_insights() {
     local output
 
@@ -144,6 +196,9 @@ NODE
 
 main() {
     test_helper_computes_weights_and_source_omission
+    test_single_node_graph_louvain_returns_safely
+    test_parse_sources_yaml_multiline
+    test_node_helper_bad_json_exits_with_error
     test_helper_reports_sparse_and_bridge_insights
     echo "PASS: graph analysis helper regression coverage"
 }

--- a/tests/graph-analysis-helper.regression-1.sh
+++ b/tests/graph-analysis-helper.regression-1.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Regression: graph analysis helper should compute weights, source omission, and insights deterministically
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/scripts/graph-analysis.js"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+assert_text_contains() {
+    local text="$1"
+    local expected="$2"
+
+    if ! printf '%s' "$text" | grep -F -- "$expected" > /dev/null; then
+        fail "Expected output to contain: $expected"
+    fi
+}
+
+test_helper_computes_weights_and_source_omission() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+
+    mkdir -p "$tmp_dir/wiki/entities"
+
+    cat > "$tmp_dir/wiki/entities/A.md" <<'EOF'
+---
+sources: ["same.pdf"]
+---
+
+# A
+
+[[B]]
+EOF
+
+    cat > "$tmp_dir/wiki/entities/B.md" <<'EOF'
+---
+sources: ["same.pdf"]
+---
+
+# B
+
+[[A]]
+EOF
+
+    cat > "$tmp_dir/wiki/entities/C.md" <<'EOF'
+# C
+
+[[A]]
+EOF
+
+    cat > "$tmp_dir/nodes.json" <<EOF
+[
+  {"id":"A","label":"A","type":"entity","source_path":"$tmp_dir/wiki/entities/A.md"},
+  {"id":"B","label":"B","type":"entity","source_path":"$tmp_dir/wiki/entities/B.md"},
+  {"id":"C","label":"C","type":"entity","source_path":"$tmp_dir/wiki/entities/C.md"}
+]
+EOF
+
+    cat > "$tmp_dir/edges.json" <<'EOF'
+[
+  {"id":"e1","from":"A","to":"B","type":"EXTRACTED"},
+  {"id":"e2","from":"B","to":"A","type":"EXTRACTED"},
+  {"id":"e3","from":"C","to":"A","type":"EXTRACTED"}
+]
+EOF
+
+    node "$HELPER" "$tmp_dir/nodes.json" "$tmp_dir/edges.json" "$tmp_dir/out.json" 0 500 250 1000 > /dev/null
+
+    output="$(jq -r '.edges[] | select(.from == "A" and .to == "B") | [.weight, .source_signal_available, .signals.source_overlap, .signals.type_affinity] | @tsv' "$tmp_dir/out.json")"
+    [ "$output" = $'0.667	true	1	1' ] || fail "Unexpected A-B edge metrics: $output"
+
+    output="$(jq -r '.edges[] | select(.from == "C" and .to == "A") | [.weight, .source_signal_available, (.signals.source_overlap // "null"), .signals.type_affinity] | @tsv' "$tmp_dir/out.json")"
+    [ "$output" = $'0.5	false	null	1' ] || fail "Expected missing sources to be omitted from denominator, got: $output"
+
+    rm -rf "$tmp_dir"
+}
+
+test_helper_reports_sparse_and_bridge_insights() {
+    local output
+
+    output="$(node - <<'NODE' "$HELPER"
+const helper = require(process.argv[2]);
+const nodesById = {
+  's-topic': { id: 's-topic', label: 'Sparse Topic' },
+  's1': { id: 's1', label: 'S1' },
+  's2': { id: 's2', label: 'S2' },
+  's3': { id: 's3', label: 'S3' },
+  's4': { id: 's4', label: 'S4' },
+  's5': { id: 's5', label: 'S5' },
+  'bridge': { id: 'bridge', label: 'Bridge' },
+  't2': { id: 't2', label: 'T2' },
+  'b1': { id: 'b1', label: 'B1' },
+  't3': { id: 't3', label: 'T3' },
+  'c1': { id: 'c1', label: 'C1' }
+};
+const edges = [
+  { from: 's-topic', to: 's1', type: 'EXTRACTED' },
+  { from: 's-topic', to: 's2', type: 'EXTRACTED' },
+  { from: 'bridge', to: 's-topic', type: 'EXTRACTED' },
+  { from: 'bridge', to: 't2', type: 'EXTRACTED' },
+  { from: 'bridge', to: 't3', type: 'EXTRACTED' },
+  { from: 't2', to: 'b1', type: 'EXTRACTED' },
+  { from: 't3', to: 'c1', type: 'EXTRACTED' }
+];
+const pairMetrics = new Map([
+  ['bridge\ts-topic', { weight: 0.8 }],
+  ['bridge\tt2', { weight: 0.8 }],
+  ['bridge\tt3', { weight: 0.8 }]
+]);
+const communityAssignments = new Map([
+  ['s-topic', 's-topic'],
+  ['s1', 's-topic'],
+  ['s2', 's-topic'],
+  ['s3', 's-topic'],
+  ['s4', 's-topic'],
+  ['s5', 's-topic'],
+  ['bridge', 'bridge'],
+  ['t2', 't2'],
+  ['b1', 't2'],
+  ['t3', 't3'],
+  ['c1', 't3']
+]);
+const insights = helper.buildInsights(nodesById, edges, pairMetrics, communityAssignments, {
+  nodeCount: Object.keys(nodesById).length,
+  edgeCount: edges.length,
+  maxInsightNodes: 250,
+  maxInsightEdges: 1000
+});
+console.log(JSON.stringify(insights));
+NODE
+)"
+
+    local bridge sparse
+    bridge="$(printf '%s' "$output" | jq -r '.bridge_nodes[]?.id')"
+    assert_text_contains "$bridge" "bridge"
+
+    sparse="$(printf '%s' "$output" | jq -r '.sparse_communities[]?.id')"
+    assert_text_contains "$sparse" "s-topic"
+}
+
+main() {
+    test_helper_computes_weights_and_source_omission
+    test_helper_reports_sparse_and_bridge_insights
+    echo "PASS: graph analysis helper regression coverage"
+}
+
+main "$@"

--- a/tests/graph-build-failures.regression-1.sh
+++ b/tests/graph-build-failures.regression-1.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Regression: graph build should fail clearly when node/helper path is broken
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GRAPH_DATA_SAMPLE="$REPO_ROOT/tests/fixtures/graph-data-sample-wiki"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+assert_text_contains() {
+    local text="$1"
+    local expected="$2"
+
+    if ! printf '%s' "$text" | grep -F -- "$expected" > /dev/null; then
+        fail "Expected output to contain: $expected"
+    fi
+}
+
+test_graph_data_exits_without_node() {
+    local tmp_dir fake_bin output
+    tmp_dir="$(mktemp -d)"
+    fake_bin="$tmp_dir/bin"
+    mkdir -p "$fake_bin"
+
+    ln -s /bin/bash "$fake_bin/bash"
+    ln -s "$(command -v jq)" "$fake_bin/jq"
+
+    if output="$(PATH="$fake_bin" bash "$REPO_ROOT/scripts/build-graph-data.sh" "$GRAPH_DATA_SAMPLE" 2>&1)"; then
+        fail "build-graph-data.sh should fail when node is unavailable"
+    fi
+
+    assert_text_contains "$output" "node"
+    assert_text_contains "$output" "图谱 2.0 构建需要 node"
+
+    rm -rf "$tmp_dir"
+}
+
+test_graph_data_exits_when_helper_missing() {
+    local tmp_dir repo_copy output
+    tmp_dir="$(mktemp -d)"
+    repo_copy="$tmp_dir/repo"
+
+    cp -R "$REPO_ROOT" "$repo_copy"
+    rm -rf "$repo_copy/.git"
+    rm "$repo_copy/scripts/graph-analysis.js"
+
+    if output="$(LLM_WIKI_TEST_MODE=1 bash "$repo_copy/scripts/build-graph-data.sh" "$repo_copy/tests/fixtures/graph-data-sample-wiki" 2>&1)"; then
+        fail "build-graph-data.sh should fail when helper is missing"
+    fi
+
+    assert_text_contains "$output" "graph-analysis.js"
+    assert_text_contains "$output" "图谱分析 helper"
+
+    rm -rf "$tmp_dir"
+}
+
+main() {
+    test_graph_data_exits_without_node
+    test_graph_data_exits_when_helper_missing
+    echo "PASS: graph build failure regression coverage"
+}
+
+main "$@"

--- a/tests/graph-html-insights.regression-1.sh
+++ b/tests/graph-html-insights.regression-1.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Regression: wash graph HTML should expose insights panel wiring and weighted neighbor cues
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GRAPH_HTML_BASIC="tests/fixtures/graph-interactive-basic"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+assert_file_contains() {
+    local file="$1"
+    local text="$2"
+
+    if ! grep -F -- "$text" "$file" > /dev/null; then
+        fail "Expected $file to contain: $text"
+    fi
+}
+
+build_graph_html_fixture() {
+    local tmp_dir="$1"
+    local output_dir="$tmp_dir/wiki"
+
+    mkdir -p "$output_dir"
+    cp "$REPO_ROOT/$GRAPH_HTML_BASIC/wiki/graph-data.json" "$output_dir/graph-data.json"
+
+    bash "$REPO_ROOT/scripts/build-graph-html.sh" "$tmp_dir" > /dev/null 2>&1 \
+        || fail "build-graph-html.sh should succeed on basic fixture"
+}
+
+test_graph_html_has_insights_panel_shell() {
+    local tmp_dir html js
+    tmp_dir="$(mktemp -d)"
+    build_graph_html_fixture "$tmp_dir"
+    html="$tmp_dir/wiki/knowledge-graph.html"
+    js="$tmp_dir/wiki/graph-wash.js"
+
+    assert_file_contains "$html" 'id="insights-panel"'
+    assert_file_contains "$html" 'id="insights-body"'
+    assert_file_contains "$js" 'renderInsights()'
+    assert_file_contains "$js" 'focusNode(nodeId)'
+    assert_file_contains "$js" 'insight-item'
+
+    rm -rf "$tmp_dir"
+}
+
+test_graph_html_has_weighted_edge_and_neighbor_hooks() {
+    local tmp_dir js
+    tmp_dir="$(mktemp -d)"
+    build_graph_html_fixture "$tmp_dir"
+    js="$tmp_dir/wiki/graph-wash.js"
+
+    assert_file_contains "$js" 'edgeStrokeWidth(edge)'
+    assert_file_contains "$js" 'edgeOpacity(edge)'
+    assert_file_contains "$js" 'nb-item__strength'
+    assert_file_contains "$js" 'clampWeight(o.weight)'
+
+    rm -rf "$tmp_dir"
+}
+
+main() {
+    test_graph_html_has_insights_panel_shell
+    test_graph_html_has_weighted_edge_and_neighbor_hooks
+    echo "PASS: graph HTML insights regression coverage"
+}
+
+main "$@"

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -1324,7 +1324,7 @@ test_graph_data_has_three_confidence_types() {
 }
 
 test_graph_data_community_clustering() {
-    local tmp_dir communities
+    local tmp_dir arch_nodes finetune_nodes paper_comm attention_comm
     tmp_dir="$(mktemp -d)"
     trap 'rm -rf "$tmp_dir"' RETURN
 
@@ -1333,23 +1333,22 @@ test_graph_data_community_clustering() {
         "$REPO_ROOT/$GRAPH_DATA_SAMPLE" \
         "$tmp_dir/graph-data.json" > /dev/null 2>&1
 
-    # Transformer/Attention/Encoder/Decoder 属于 arch 社区
-    local arch_nodes
     arch_nodes=$(jq -r '.nodes[] | select(.community == "arch") | .id' "$tmp_dir/graph-data.json" | sort | tr '\n' ' ')
-    assert_text_contains "$arch_nodes" "Attention"
     assert_text_contains "$arch_nodes" "Decoder"
     assert_text_contains "$arch_nodes" "Encoder"
     assert_text_contains "$arch_nodes" "Transformer"
+    assert_text_contains "$arch_nodes" "arch"
 
-    # GPT 属于 finetune 社区
-    local finetune_nodes
-    finetune_nodes=$(jq -r '.nodes[] | select(.community == "finetune") | .id' "$tmp_dir/graph-data.json")
+    finetune_nodes=$(jq -r '.nodes[] | select(.community == "finetune") | .id' "$tmp_dir/graph-data.json" | sort | tr '\n' ' ')
     assert_text_contains "$finetune_nodes" "GPT"
+    assert_text_contains "$finetune_nodes" "finetune"
 
-    # paper 没有社区（null）
-    local paper_comm
+    attention_comm=$(jq -r '.nodes[] | select(.community == "Attention") | .id' "$tmp_dir/graph-data.json" | sort | tr '\n' ' ')
+    assert_text_contains "$attention_comm" "Attention"
+    assert_text_contains "$attention_comm" "paper"
+
     paper_comm=$(jq -r '.nodes[] | select(.id == "paper") | .community' "$tmp_dir/graph-data.json")
-    [ "$paper_comm" = "null" ] || fail "Expected paper community to be null, got: $paper_comm"
+    [ "$paper_comm" = "Attention" ] || fail "Expected paper community to be Attention, got: $paper_comm"
 }
 
 test_graph_data_empty_wiki_has_zero_nodes_and_edges() {
@@ -1519,11 +1518,14 @@ test_graph_html_basic_assembly
 test_graph_html_escapes_script_tag_in_content
 test_graph_html_missing_data_exits_with_error
 test_graph_html_missing_template_exits_with_error
+bash "$REPO_ROOT/tests/graph-analysis-helper.regression-1.sh" || fail "graph-analysis-helper.regression-1.sh 测试失败"
+bash "$REPO_ROOT/tests/graph-build-failures.regression-1.sh" || fail "graph-build-failures.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-brand-link.regression-1.sh" || fail "graph-html-brand-link.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-long-label.regression-1.sh" || fail "graph-html-long-label.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-minimap.regression-1.sh" || fail "graph-html-minimap.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-toolbar.regression-1.sh" || fail "graph-html-toolbar.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-drawer-neighbors.regression-1.sh" || fail "graph-html-drawer-neighbors.regression-1.sh 测试失败"
+bash "$REPO_ROOT/tests/graph-html-insights.regression-1.sh" || fail "graph-html-insights.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-a11y.regression-1.sh" || fail "graph-html-a11y.regression-1.sh 测试失败"
 test_graph_data_dead_links_are_ignored
 test_graph_data_self_links_are_ignored


### PR DESCRIPTION
## Summary

- Add 4-signal relevance model for edge weights (direct link, source overlap, Adamic-Adar, type affinity)
- Add Louvain community detection with cohesion scoring (replaces topic-page-based grouping)
- Add insights module: bridge nodes (cross-community connectors) and sparse nodes (low-degree isolates)
- Add Insights panel in graph HTML with clickable insight items
- Add `sources: []` frontmatter field to source template (foundation for source overlap signal)
- Frontend performance: search index memory truncation, simulation tick throttle

## Changes

### Core (`scripts/graph-analysis.js`, 720 lines new)
- Node.js helper for weighted graph computation
- 4-signal edge weight calculation with source omission handling
- Louvain community detection (iterative modularity optimization)
- Bridge node detection (connects 2+ OTHER communities)
- Sparse community detection (cohesion < 0.15 with 3+ nodes)
- YAML multiline `sources:` frontmatter parser
- Clean CLI error handling (ENOENT, SyntaxError, generic)

### Build pipeline (`scripts/build-graph-data.sh`)
- Integrates `graph-analysis.js` into graph data generation
- Outputs `edges[].weight`, `edges[].signals`, `insights` to graph-data.json

### Frontend (`templates/graph-styles/wash/`)
- Insights panel: bridge nodes, sparse nodes, knowledge gaps
- Clickable insight items highlight relevant nodes
- Node drawer shows neighbor list with edge weights
- Search index truncation (content capped at 500 chars)
- Simulation tick blob render throttle (alpha < 0.15)

### Tests
- `tests/graph-analysis-helper.regression-1.sh`: edge weight computation, single-node Louvain, YAML parsing, bad JSON input
- `tests/graph-build-failures.regression-1.sh`: build script error handling
- `tests/graph-html-insights.regression-1.sh`: insights panel rendering
- Updated expected outputs and test fixtures with `sources` frontmatter

## Test plan

- [x] `bash tests/regression.sh` — all checks pass
- [x] `bash install.sh --dry-run --platform codex` — no errors
- [x] Privacy path leak check — clean
- [x] Browser QA on generated knowledge-graph.html — 0 issues, health score 100/100
- [ ] Merge and verify on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)