### PR TITLE
Add Hermes platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ deps/baoyu-url-to-markdown/scripts/bun.lock
 .context/
 .gstack/
 .playwright-cli/
+.omx/
+.codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v3.1.0 (2026-04-21)
+
+### 新增
+
+- 新增根 `HERMES.md` 与 `platforms/hermes/README.md`，让 Hermes 进入仓库时能走自己的安装入口，不再误吃 Codex 专属提示
+- `install.sh` 与 `scripts/runtime-context.sh` 新增 `hermes` 平台支持，默认技能目录为 `~/.hermes/skills/llm-wiki`
+- `README.md`、`README.en.md`、`SKILL.md` 补齐 Hermes 平台说明与 metadata，保持共享核心不分叉
+
+### 测试
+
+- `tests/regression.sh` 新增 Hermes 安装与入口文档断言，继续兜住四平台安装矩阵
+- README 结构断言扩展到 Hermes 安装、升级与根 `HERMES.md` 提示
+
 ## v3.0.2 (2026-04-21)
 
 ### 修复

--- a/HERMES.md
+++ b/HERMES.md
@@ -1,34 +1,34 @@
-# AGENTS.md
+# HERMES.md
 
-这是 llm-wiki 在 Codex 下的入口文件。
+这是 llm-wiki 在 Hermes 下的入口文件。
 
 先看这三个文件：
 
 - [README.md](README.md)：多平台总说明
-- [platforms/codex/AGENTS.md](platforms/codex/AGENTS.md)：Codex 专属入口提示
+- [platforms/hermes/README.md](platforms/hermes/README.md)：Hermes 专属入口提示
 - [SKILL.md](SKILL.md)：核心能力和工作流
 
-## Codex 安装动作
+## Hermes 安装动作
 
 如果当前任务是安装这个 skill，执行：
 
 ```bash
-bash install.sh --platform codex
+bash install.sh --platform hermes
 ```
 
-默认安装到 `~/.codex/skills/llm-wiki`。如果用户机器上还是旧的 `~/.Codex/skills`，安装器也会自动兼容。
+默认安装到 `~/.hermes/skills/llm-wiki`。
 
 默认只准备知识库核心主线。如果这次要自动提取网页 / X / 微信公众号 / YouTube / 知乎，再执行：
 
 ```bash
-bash install.sh --platform codex --with-optional-adapters
+bash install.sh --platform hermes --with-optional-adapters
 ```
 
 ## 重要提醒
 
-- 不要把这个仓库当成 Codex 专属仓库；Claude Code、OpenClaw、Hermes 也共用同一套核心内容
+- 不要把这个仓库当成 Hermes 专属仓库；Claude Code、Codex、OpenClaw 也共用同一套核心内容
+- Hermes 会优先读取仓库根的 `HERMES.md`；这里负责安装入口，知识库能力本身仍以 [SKILL.md](SKILL.md) 为准
 - 安装完成后，再按 [SKILL.md](SKILL.md) 的工作流继续做事
-- 如果 OpenClaw 使用的是自定义技能目录，可以改用 `--target-dir <你的技能目录>/llm-wiki`
 
 ## 使用顺序
 

--- a/README.en.md
+++ b/README.en.md
@@ -10,9 +10,9 @@ Based on [Andrej Karpathy](https://karpathy.ai/)'s [llm-wiki methodology](https:
 
 Turn scattered information into a growing, interconnected knowledge base
 
-[![version](https://img.shields.io/badge/v3.0.0-card%20graph-E8D5B5?style=flat-square&labelColor=3a3026&color=E8D5B5)](https://github.com/sdyckjq-lab/llm-wiki-skill/releases)
+[![version](https://img.shields.io/badge/v3.1.0-Hermes%20support-E8D5B5?style=flat-square&labelColor=3a3026&color=E8D5B5)](https://github.com/sdyckjq-lab/llm-wiki-skill/releases)
 [![license](https://img.shields.io/badge/MIT-license-5a6e5c?style=flat-square&labelColor=3a3026)](LICENSE)
-[![platforms](https://img.shields.io/badge/Claude·Codex·OpenClaw-multi--platform-7a96a6?style=flat-square&labelColor=3a3026)]
+[![platforms](https://img.shields.io/badge/Claude·Codex·OpenClaw·Hermes-multi--platform-7a96a6?style=flat-square&labelColor=3a3026)]
 
 </div>
 
@@ -41,6 +41,9 @@ bash install.sh --platform codex
 
 # OpenClaw
 bash install.sh --platform openclaw
+
+# Hermes
+bash install.sh --platform hermes
 ```
 
 Then just say:
@@ -90,6 +93,7 @@ Each platform has its own setup guide:
 - [Claude Code](platforms/claude/CLAUDE.md)
 - [Codex](platforms/codex/AGENTS.md)
 - [OpenClaw](platforms/openclaw/README.md)
+- [Hermes](platforms/hermes/README.md)
 
 ---
 
@@ -122,6 +126,7 @@ Each platform has its own setup guide:
 | Claude Code | `~/.claude/skills/llm-wiki` |
 | Codex | `~/.codex/skills/llm-wiki` |
 | OpenClaw | `~/.openclaw/skills/llm-wiki` |
+| Hermes | `~/.hermes/skills/llm-wiki` |
 
 ### Updating
 
@@ -139,6 +144,10 @@ Custom directories:
 
 ```bash
 bash install.sh --upgrade --platform openclaw --target-dir <your-skill-dir>/llm-wiki
+```
+
+```bash
+bash install.sh --upgrade --platform hermes --target-dir <your-skill-dir>/llm-wiki
 ```
 
 ### Prerequisites
@@ -183,7 +192,10 @@ your-knowledge-base/
 <summary><strong>FAQ</strong></summary>
 
 **Is this Claude-only?**
-No. Claude is one of multiple entry points. The same repo can be installed by Claude Code, Codex, or OpenClaw.
+No. Claude is one of multiple entry points. The same repo can be installed by Claude Code, Codex, OpenClaw, or Hermes.
+
+**Why does Hermes care about `HERMES.md`?**
+Hermes loads the repo root `HERMES.md` as its highest-priority project context. That file only defines the Hermes entry and install path; the shared workflow still lives in `SKILL.md`.
 
 **Can I update from within Claude Code?**
 Yes. `/llm-wiki-upgrade` updates the core. Add `--with-optional-adapters` to also refresh web/X/WeChat/YouTube/Zhihu extraction.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 把碎片化的信息变成持续积累、互相链接的知识库
 
-[![version](https://img.shields.io/badge/v3.0.2-卡片式图谱-E8D5B5?style=flat-square&labelColor=3a3026&color=E8D5B5)](https://github.com/sdyckjq-lab/llm-wiki-skill/releases)
+[![version](https://img.shields.io/badge/v3.1.0-Hermes%20支持-E8D5B5?style=flat-square&labelColor=3a3026&color=E8D5B5)](https://github.com/sdyckjq-lab/llm-wiki-skill/releases)
 [![license](https://img.shields.io/badge/MIT-license-5a6e5c?style=flat-square&labelColor=3a3026)](LICENSE)
-[![platforms](https://img.shields.io/badge/Claude·Codex·OpenClaw-多平台-7a96a6?style=flat-square&labelColor=3a3026)]
+[![platforms](https://img.shields.io/badge/Claude·Codex·OpenClaw·Hermes-多平台-7a96a6?style=flat-square&labelColor=3a3026)]
 
 </div>
 
@@ -41,6 +41,9 @@ bash install.sh --platform codex
 
 # OpenClaw
 bash install.sh --platform openclaw
+
+# Hermes
+bash install.sh --platform hermes
 ```
 
 然后说：
@@ -91,6 +94,7 @@ bash install.sh --platform claude --with-optional-adapters
 - [Claude Code](platforms/claude/CLAUDE.md)
 - [Codex](platforms/codex/AGENTS.md)
 - [OpenClaw](platforms/openclaw/README.md)
+- [Hermes](platforms/hermes/README.md)
 
 ---
 
@@ -123,6 +127,7 @@ bash install.sh --platform claude --with-optional-adapters
 | Claude Code | `~/.claude/skills/llm-wiki` |
 | Codex | `~/.codex/skills/llm-wiki` |
 | OpenClaw | `~/.openclaw/skills/llm-wiki` |
+| Hermes | `~/.hermes/skills/llm-wiki` |
 
 ### 更新
 
@@ -140,6 +145,10 @@ Claude Code 默认安装的，可以直接用 `/llm-wiki-upgrade`。
 
 ```bash
 bash install.sh --upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki
+```
+
+```bash
+bash install.sh --upgrade --platform hermes --target-dir <你的技能目录>/llm-wiki
 ```
 
 ### 前置条件
@@ -184,7 +193,10 @@ bash install.sh --upgrade --platform openclaw --target-dir <你的技能目录>/
 <summary><strong>常见问题</strong></summary>
 
 **这个仓库还是只给 Claude 用吗？**
-不是。Claude 只是其中一个入口。同一个链接能被 Claude Code、Codex、OpenClaw 安装和使用。
+不是。Claude 只是其中一个入口。同一个链接能被 Claude Code、Codex、OpenClaw、Hermes 安装和使用。
+
+**为什么 Hermes 要看 `HERMES.md`？**
+Hermes 会优先加载仓库根的 `HERMES.md` 作为项目上下文。这个文件只负责 Hermes 的入口与安装说明，核心能力和工作流仍以 `SKILL.md` 为准。
 
 **Claude Code 里可以直接用命令更新吗？**
 可以。默认安装后自带 `/llm-wiki-upgrade`，更新核心主线。需要网页/X/公众号/YouTube/知乎提取能力时，再加 `--with-optional-adapters`。

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,8 @@
 ---
 name: llm-wiki
+version: 3.1.0
+author: sdyckjq-lab
+license: MIT
 description: |
   个人知识库构建系统（基于 Karpathy llm-wiki 方法论）。让 AI 持续构建和维护你的知识库，
   支持多种素材源（网页、推特、公众号、小红书、知乎、YouTube、PDF、本地文件），
@@ -7,6 +10,13 @@ description: |
   触发条件：用户明确提到"知识库"、"wiki"、"llm-wiki"，或要求对已初始化的知识库执行
   消化、查询、健康检查等操作。不要在用户只是要求"总结这篇文章"时触发——必须是明确的
   知识库相关意图。
+metadata:
+  hermes:
+    tags:
+      - knowledge-base
+      - wiki
+      - research
+      - note-taking
 ---
 
 # llm-wiki — 个人知识库构建系统

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ MANAGED_ITEMS=(
   "README.md"
   "CLAUDE.md"
   "AGENTS.md"
+  "HERMES.md"
   "CHANGELOG.md"
   "install.sh"
   "setup.sh"
@@ -56,11 +57,11 @@ err()   { printf '\033[31m[错误]\033[0m %s\n' "$1" >&2; }
 usage() {
   cat <<'EOF'
 用法：
-  bash install.sh --platform <claude|codex|openclaw|auto> [--dry-run]
+  bash install.sh --platform <claude|codex|openclaw|hermes|auto> [--dry-run]
   bash install.sh --platform claude --install-hooks
   bash install.sh --install-hooks
   bash install.sh --uninstall-hooks
-  bash install.sh --upgrade [--platform <claude|codex|openclaw|auto>]
+  bash install.sh --upgrade [--platform <claude|codex|openclaw|hermes|auto>]
   bash install.sh --platform codex --with-optional-adapters
 
 选项：
@@ -232,6 +233,10 @@ detect_available_platforms() {
 
   if [ -d "$HOME/.openclaw" ] || [ -d "$HOME/.openclaw/skills" ]; then
     found+=("openclaw")
+  fi
+
+  if [ -d "$HOME/.hermes" ] || [ -d "$HOME/.hermes/skills" ]; then
+    found+=("hermes")
   fi
 
   printf '%s\n' "${found[@]}"
@@ -534,7 +539,7 @@ if [ "$UPGRADE" -eq 1 ]; then
 
   if [ "$PLATFORM" = "auto" ]; then
     detected_platforms=()
-    for p in claude codex openclaw; do
+    for p in claude codex openclaw hermes; do
       skill_root_candidate="$(resolve_platform_skill_root "$p")"
       [ -d "$skill_root_candidate/$SKILL_NAME" ] && detected_platforms+=("$p")
     done
@@ -635,7 +640,7 @@ if [ "$PLATFORM" = "auto" ]; then
   if [ "${#detected_platforms[@]}" -eq 1 ]; then
     PLATFORM="${detected_platforms[0]}"
   elif [ "${#detected_platforms[@]}" -eq 0 ]; then
-    err "没有检测到受支持的平台目录。请显式传入 --platform claude|codex|openclaw"
+    err "没有检测到受支持的平台目录。请显式传入 --platform claude|codex|openclaw|hermes"
     exit 1
   else
     err "检测到多个可用平台：${detected_platforms[*]}。请显式传入 --platform"

--- a/platforms/hermes/README.md
+++ b/platforms/hermes/README.md
@@ -1,0 +1,31 @@
+# Hermes 入口
+
+这是 Hermes 的薄入口文件。共享说明看 [../../README.md](../../README.md)，核心能力看 [../../SKILL.md](../../SKILL.md)。
+
+## Hermes 应该怎么装
+
+执行：
+
+```bash
+bash install.sh --platform hermes
+```
+
+如果你还需要网页 / X / 微信公众号 / YouTube / 知乎自动提取，再执行：
+
+```bash
+bash install.sh --platform hermes --with-optional-adapters
+```
+
+默认安装位置：`~/.hermes/skills/llm-wiki`
+
+如果你的 Hermes 配了其他 skill 目录，改用：
+
+```bash
+bash install.sh --platform hermes --target-dir <你的技能目录>/llm-wiki
+```
+
+之后升级同一个自定义目录时，也传同样的目标目录：
+
+```bash
+bash install.sh --upgrade --platform hermes --target-dir <你的技能目录>/llm-wiki
+```

--- a/scripts/runtime-context.sh
+++ b/scripts/runtime-context.sh
@@ -16,6 +16,9 @@ resolve_platform_skill_root() {
     openclaw)
       printf '%s\n' "$HOME/.openclaw/skills"
       ;;
+    hermes)
+      printf '%s\n' "$HOME/.hermes/skills"
+      ;;
     *)
       echo "不支持的平台：$1" >&2
       return 1

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -214,7 +214,7 @@ test_install_auto_refuses_ambiguous_platforms() {
     tmp_dir="$(mktemp -d)"
     trap 'rm -rf "$tmp_dir"' RETURN
 
-    mkdir -p "$tmp_dir/home/.claude/skills" "$tmp_dir/home/.codex/skills"
+    mkdir -p "$tmp_dir/home/.claude/skills" "$tmp_dir/home/.codex/skills" "$tmp_dir/home/.hermes/skills"
 
     if output="$(
         HOME="$tmp_dir/home" \
@@ -251,6 +251,31 @@ exit 1'
     assert_path_exists "$tmp_dir/home/.openclaw/skills/llm-wiki/deps/baoyu-url-to-markdown"
     [ ! -d "$tmp_dir/home/.openclaw/skills/llm-wiki-upgrade" ] || fail "Did not expect Claude-only companion skill to be installed for OpenClaw"
     [ ! -d "$tmp_dir/home/.openclaw/skills/baoyu-url-to-markdown" ] || fail "Did not expect optional adapters to be enabled by default"
+}
+
+test_install_hermes_copies_bundle() {
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/home/.hermes/skills" "$tmp_dir/bin"
+
+    make_stub "$tmp_dir/bin/bun" '#!/bin/sh
+mkdir -p node_modules
+exit 0'
+
+    make_stub "$tmp_dir/bin/lsof" '#!/bin/sh
+exit 1'
+
+    HOME="$tmp_dir/home" \
+    PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    bash "$REPO_ROOT/install.sh" --platform hermes > /dev/null 2>&1 || fail "install.sh should install for Hermes"
+
+    assert_path_exists "$tmp_dir/home/.hermes/skills/llm-wiki/SKILL.md"
+    assert_path_exists "$tmp_dir/home/.hermes/skills/llm-wiki/HERMES.md"
+    assert_path_exists "$tmp_dir/home/.hermes/skills/llm-wiki/platforms/hermes/README.md"
+    assert_path_exists "$tmp_dir/home/.hermes/skills/llm-wiki/scripts/source-registry.sh"
+    [ ! -d "$tmp_dir/home/.hermes/skills/baoyu-url-to-markdown" ] || fail "Did not expect optional adapters to be enabled by default"
 }
 
 test_upgrade_refreshes_claude_companion_skill() {
@@ -527,6 +552,8 @@ test_platform_entries_mention_hook_and_wiki_context() {
     assert_file_contains "$REPO_ROOT/platforms/claude/CLAUDE.md" "--install-hooks"
     assert_file_contains "$REPO_ROOT/platforms/codex/AGENTS.md" "优先查阅 wiki/index.md"
     assert_file_contains "$REPO_ROOT/platforms/openclaw/README.md" "--upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki"
+    assert_file_contains "$REPO_ROOT/platforms/hermes/README.md" "--platform hermes"
+    assert_file_contains "$REPO_ROOT/platforms/hermes/README.md" "~/.hermes/skills/llm-wiki"
 }
 
 test_root_entries_explain_core_only_optional_and_target_dir() {
@@ -536,6 +563,8 @@ test_root_entries_explain_core_only_optional_and_target_dir() {
     assert_file_contains "$REPO_ROOT/CLAUDE.md" "/llm-wiki-upgrade"
     assert_file_contains "$REPO_ROOT/CLAUDE.md" "--with-optional-adapters"
     assert_file_contains "$REPO_ROOT/CLAUDE.md" "默认只准备知识库核心主线"
+    assert_file_contains "$REPO_ROOT/HERMES.md" "--platform hermes"
+    assert_file_contains "$REPO_ROOT/HERMES.md" "~/.hermes/skills/llm-wiki"
 }
 
 test_skill_md_phase5_lint_mentions_confidence_audit() {
@@ -562,11 +591,14 @@ test_readme_sections() {
     assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform claude"
     assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform codex"
     assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform openclaw"
+    assert_file_contains "$REPO_ROOT/README.md" "bash install.sh --platform hermes"
     assert_file_contains "$REPO_ROOT/README.md" "--with-optional-adapters"
     assert_file_contains "$REPO_ROOT/README.md" "/llm-wiki-upgrade"
     assert_file_contains "$REPO_ROOT/README.md" "--target-dir <你的技能目录>/llm-wiki"
     assert_file_contains "$REPO_ROOT/README.md" "--upgrade --platform openclaw --target-dir <你的技能目录>/llm-wiki"
+    assert_file_contains "$REPO_ROOT/README.md" "--upgrade --platform hermes --target-dir <你的技能目录>/llm-wiki"
     assert_file_contains "$REPO_ROOT/README.md" "wechat-article-to-markdown"
+    assert_file_contains "$REPO_ROOT/README.md" "HERMES.md"
     assert_file_not_contains "$REPO_ROOT/README.md" "bash setup.sh"
     assert_file_not_contains "$REPO_ROOT/README.md" "x-article-extractor"
     assert_file_not_contains "$REPO_ROOT/README.md" "baoyu-danger-x-to-markdown"
@@ -611,7 +643,7 @@ test_upgrade_auto_refuses_ambiguous_installed_platforms() {
     tmp_dir="$(mktemp -d)"
     trap 'rm -rf "$tmp_dir"' RETURN
 
-    mkdir -p "$tmp_dir/home/.claude/skills/llm-wiki" "$tmp_dir/home/.codex/skills/llm-wiki"
+    mkdir -p "$tmp_dir/home/.claude/skills/llm-wiki" "$tmp_dir/home/.codex/skills/llm-wiki" "$tmp_dir/home/.hermes/skills/llm-wiki"
 
     if output="$(
         HOME="$tmp_dir/home" \
@@ -1192,6 +1224,7 @@ test_upgrade_uses_explicit_target_dir
 test_upgrade_fails_when_explicit_target_dir_is_missing
 test_upgrade_refreshes_claude_companion_skill
 test_install_openclaw_copies_bundle
+test_install_hermes_copies_bundle
 test_init_fills_language_placeholder
 test_phase1_templates_exist
 test_init_creates_purpose_and_cache_files
@@ -1486,14 +1519,16 @@ test_graph_data_self_links_are_ignored() {
 }
 
 test_graph_data_exits_without_jq() {
-    local tmp_dir
+    local tmp_dir output
     tmp_dir="$(mktemp -d)"
     trap 'rm -rf "$tmp_dir"' RETURN
 
     mkdir -p "$tmp_dir/wiki/entities"
+    mkdir -p "$tmp_dir/bin"
+    ln -s /bin/bash "$tmp_dir/bin/bash"
 
-    # 用 PATH 只含 /bin（无 jq）来测试依赖缺失
-    if output="$(PATH=/bin bash "$REPO_ROOT/scripts/build-graph-data.sh" "$tmp_dir" 2>&1)"; then
+    # 用只包含 bash 的隔离 PATH 来测试 jq 依赖缺失，避免宿主机把 jq 装进 /bin
+    if output="$(PATH="$tmp_dir/bin" "$tmp_dir/bin/bash" "$REPO_ROOT/scripts/build-graph-data.sh" "$tmp_dir" 2>&1)"; then
         fail "build-graph-data.sh should fail when jq is not available"
     fi
     assert_text_contains "$output" "jq"


### PR DESCRIPTION
## Summary
- add root HERMES.md and Hermes platform entry docs
- add Hermes support in install.sh and runtime-context.sh
- update README / README.en / SKILL metadata
- extend regression coverage for Hermes install flow

## Verification
- bash tests/regression.sh
- bash install.sh --platform hermes --dry-run
