### PR TITLE
fix(windows): resolve Chinese encoding mojibake on PowerShell 5.1 (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v3.2.1 (2026-04-24)
+
+### 修复
+
+- Windows PowerShell 5.1 中文编码乱码（issue #16）：
+  - `scripts/shared-config.sh` 自动检测 `python3` / `python` 命令（Windows 默认只有 `python.exe`）
+  - 自动导出 `PYTHONIOENCODING=utf-8`，统一 Python 子进程输出编码
+  - Python 检测增加 3.8+ 版本校验，和错误消息、README 文档对齐
+- `hook-session-start.sh` / `cache.sh` / `delete-helper.sh` 引用 `shared-config.sh`，统一使用 `$PYTHON_CMD`
+
+### 新增
+
+- `install.ps1` Windows PowerShell 安装入口：自动 `chcp 65001` + `$OutputEncoding = UTF8` + 转发 bash 安装流程
+- `install.sh` 的 `MANAGED_ITEMS` 清单加入 `install.ps1`，并新增安装后校验环节，确保清单文件都拷贝到位
+- `README.md` / `README.en.md` 新增 Windows 章节（Python 检测说明 + `install.ps1` 使用流程）
+
 ## v3.2.0 (2026-04-23)
 
 ### 新增

--- a/README.en.md
+++ b/README.en.md
@@ -210,6 +210,41 @@ Requires `uv`. Install it, then re-run with `--with-optional-adapters`.
 
 ---
 
+## Windows Users
+
+Windows PowerShell 5.1 (bundled with Win10 / Win11) defaults to GB2312 for console encoding, ASCII (CP1252) for `$OutputEncoding`, and `gbk` for Python subprocess `sys.stdout.encoding` on Chinese locale. Running `bash install.sh` directly under PowerShell 5.1 garbles Chinese output and hook JSON ([#16](https://github.com/sdyckjq-lab/llm-wiki-skill/issues/16)).
+
+**Option A — Use `install.ps1` (recommended)**
+
+From the repo root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File install.ps1 --platform claude
+powershell -ExecutionPolicy Bypass -File install.ps1 --platform codex --dry-run
+```
+
+`install.ps1` sets console / `$OutputEncoding` / `PYTHONIOENCODING` all to UTF-8, then delegates to `bash install.sh`.
+
+**Option B — Manually set PowerShell encoding**
+
+```powershell
+chcp 65001
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+$env:PYTHONIOENCODING = 'utf-8'
+bash install.sh --platform claude
+```
+
+**Option C — Upgrade to PowerShell 7+**
+
+PowerShell 7 defaults to UTF-8. Install: `winget install Microsoft.PowerShell`, then run `bash install.sh --platform claude` under `pwsh` directly.
+
+### Python command
+
+Windows typically installs Python as `python.exe`, not `python3.exe` (the `python3` on PATH via Microsoft Store is a stub that prompts installation instead of running). `scripts/shared-config.sh` auto-detects: **tries `python3` first, falls back to `python`**. As long as Python 3.8+ is on PATH under either name, all scripts work.
+
+---
+
 ## Credits
 
 This project builds on:

--- a/README.md
+++ b/README.md
@@ -213,6 +213,41 @@ Hermes 会优先加载仓库根的 `HERMES.md` 作为项目上下文。这个文
 
 ---
 
+## Windows 用户
+
+Windows PowerShell 5.1（Win10 / Win11 系统自带）默认 console 编码为 GB2312、`$OutputEncoding` 为 ASCII，Python 子进程 `sys.stdout.encoding` 默认为 `gbk`。直接在 PS 5.1 下运行 `bash install.sh` 会导致中文输出和 hook JSON 出现乱码（[#16](https://github.com/sdyckjq-lab/llm-wiki-skill/issues/16)）。
+
+**方案 A — 使用 `install.ps1`（推荐）**
+
+在仓库根目录下：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File install.ps1 --platform claude
+powershell -ExecutionPolicy Bypass -File install.ps1 --platform codex --dry-run
+```
+
+`install.ps1` 会自动把 console / `$OutputEncoding` / `PYTHONIOENCODING` 全部设为 UTF-8，再转发到 `bash install.sh`。
+
+**方案 B — 手动设置 PowerShell 编码**
+
+```powershell
+chcp 65001
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+$env:PYTHONIOENCODING = 'utf-8'
+bash install.sh --platform claude
+```
+
+**方案 C — 升级到 PowerShell 7+**
+
+PowerShell 7 默认 UTF-8。安装：`winget install Microsoft.PowerShell`，然后 `pwsh` 下直接 `bash install.sh --platform claude`。
+
+### Python 命令
+
+Windows 上 Python 通常安装为 `python.exe` 而非 `python3.exe`（Microsoft Store 的 `python3` 是安装提示 stub，调用会失败）。本项目 `scripts/shared-config.sh` 已加入自动检测：**先尝试 `python3`，失败回退到 `python`**。所以只要 Python 3.8+ 在 PATH 中（任一命名即可），脚本能正常工作。
+
+---
+
 ## 致谢
 
 本项目复用和集成了以下开源项目：

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,87 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  llm-wiki Windows PowerShell install wrapper
+
+.DESCRIPTION
+  Fixes the combined encoding problem on Windows PowerShell 5.1:
+    - console default is GB2312 (CP936) on Chinese Windows
+    - $OutputEncoding defaults to ASCII (CP1252)
+    - Python subprocess sys.stdout.encoding defaults to gbk (cp936)
+  This wrapper forces UTF-8 across all three layers so install.sh Chinese
+  output and hook-generated JSON are not garbled (issue #16).
+
+  Steps:
+    1. chcp 65001 (console code page)
+    2. [Console]::InputEncoding / OutputEncoding = UTF-8
+    3. $OutputEncoding = UTF-8 (how PS decodes subprocess stdout)
+    4. PYTHONIOENCODING=utf-8 (Python subprocess output)
+    5. Invoke bash install.sh, forwarding all args
+
+  All Write-Host output is kept ASCII-only so this script works even when
+  PowerShell 5.1 parses the .ps1 file under Chinese ANSI (GBK) codepage
+  with no BOM. The actual Chinese UI comes from install.sh after handoff.
+
+.EXAMPLE
+  PS> powershell -ExecutionPolicy Bypass -File install.ps1 --platform claude
+
+.EXAMPLE
+  PS> powershell -ExecutionPolicy Bypass -File install.ps1 --platform codex --dry-run
+
+.NOTES
+  - Requires Git for Windows (Git Bash) or WSL to provide bash on PATH
+  - PowerShell 7+ users default to UTF-8 and can run bash install.sh directly
+  - This wrapper adjusts environment only; it does not alter install.sh logic
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$RemainingArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+# 1. Switch console code page to UTF-8
+$null = & chcp.com 65001
+
+# 2. Console input/output encoding
+[Console]::InputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# 3. How PS decodes subprocess stdout bytes
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
+# 4. Force Python subprocess stdout/stderr to UTF-8
+$env:PYTHONIOENCODING = 'utf-8'
+
+# 5. Detect bash
+$bashCmd = Get-Command bash -ErrorAction SilentlyContinue
+if (-not $bashCmd) {
+  Write-Host "[llm-wiki] Error: bash not found on PATH." -ForegroundColor Red
+  Write-Host "          Install Git for Windows first: https://git-scm.com/download/win" -ForegroundColor Red
+  exit 1
+}
+
+# Script root (use $PSScriptRoot to avoid null $MyInvocation.MyCommand.Path under -File)
+$scriptDir = $PSScriptRoot
+if ([string]::IsNullOrEmpty($scriptDir)) {
+  $scriptDir = Split-Path -Parent $PSCommandPath
+}
+$installSh = Join-Path -Path $scriptDir -ChildPath 'install.sh'
+
+if (-not (Test-Path $installSh)) {
+  Write-Host "[llm-wiki] Error: install.sh not found at $installSh" -ForegroundColor Red
+  exit 1
+}
+
+Write-Host "[llm-wiki] UTF-8 environment ready, launching install.sh..." -ForegroundColor Cyan
+
+# Forward args
+if ($null -eq $RemainingArgs -or $RemainingArgs.Count -eq 0) {
+  & bash $installSh
+} else {
+  & bash $installSh @RemainingArgs
+}
+
+exit $LASTEXITCODE

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,7 @@ MANAGED_ITEMS=(
   "CHANGELOG.md"
   "install.sh"
   "setup.sh"
+  "install.ps1"
   "scripts"
   "templates"
   "deps"
@@ -301,6 +302,19 @@ install_bundle() {
 
     copy_item "$source_path" "$target_path"
   done
+
+  # 安装后校验：确保清单文件都已就位（Windows install.ps1 尤其重要）
+  if [ "$DRY_RUN" -ne 1 ]; then
+    for item in "${MANAGED_ITEMS[@]}"; do
+      source_path="$SCRIPT_DIR/$item"
+      target_path="$target_dir/$item"
+      if [ -e "$source_path" ] && [ ! -e "$target_path" ]; then
+        err "$item：已列入安装清单但未出现在目标目录，拷贝可能失败"
+        exit 1
+      fi
+    done
+    ok "已校验全部 ${#MANAGED_ITEMS[@]} 项安装清单文件"
+  fi
 }
 
 install_node_deps() {

--- a/scripts/cache.sh
+++ b/scripts/cache.sh
@@ -3,6 +3,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/shared-config.sh"
+
 usage() {
   cat <<'EOF'
 用法：
@@ -62,7 +66,7 @@ EOF
 }
 
 relative_path() {
-  python3 - "$1" "$2" <<'PY'
+  "$PYTHON_CMD" - "$1" "$2" <<'PY'
 import os
 import sys
 
@@ -81,7 +85,7 @@ normalized_source_page() {
 
   case "$source_page" in
     /*)
-      python3 - "$wiki_root" "$source_page" <<'PY'
+      "$PYTHON_CMD" - "$wiki_root" "$source_page" <<'PY'
 import os
 import sys
 
@@ -106,7 +110,7 @@ PY
 }
 
 file_hash() {
-  python3 - "$1" "$2" <<'PY'
+  "$PYTHON_CMD" - "$1" "$2" <<'PY'
 import hashlib
 import pathlib
 import sys
@@ -140,7 +144,7 @@ cache_check() {
   current_hash="$(file_hash "$relative_path_value" "$file_path")"
 
   result="$(
-    python3 - "$cache_file" "$wiki_root" "$relative_path_value" "$current_hash" <<'PY'
+    "$PYTHON_CMD" - "$cache_file" "$wiki_root" "$relative_path_value" "$current_hash" <<'PY'
 import hashlib
 import json
 import os
@@ -221,7 +225,7 @@ cache_update() {
   normalized_source="$(normalized_source_page "$wiki_root" "$source_page")"
   timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-  python3 - "$cache_file" "$relative_path_value" "$current_hash" "$timestamp" "$normalized_source" <<'PY'
+  "$PYTHON_CMD" - "$cache_file" "$relative_path_value" "$current_hash" "$timestamp" "$normalized_source" <<'PY'
 import json
 import os
 import sys
@@ -267,7 +271,7 @@ cache_invalidate() {
 
   relative_path_value="$(relative_path "$wiki_root" "$file_path")"
 
-  python3 - "$cache_file" "$relative_path_value" <<'PY'
+  "$PYTHON_CMD" - "$cache_file" "$relative_path_value" <<'PY'
 import json
 import os
 import sys

--- a/scripts/cache.sh
+++ b/scripts/cache.sh
@@ -66,6 +66,8 @@ EOF
 }
 
 relative_path() {
+  require_python_cmd
+
   "$PYTHON_CMD" - "$1" "$2" <<'PY'
 import os
 import sys
@@ -85,6 +87,8 @@ normalized_source_page() {
 
   case "$source_page" in
     /*)
+      require_python_cmd
+
       "$PYTHON_CMD" - "$wiki_root" "$source_page" <<'PY'
 import os
 import sys
@@ -110,6 +114,8 @@ PY
 }
 
 file_hash() {
+  require_python_cmd
+
   "$PYTHON_CMD" - "$1" "$2" <<'PY'
 import hashlib
 import pathlib
@@ -139,6 +145,8 @@ cache_check() {
     printf 'MISS\n'
     return 0
   fi
+
+  require_python_cmd
 
   relative_path_value="$(relative_path "$wiki_root" "$file_path")"
   current_hash="$(file_hash "$relative_path_value" "$file_path")"
@@ -245,6 +253,8 @@ cache_update() {
   cache_file="$(cache_file_path "$wiki_root")"
   ensure_cache_file "$cache_file"
 
+  require_python_cmd
+
   relative_path_value="$(relative_path "$wiki_root" "$file_path")"
   current_hash="$(file_hash "$relative_path_value" "$file_path")"
   normalized_source="$(normalized_source_page "$wiki_root" "$source_page")"
@@ -293,6 +303,8 @@ cache_invalidate() {
     printf 'INVALIDATED\n'
     return 0
   fi
+
+  require_python_cmd
 
   relative_path_value="$(relative_path "$wiki_root" "$file_path")"
 

--- a/scripts/delete-helper.sh
+++ b/scripts/delete-helper.sh
@@ -3,6 +3,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/shared-config.sh"
+
 usage() {
   cat <<'EOF'
 用法：
@@ -27,7 +31,7 @@ scan_refs() {
 
   {
     grep -rlF --include='*.md' -- "$needle" "$wiki_dir" 2>/dev/null || true
-  } | python3 -c '
+  } | "$PYTHON_CMD" -c '
 import os
 import sys
 

--- a/scripts/delete-helper.sh
+++ b/scripts/delete-helper.sh
@@ -29,6 +29,8 @@ scan_refs() {
     exit 1
   }
 
+  require_python_cmd
+
   {
     grep -rlF --include='*.md' -- "$needle" "$wiki_dir" 2>/dev/null || true
   } | "$PYTHON_CMD" -c '

--- a/scripts/hook-session-start.sh
+++ b/scripts/hook-session-start.sh
@@ -3,6 +3,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/shared-config.sh"
+
 WIKI_PATH=""
 
 if [ -f "$HOME/.llm-wiki-path" ]; then
@@ -18,10 +22,15 @@ if [ -z "$WIKI_PATH" ] || [ ! -f "$WIKI_PATH/.wiki-schema.md" ]; then
   exit 0
 fi
 
-python3 - "$WIKI_PATH" <<'PY'
+"$PYTHON_CMD" - "$WIKI_PATH" <<'PY'
 import json
 import os
 import sys
+
+# 防御性：即使上游 shared-config.sh 未设置 PYTHONIOENCODING，
+# 此处也强制 stdout 为 UTF-8，避免 Agent 接到 gbk 字节
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
 
 wiki_path = os.path.realpath(sys.argv[1])
 message = f"[llm-wiki] 检测到知识库: {wiki_path}/index.md，回答问题时优先查阅 wiki 内容获取上下文"

--- a/scripts/hook-session-start.sh
+++ b/scripts/hook-session-start.sh
@@ -22,6 +22,8 @@ if [ -z "$WIKI_PATH" ] || [ ! -f "$WIKI_PATH/.wiki-schema.md" ]; then
   exit 0
 fi
 
+require_python_cmd
+
 "$PYTHON_CMD" - "$WIKI_PATH" <<'PY'
 import json
 import os

--- a/scripts/shared-config.sh
+++ b/scripts/shared-config.sh
@@ -1,4 +1,30 @@
 #!/bin/bash
-# 共享配置：被 install.sh 和 adapter-state.sh 引用
+# 共享配置：被 install.sh / hook-session-start.sh / cache.sh / delete-helper.sh 等引用
 # 微信公众号提取工具的 Git 仓库地址
 WECHAT_TOOL_URL="git+https://github.com/jackwener/wechat-article-to-markdown.git"
+
+# Python 命令检测：Windows 默认安装为 python.exe，不存在 python3 命令
+# （Microsoft Store 的 python3 是安装提示 stub，运行会失败）
+_detect_python_cmd() {
+  if command -v python3 >/dev/null 2>&1 && python3 -c "" >/dev/null 2>&1; then
+    echo "python3"
+  elif command -v python >/dev/null 2>&1 && python -c "" >/dev/null 2>&1; then
+    echo "python"
+  else
+    echo ""
+  fi
+}
+
+if [ -z "${PYTHON_CMD:-}" ]; then
+  PYTHON_CMD="$(_detect_python_cmd)"
+  if [ -z "$PYTHON_CMD" ]; then
+    echo "[llm-wiki] 错误：找不到可用的 Python 3，请先安装 Python 3.8+ 并加入 PATH" >&2
+    return 1 2>/dev/null || exit 1
+  fi
+  export PYTHON_CMD
+fi
+
+# 统一 Python 子进程 stdout/stderr 编码为 UTF-8
+# Windows 中文环境下 Python 无 TTY 时 sys.stdout.encoding 默认 gbk (cp936)，
+# 会导致 Agent 通过 subprocess 读取的 JSON / 输出出现乱码 (issue #16)
+export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"

--- a/scripts/shared-config.sh
+++ b/scripts/shared-config.sh
@@ -6,9 +6,11 @@ WECHAT_TOOL_URL="git+https://github.com/jackwener/wechat-article-to-markdown.git
 # Python 命令检测：Windows 默认安装为 python.exe，不存在 python3 命令
 # （Microsoft Store 的 python3 是安装提示 stub，运行会失败）
 _detect_python_cmd() {
-  if command -v python3 >/dev/null 2>&1 && python3 -c "" >/dev/null 2>&1; then
+  # 要求 Python 3.8+（见 README Windows 小节与下方错误消息）
+  local ver_check='import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)'
+  if command -v python3 >/dev/null 2>&1 && python3 -c "$ver_check" >/dev/null 2>&1; then
     echo "python3"
-  elif command -v python >/dev/null 2>&1 && python -c "" >/dev/null 2>&1; then
+  elif command -v python >/dev/null 2>&1 && python -c "$ver_check" >/dev/null 2>&1; then
     echo "python"
   else
     echo ""

--- a/scripts/shared-config.sh
+++ b/scripts/shared-config.sh
@@ -5,26 +5,48 @@ WECHAT_TOOL_URL="git+https://github.com/jackwener/wechat-article-to-markdown.git
 
 # Python 命令检测：Windows 默认安装为 python.exe，不存在 python3 命令
 # （Microsoft Store 的 python3 是安装提示 stub，运行会失败）
+_python_version_check='import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)'
+
+_python_cmd_is_valid() {
+  local candidate="$1"
+
+  command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "$_python_version_check" >/dev/null 2>&1
+}
+
 _detect_python_cmd() {
   # 要求 Python 3.8+（见 README Windows 小节与下方错误消息）
-  local ver_check='import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)'
-  if command -v python3 >/dev/null 2>&1 && python3 -c "$ver_check" >/dev/null 2>&1; then
+  if _python_cmd_is_valid python3; then
     echo "python3"
-  elif command -v python >/dev/null 2>&1 && python -c "$ver_check" >/dev/null 2>&1; then
+  elif _python_cmd_is_valid python; then
     echo "python"
   else
     echo ""
   fi
 }
 
-if [ -z "${PYTHON_CMD:-}" ]; then
-  PYTHON_CMD="$(_detect_python_cmd)"
-  if [ -z "$PYTHON_CMD" ]; then
-    echo "[llm-wiki] 错误：找不到可用的 Python 3，请先安装 Python 3.8+ 并加入 PATH" >&2
-    return 1 2>/dev/null || exit 1
+require_python_cmd() {
+  local detected_cmd
+
+  if [ "${PYTHON_CMD_READY:-0}" = "1" ]; then
+    return 0
   fi
+
+  if [ -n "${PYTHON_CMD:-}" ] && _python_cmd_is_valid "$PYTHON_CMD"; then
+    export PYTHON_CMD
+    PYTHON_CMD_READY=1
+    return 0
+  fi
+
+  detected_cmd="$(_detect_python_cmd)"
+  if [ -z "$detected_cmd" ]; then
+    echo "[llm-wiki] 错误：找不到可用的 Python 3，请先安装 Python 3.8+ 并加入 PATH" >&2
+    return 1
+  fi
+
+  PYTHON_CMD="$detected_cmd"
   export PYTHON_CMD
-fi
+  PYTHON_CMD_READY=1
+}
 
 # 统一 Python 子进程 stdout/stderr 编码为 UTF-8
 # Windows 中文环境下 Python 无 TTY 时 sys.stdout.encoding 默认 gbk (cp936)，

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -92,6 +92,17 @@ make_stub() {
     chmod +x "$path"
 }
 
+make_path_without_python() {
+    local bin_dir="$1"
+    local cmd cmd_path
+
+    mkdir -p "$bin_dir"
+    for cmd in bash dirname pwd mkdir tr awk sed sort cut head tail find wc uname date printf grep cat rm cp chmod mktemp; do
+        cmd_path="$(PATH="/usr/bin:/bin:/usr/sbin:/sbin" command -v "$cmd" 2>/dev/null || true)"
+        [ -n "$cmd_path" ] && ln -s "$cmd_path" "$bin_dir/$cmd"
+    done
+}
+
 make_repo_copy_without_git() {
     local dest="$1"
 
@@ -207,6 +218,39 @@ test_install_dry_run_for_claude() {
     assert_text_contains "$output" "--with-optional-adapters"
     assert_text_not_contains "$output" "uv tool install"
     assert_text_not_contains "$output" "bun install"
+}
+
+test_install_help_does_not_require_python() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    make_path_without_python "$tmp_dir/bin"
+
+    output="$(
+        PATH="$tmp_dir/bin" \
+        bash "$REPO_ROOT/install.sh" --help 2>&1
+    )" || fail "install.sh --help should not require Python"
+
+    assert_text_contains "$output" "用法："
+}
+
+test_install_dry_run_does_not_require_python() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/home/.codex/skills"
+    make_path_without_python "$tmp_dir/bin"
+
+    output="$(
+        HOME="$tmp_dir/home" \
+        PATH="$tmp_dir/bin" \
+        bash "$REPO_ROOT/install.sh" --platform codex --dry-run 2>&1
+    )" || fail "install.sh dry-run should not require Python"
+
+    assert_text_contains "$output" "install.ps1"
+    assert_text_contains "$output" "llm-wiki 已准备完成"
 }
 
 test_install_auto_refuses_ambiguous_platforms() {
@@ -506,6 +550,23 @@ test_hook_session_start_returns_empty_json_without_wiki() {
     )" || fail "hook-session-start.sh should succeed without wiki"
 
     [ "$output" = "{}" ] || fail "Expected hook-session-start.sh to return {} without wiki"
+}
+
+test_hook_session_start_without_wiki_does_not_require_python() {
+    local tmp_dir output
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/home"
+    make_path_without_python "$tmp_dir/bin"
+
+    output="$(
+        HOME="$tmp_dir/home" \
+        PATH="$tmp_dir/bin" \
+        bash "$REPO_ROOT/scripts/hook-session-start.sh" 2>&1
+    )" || fail "hook-session-start.sh should return {} without Python when no wiki exists"
+
+    [ "$output" = "{}" ] || fail "Expected hook-session-start.sh to return {} without wiki, got: $output"
 }
 
 test_install_registers_and_uninstalls_session_start_hook() {
@@ -1294,6 +1355,8 @@ test_skill_md_step12_does_not_call_cache_update() {
 test_setup_runs_on_bash_3_2
 test_install_with_optional_adapters_bootstraps_dependencies
 test_install_dry_run_for_claude
+test_install_help_does_not_require_python
+test_install_dry_run_does_not_require_python
 test_install_auto_refuses_ambiguous_platforms
 test_upgrade_auto_refuses_ambiguous_installed_platforms
 test_upgrade_uses_explicit_target_dir
@@ -1314,6 +1377,7 @@ test_delete_helper_scans_reference_files
 test_skill_md_phase3_query_mentions_persistence_and_duplicate_handling
 test_hook_session_start_outputs_context_when_wiki_exists
 test_hook_session_start_returns_empty_json_without_wiki
+test_hook_session_start_without_wiki_does_not_require_python
 test_install_registers_and_uninstalls_session_start_hook
 test_platform_entries_mention_hook_and_wiki_context
 test_root_entries_explain_core_only_optional_and_target_dir


### PR DESCRIPTION
## Summary

Windows PowerShell 5.1 下 Chinese 输出全乱码（issue #16），因为 PS console、`$OutputEncoding`、Python subprocess `sys.stdout` 三层都默认非 UTF-8。改了 `scripts/shared-config.sh` 做 python command detect + `PYTHONIOENCODING=utf-8` export，新增 `install.ps1` wrapper，3 份 hook/helper 脚本接入 `$PYTHON_CMD`，README 补 Windows 章节。

## 背景

我在 Windows 11 Home China 上复现了 #16，顺手挖了下根因，发现不是一个简单 "chcp 65001 就行" 的问题，而是三层叠加：

- `[Console]::OutputEncoding` 默认 `GB2312`（显示层）
- `$OutputEncoding` 默认 `ASCII (CP1252)`（PS 对 subprocess stdout 解码）
- Python 无 TTY 时 `sys.stdout.encoding` 默认 `gbk`（Python 子进程写入）

所以哪怕用户 `chcp 65001` 改了 console，PS 读 bash/Python 子进程的 stdout 仍按 CP1252 解，Python 写入仍按 gbk 编码，Agent 拿到的 JSON 还是坏的。这也解释了 #16 里 @yuhw2001 说的 "指定 utf-8 也不能完全解决" —— 单独改一层没用。

顺手还踩到一个附属 bug：Windows 上 `python3.exe` 通常不存在（Microsoft Store 的 `python3` 是 install-prompt stub，调用直接 exit 1），实际可用的是 `python.exe`。`hook-session-start.sh` / `cache.sh` / `delete-helper.sh` 里硬写 `python3 - <<'PY'` 会 silent fail，看起来像 hook 没生效。

## 改了什么

**`scripts/shared-config.sh`** 是原本就被 install.sh 和 adapter-state.sh source 的小 config 文件，把 Python detect 和 encoding export 放这里最自然：

- `_detect_python_cmd()` 先试 `python3`，不行回退 `python`，用 `-c ""` 空调用验证（过滤掉 Store stub）
- 把结果 export 成 `$PYTHON_CMD` 给下游脚本用
- `export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"`，让所有 Python 子进程即使不显式 reconfigure 也默认 UTF-8

然后 `hook-session-start.sh` / `cache.sh` / `delete-helper.sh` source shared-config 之后把 `python3 - ...` 改成 `"$PYTHON_CMD" - ...`。`hook-session-start.sh` 里额外加了一行 `sys.stdout.reconfigure(encoding="utf-8")` 做 defense-in-depth，即使上游 env 没设也保证 stdout 是 UTF-8。

**`install.ps1`** 是新文件。PS 5.1 用户直接跑 `bash install.sh` 编码坏，升级到 PS 7 又是额外一步，所以写了个 wrapper 把三层编码都 force UTF-8，再 transparent 转发到 `bash install.sh`：

```powershell
chcp 65001
[Console]::InputEncoding  = [System.Text.Encoding]::UTF8
[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
$OutputEncoding           = [System.Text.Encoding]::UTF8
$env:PYTHONIOENCODING     = 'utf-8'
& bash install.sh @RemainingArgs
```

一个小坑：`install.ps1` 文件本身没 BOM 的话，PS 5.1 会按系统 ANSI（中文 Windows 是 GBK）去 parse 这个 .ps1 文件，导致脚本里的 Chinese literal 自己乱码（就是 Write-Host 那行自己先乱）。保 BOM 又跨平台别扭，所以我把 `install.ps1` 里所有 Write-Host 都写成纯 ASCII 英文。真正的中文显示来自 `install.sh` 被 bash 起起来之后的输出，那时候编码已经 force UTF-8 了，没问题。

**README.md / README.en.md** 补了 "Windows 用户" 章节，3 个选项：install.ps1 / 手动设编码 / 升级 PS 7（@yuhw2001 最早提的 workaround 保留为 Option C）。另外说明了 python3/python 命名检测。

## 测试

Windows 11 Home China / PS 5.1.26100.7920 / Python 3.13.7 / Git Bash。

改之前：

```
PS> bash scripts/hook-session-start.sh
(silent exit 1 — python3 stub)
```

改之后：

```
PS> bash scripts/hook-session-start.sh
{"hookSpecificOutput": {"hookEventName": "SessionStart",
"additionalContext": "[llm-wiki] 检测到知识库: /path/index.md，回答问题时优先查阅 wiki 内容获取上下文"}}

PS> powershell -ExecutionPolicy Bypass -File install.ps1 --dry-run --platform claude
[llm-wiki] UTF-8 environment ready, launching install.sh...
================================
  llm-wiki 安装
================================
平台：claude
...
```

Git Bash + PS 5.1 两环境都跑过，输出都正确。macOS/Linux 行为没变（shared-config 的 python detect 在 Unix 上第一个 `python3` 就成功，encoding 设置也没负作用）。

## 关于 @yuhw2001 的原方案

@yuhw2001 在 #16 提的 "强制用 PS 7" 是正确的 workaround，这条路径保留为 README 里的 Option C。这个 PR 补的是 Option A（install.ps1）+ Option B（手动）和 python3/python detection，让不方便升级 PS 7 的用户也能跑。

也顺便 cover 了 TODOS.md 第 39 行那条 "至少先明确 PowerShell 5.1 / 7 的支持边界，并补安装与使用提示"。

如果 scope 有觉得可以拆小或加测试的地方，请 @ 一下我。
