### PR TITLE
fix(graph): preserve explicit confidence when same edge appears multiple times (closes #38)

### DIFF
--- a/scripts/build-graph-data.sh
+++ b/scripts/build-graph-data.sh
@@ -172,6 +172,13 @@ VALID_IDS="$TMPDIR/valid_ids.txt"
 cut -f1 "$NODES_TSV" | sort -u > "$VALID_IDS"
 
 EDGES_TSV="$TMPDIR/edges.tsv"
+# 合并同一 from+to 的多条 raw edges：
+#   - 第一次遇到时记录（有 conf 就用 conf，无 conf 就留空 → 最终默认 EXTRACTED）
+#   - 后续遇到带显式 conf 的条目时 **升级**（覆盖之前的空值或 EXTRACTED 默认）
+#   - 若后续遇到多条不同的非空 conf，保留首个非空（按首次显式标注优先）
+#
+# 这解决了"同一对节点被多次 [[]] 引用（正文 + 相关页面列表）时，
+#  首次出现的空 conf 会永久锁定 edge type 为 EXTRACTED"的问题。
 awk -F'\t' -v valids="$VALID_IDS" '
   BEGIN {
     while ((getline line < valids) > 0) valid[line] = 1
@@ -182,10 +189,13 @@ awk -F'\t' -v valids="$VALID_IDS" '
     if (!(to in valid)) next
     if (from == to) next
     key = from "\t" to
-    if (!(key in seen) || (conf != "" && saved_conf[key] == "")) {
+    if (!(key in seen)) {
       seen[key] = 1
-      saved_conf[key] = (conf != "" ? conf : (saved_conf[key] == "" ? "EXTRACTED" : saved_conf[key]))
+      saved_conf[key] = conf  # 可能为空，在 END 中兜底为 EXTRACTED
       order[++count] = key
+    } else if (conf != "" && saved_conf[key] == "") {
+      # 升级：之前未见显式 conf（留空），现在有，采用
+      saved_conf[key] = conf
     }
   }
   END {

--- a/tests/graph-data-confidence-merge.regression-1.sh
+++ b/tests/graph-data-confidence-merge.regression-1.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# Regression: build-graph-data.sh should upgrade edge type from default EXTRACTED
+# to explicit INFERRED / AMBIGUOUS when the same (from, to) pair is referenced
+# multiple times within a single source file.
+#
+# Motivates fix for:
+#   scripts/build-graph-data.sh edge-merge awk block —
+#   previously the condition `saved_conf[key] == ""` was always false once the
+#   key had been seen (because the ternary in the same branch always filled
+#   it with "EXTRACTED" or the current conf), so the first occurrence locked
+#   the edge type forever. Any later `<!-- confidence: INFERRED -->` annotation
+#   on the same [[link]] in subsequent lines was silently ignored.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/build-graph-data.sh"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+test_explicit_confidence_overrides_default_on_same_page() {
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/wiki/entities"
+
+    # A.md: first reference to B has no annotation (default EXTRACTED),
+    # later reference in the 相关页面 list carries explicit INFERRED.
+    # Before the fix, first occurrence locks type to EXTRACTED forever.
+    cat > "$tmp_dir/wiki/entities/A.md" <<'EOF'
+---
+tags: [test]
+---
+
+# A
+
+正文中提到 [[B]] 是一个相关的模块。
+
+## 相关页面
+
+- [[B]] <!-- confidence: INFERRED --> — 推断关联
+EOF
+
+    cat > "$tmp_dir/wiki/entities/B.md" <<'EOF'
+---
+tags: [test]
+---
+
+# B
+
+## 相关页面
+
+- [[A]] <!-- confidence: INFERRED --> — 推断关联
+EOF
+
+    # Minimal purpose.md so build-graph-data doesn't bail
+    cat > "$tmp_dir/purpose.md" <<'EOF'
+# 研究目的
+test
+EOF
+
+    LLM_WIKI_TEST_MODE=1 \
+        bash "$SCRIPT" "$tmp_dir" "$tmp_dir/graph-data.json" > /dev/null 2>&1 \
+        || fail "build-graph-data.sh should succeed on fixture"
+
+    local a_to_b_type b_to_a_type
+    a_to_b_type=$(jq -r '.edges[] | select(.from == "A" and .to == "B") | .type' "$tmp_dir/graph-data.json")
+    b_to_a_type=$(jq -r '.edges[] | select(.from == "B" and .to == "A") | .type' "$tmp_dir/graph-data.json")
+
+    [ "$a_to_b_type" = "INFERRED" ] \
+        || fail "A→B should be INFERRED after merging (default + explicit INFERRED on same page), got: $a_to_b_type"
+
+    [ "$b_to_a_type" = "INFERRED" ] \
+        || fail "B→A should be INFERRED (only one reference, explicitly annotated), got: $b_to_a_type"
+}
+
+test_ambiguous_overrides_default_when_mixed() {
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/wiki/entities"
+
+    # X.md references Y multiple times: plain body + AMBIGUOUS annotation
+    cat > "$tmp_dir/wiki/entities/X.md" <<'EOF'
+---
+tags: [test]
+---
+
+# X
+
+See [[Y]] in context.
+Also mention [[Y]] again.
+
+## 相关页面
+
+- [[Y]] <!-- confidence: AMBIGUOUS --> — 待确认
+EOF
+
+    cat > "$tmp_dir/wiki/entities/Y.md" <<'EOF'
+---
+tags: [test]
+---
+
+# Y
+
+## 相关页面
+
+- [[X]]
+EOF
+
+    cat > "$tmp_dir/purpose.md" <<'EOF'
+# 研究目的
+test
+EOF
+
+    LLM_WIKI_TEST_MODE=1 \
+        bash "$SCRIPT" "$tmp_dir" "$tmp_dir/graph-data.json" > /dev/null 2>&1 \
+        || fail "build-graph-data.sh should succeed on fixture"
+
+    local x_to_y_type
+    x_to_y_type=$(jq -r '.edges[] | select(.from == "X" and .to == "Y") | .type' "$tmp_dir/graph-data.json")
+
+    [ "$x_to_y_type" = "AMBIGUOUS" ] \
+        || fail "X→Y should be AMBIGUOUS (default + default + AMBIGUOUS merge), got: $x_to_y_type"
+}
+
+test_default_extracted_when_no_annotation() {
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/wiki/entities"
+
+    cat > "$tmp_dir/wiki/entities/P.md" <<'EOF'
+---
+tags: [test]
+---
+
+# P
+
+See [[Q]].
+
+## 相关页面
+
+- [[Q]]
+EOF
+
+    cat > "$tmp_dir/wiki/entities/Q.md" <<'EOF'
+---
+tags: [test]
+---
+
+# Q
+
+## 相关页面
+
+- [[P]]
+EOF
+
+    cat > "$tmp_dir/purpose.md" <<'EOF'
+# 研究目的
+test
+EOF
+
+    LLM_WIKI_TEST_MODE=1 \
+        bash "$SCRIPT" "$tmp_dir" "$tmp_dir/graph-data.json" > /dev/null 2>&1 \
+        || fail "build-graph-data.sh should succeed on fixture"
+
+    local p_to_q_type
+    p_to_q_type=$(jq -r '.edges[] | select(.from == "P" and .to == "Q") | .type' "$tmp_dir/graph-data.json")
+
+    [ "$p_to_q_type" = "EXTRACTED" ] \
+        || fail "P→Q should default to EXTRACTED when no annotation exists, got: $p_to_q_type"
+}
+
+test_first_explicit_wins_among_multiple_explicit() {
+    # When two different explicit confidence values appear for the same
+    # (from, to) pair within the same page, the first-seen one should win
+    # (stable + deterministic). This keeps semantics aligned with the
+    # existing "first occurrence" comment in the awk block.
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    mkdir -p "$tmp_dir/wiki/entities"
+
+    cat > "$tmp_dir/wiki/entities/M.md" <<'EOF'
+---
+tags: [test]
+---
+
+# M
+
+See [[N]] <!-- confidence: INFERRED --> in the body.
+
+## 相关页面
+
+- [[N]] <!-- confidence: AMBIGUOUS --> — should NOT override INFERRED
+EOF
+
+    cat > "$tmp_dir/wiki/entities/N.md" <<'EOF'
+---
+tags: [test]
+---
+
+# N
+
+## 相关页面
+
+- [[M]]
+EOF
+
+    cat > "$tmp_dir/purpose.md" <<'EOF'
+# 研究目的
+test
+EOF
+
+    LLM_WIKI_TEST_MODE=1 \
+        bash "$SCRIPT" "$tmp_dir" "$tmp_dir/graph-data.json" > /dev/null 2>&1 \
+        || fail "build-graph-data.sh should succeed on fixture"
+
+    local m_to_n_type
+    m_to_n_type=$(jq -r '.edges[] | select(.from == "M" and .to == "N") | .type' "$tmp_dir/graph-data.json")
+
+    [ "$m_to_n_type" = "INFERRED" ] \
+        || fail "M→N should keep first explicit INFERRED, got: $m_to_n_type"
+}
+
+test_explicit_confidence_overrides_default_on_same_page
+test_ambiguous_overrides_default_when_mixed
+test_default_extracted_when_no_annotation
+test_first_explicit_wins_among_multiple_explicit
+
+echo "PASS: graph-data-confidence-merge.regression-1"

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -1634,6 +1634,7 @@ test_graph_html_missing_data_exits_with_error
 test_graph_html_missing_template_exits_with_error
 bash "$REPO_ROOT/tests/graph-analysis-helper.regression-1.sh" || fail "graph-analysis-helper.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-build-failures.regression-1.sh" || fail "graph-build-failures.regression-1.sh 测试失败"
+bash "$REPO_ROOT/tests/graph-data-confidence-merge.regression-1.sh" || fail "graph-data-confidence-merge.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-brand-link.regression-1.sh" || fail "graph-html-brand-link.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-long-label.regression-1.sh" || fail "graph-html-long-label.regression-1.sh 测试失败"
 bash "$REPO_ROOT/tests/graph-html-minimap.regression-1.sh" || fail "graph-html-minimap.regression-1.sh 测试失败"


### PR DESCRIPTION
## Summary

Fixes issue #38 — `build-graph-data.sh` edge-merge awk block loses explicit `<!-- confidence: INFERRED / AMBIGUOUS -->` annotations whenever the same `(from, to)` pair appears multiple times in a single page (very common pattern: body reference + "相关页面" list).

The guard condition `saved_conf[key] == \"\"` on the merge branch was always false after the first insertion, because the ternary in the same line filled empty values with `\"EXTRACTED\"` immediately. Consequence: the first occurrence locked the edge type forever, and later `<!-- confidence: ... -->` on the same link became dead weight.

## Changes

**`scripts/build-graph-data.sh`** — split the merge branch in two:

```awk
if (!(key in seen)) {
  seen[key] = 1
  saved_conf[key] = conf          # may be empty; END block backfills to EXTRACTED
  order[++count] = key
} else if (conf != \"\" && saved_conf[key] == \"\") {
  # Upgrade: previous occurrences had no explicit conf; this one does.
  saved_conf[key] = conf
}
```

Semantics:

- First sighting: record whatever `conf` is (possibly empty; finalized to `EXTRACTED` in the `END` block).
- Later sightings with explicit `conf` + previous empty: **upgrade** to the explicit value.
- Later sightings when both are non-empty but different: **first explicit wins** (stable, deterministic; matches the original `同 from+to 的重复边按首次出现保留（优先取有 confidence 的那条）` comment's intent).

**`tests/graph-data-confidence-merge.regression-1.sh`** — new regression with 4 scenarios:

1. `test_explicit_confidence_overrides_default_on_same_page` — A body reference (default) + 相关页面 list with `INFERRED`. Expect A→B = `INFERRED`.
2. `test_ambiguous_overrides_default_when_mixed` — default × 2 + `AMBIGUOUS` annotation. Expect `AMBIGUOUS`.
3. `test_default_extracted_when_no_annotation` — sanity check: no annotation ⇒ `EXTRACTED`.
4. `test_first_explicit_wins_among_multiple_explicit` — `INFERRED` in body + `AMBIGUOUS` in 相关页面. Expect `INFERRED` (first explicit wins).

**`tests/regression.sh`** — wires the new regression into the main entry point.

## Verification

- New regression: stash the fix → 3 of 4 scenarios fail as expected. Restore fix → all pass.
- Full `bash tests/regression.sh` → **all green** (existing `test_graph_data_sample_wiki_matches_expected` snapshot unchanged; sample fixture happens not to exercise the multi-reference path, which is why the bug slipped through).
- JS unit tests (`tests/js/*`) unaffected.

## Scope / Risk

Two-line change inside a single awk script; no public API, config, or output format changes. The only observable output difference is that edges with legitimate multi-reference + explicit-confidence now carry the intended type instead of a silently-overridden `EXTRACTED`.

## Test plan

- [x] New regression test fails before fix, passes after fix
- [x] Full regression suite (`bash tests/regression.sh`) passes
- [x] Existing sample-wiki snapshot diff is clean
- [x] Manually verified on two real wikis (~50 INFERRED/AMBIGUOUS annotations each) — now reflected correctly in `graph-data.json`