### PR TITLE
fix(scripts): show cross-platform install hints for jq/node runtime errors

### DIFF
--- a/scripts/build-graph-data.sh
+++ b/scripts/build-graph-data.sh
@@ -13,7 +13,9 @@
 set -eu
 shopt -s nullglob
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+[ "$SCRIPT_DIR" = "${BASH_SOURCE[0]}" ] && SCRIPT_DIR="."
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/shared-config.sh"
 

--- a/scripts/build-graph-data.sh
+++ b/scripts/build-graph-data.sh
@@ -13,10 +13,14 @@
 set -eu
 shopt -s nullglob
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/shared-config.sh"
+
 WIKI_ROOT="${1:-.}"
 DEFAULT_OUTPUT="$WIKI_ROOT/wiki/graph-data.json"
 OUTPUT="${2:-$DEFAULT_OUTPUT}"
-SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 HELPER="$SKILL_DIR/scripts/graph-analysis.js"
 MAX_CONTENT_BYTES=$((2 * 1024 * 1024))
 MAX_CONTENT_LINES=500
@@ -24,12 +28,14 @@ MAX_INSIGHT_NODES=250
 MAX_INSIGHT_EDGES=1000
 
 command -v jq >/dev/null 2>&1 || {
-  echo "ERROR: jq 未安装。运行 brew install jq" >&2
+  echo "ERROR: jq is not installed. Install it via:" >&2
+  print_install_hint jq
   exit 1
 }
 
 command -v node >/dev/null 2>&1 || {
-  echo "ERROR: node 未安装。图谱 2.0 构建需要 node 运行时。运行 brew install node" >&2
+  echo "ERROR: node is not installed. Install it via:" >&2
+  print_install_hint node
   exit 1
 }
 

--- a/scripts/build-graph-html.sh
+++ b/scripts/build-graph-html.sh
@@ -19,7 +19,9 @@
 
 set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+[ "$SCRIPT_DIR" = "${BASH_SOURCE[0]}" ] && SCRIPT_DIR="."
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/shared-config.sh"
 

--- a/scripts/build-graph-html.sh
+++ b/scripts/build-graph-html.sh
@@ -19,6 +19,10 @@
 
 set -eu
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/shared-config.sh"
+
 print_usage() {
   cat <<'EOF'
 用法：
@@ -71,11 +75,12 @@ done
 WIKI_ROOT="$1"
 
 command -v jq >/dev/null 2>&1 || {
-  echo "ERROR: jq 未安装。运行 brew install jq" >&2
+  echo "ERROR: jq is not installed. Install it via:" >&2
+  print_install_hint jq
   exit 1
 }
 
-SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMPLATES_DIR="$SKILL_DIR/templates"
 DEPS_DIR="$SKILL_DIR/deps"
 DATA="$WIKI_ROOT/wiki/graph-data.json"

--- a/scripts/shared-config.sh
+++ b/scripts/shared-config.sh
@@ -52,3 +52,32 @@ require_python_cmd() {
 # Windows 中文环境下 Python 无 TTY 时 sys.stdout.encoding 默认 gbk (cp936)，
 # 会导致 Agent 通过 subprocess 读取的 JSON / 输出出现乱码 (issue #16)
 export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"
+
+# 输出指定工具的跨平台安装提示，缩进 2 空格便于嵌套在 ERROR 消息下；
+# 输出走 stderr，与 ERROR 消息保持同一通道。
+print_install_hint() {
+  local tool="$1"
+  case "$tool" in
+    jq)
+      echo "  macOS:        brew install jq" >&2
+      echo "  Linux/WSL:    sudo apt-get install jq   (Debian/Ubuntu)" >&2
+      echo "                sudo dnf install jq       (RHEL/Fedora)" >&2
+      echo "  Windows:      winget install jqlang.jq  (or choco install jq)" >&2
+      ;;
+    node)
+      echo "  macOS:        brew install node" >&2
+      echo "  Linux/WSL:    sudo apt-get install nodejs npm" >&2
+      echo "  Windows:      winget install OpenJS.NodeJS  (or choco install nodejs)" >&2
+      ;;
+    uv)
+      echo "  macOS/Linux:  curl -LsSf https://astral.sh/uv/install.sh | sh    (official)" >&2
+      echo "                brew install uv                                    (alternative)" >&2
+      echo "  Windows:      powershell -c \"irm https://astral.sh/uv/install.ps1 | iex\"   (official)" >&2
+      echo "                winget install --id=astral-sh.uv -e                (alternative)" >&2
+      ;;
+    *)
+      echo "  unknown tool: $tool" >&2
+      return 1
+      ;;
+  esac
+}

--- a/scripts/validate-step1.sh
+++ b/scripts/validate-step1.sh
@@ -3,7 +3,9 @@
 # 用法：bash validate-step1.sh <json_file>
 # 返回：0 = 格式正确，1 = 格式有问题（触发回退）
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+[ "$SCRIPT_DIR" = "${BASH_SOURCE[0]}" ] && SCRIPT_DIR="."
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/shared-config.sh"
 

--- a/scripts/validate-step1.sh
+++ b/scripts/validate-step1.sh
@@ -3,13 +3,21 @@
 # 用法：bash validate-step1.sh <json_file>
 # 返回：0 = 格式正确，1 = 格式有问题（触发回退）
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/shared-config.sh"
+
 JSON_FILE="$1"
 
 # 参数检查
 [ -z "$1" ] && { echo "ERROR: usage: validate-step1.sh <json_file>"; exit 1; }
 
 # 检查 jq 是否可用（必需依赖）
-command -v jq >/dev/null 2>&1 || { echo "ERROR: jq not found. Run: brew install jq"; exit 1; }
+command -v jq >/dev/null 2>&1 || {
+  echo "ERROR: jq is not installed. Install it via:" >&2
+  print_install_hint jq
+  exit 1
+}
 
 # 检查文件是否存在
 [ -f "$JSON_FILE" ] || { echo "ERROR: file not found: $JSON_FILE"; exit 1; }

--- a/tests/graph-build-failures.regression-1.sh
+++ b/tests/graph-build-failures.regression-1.sh
@@ -34,7 +34,7 @@ test_graph_data_exits_without_node() {
     fi
 
     assert_text_contains "$output" "node"
-    assert_text_contains "$output" "图谱 2.0 构建需要 node"
+    assert_text_contains "$output" "Install it via"
 
     rm -rf "$tmp_dir"
 }


### PR DESCRIPTION
## Summary

PR #29 让 Windows 用户能跑 skill 后，运行时缺 `jq` / `node` 仍只看到 `brew install jq` —— Windows/Linux 用户没法直接用。这个 PR 把 4 处 runtime ERROR 消息收口到 `scripts/shared-config.sh` 的 `print_install_hint <tool>` helper，统一输出 macOS / Linux+WSL / Windows 三平台安装命令，文案统一英文。

## 改了什么

**`scripts/shared-config.sh`**：新增 `print_install_hint <tool>`，case 匹配 `jq` / `node` / `uv`。输出走 stderr (`>&2`)，每个 tool 输出 3 行跨平台命令。命令全部从官方文档 verify：

- jq → jqlang.org/download
- node → nodejs.org
- uv → docs.astral.sh/uv（官方主推 standalone install script，brew/winget 作 alternative）

**3 个调用方接入**（`scripts/build-graph-data.sh` / `build-graph-html.sh` / `validate-step1.sh`）：按 `cache.sh` / `hook-session-start.sh` 现有 pattern 补 `SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"` + `source "$SCRIPT_DIR/shared-config.sh"`。`build-graph-*` 把原 `SKILL_DIR` 改写成基于 `SCRIPT_DIR` 重算。

**4 处 ERROR 文案英文化**：从 `ERROR: jq 未安装。运行 brew install jq` 改成：

```
ERROR: jq is not installed. Install it via:
  macOS:        brew install jq
  Linux/WSL:    sudo apt-get install jq   (Debian/Ubuntu)
                sudo dnf install jq       (RHEL/Fedora)
  Windows:      winget install jqlang.jq  (or choco install jq)
```

WSL 不单独列：WSL 内本质就是 Linux，apt-get 直接用，单列只是冗余。

## 测试改动

- `tests/graph-build-failures.regression-1.sh:37` 之前断言 `"图谱 2.0 构建需要 node"` 这个本地化短语，文案英文化后会 fail。改成 `assert_text_contains "$output" "Install it via"`，锁的是"输出含跨平台 hint 头"这个契约。
- `tests/regression.sh:1663` `test_graph_data_exits_without_jq` 不需改 —— 它只断言 `"jq"` 子串，新文案仍含。

本地 smoke：helper 三个 case 输出符合官方文档；`build-graph-data.sh` node-missing 整链实测；5 个文件 `bash -n` 全过。

## 不在本 PR scope 内

为了控制 PR 范围，刻意没改：

- **`install.sh:410`** 和 **`SKILL.md:991`** 仍提 `brew install`：是 setup-time 文档/提示路径，不是运行时 ERROR；可单独 PR。
- **`scripts/adapter-state.sh:131, 134`** 的 `optional_hint()` 也命中 `brew install uv`，但它返回的是 8 列 TSV 字段值（contract 在 `SKILL.md:101` 文档化，`tests/adapter-state.sh` 验证），单行强约束 + 周边 `安装提示：...` 是中文输出 channel。强行英文化会破坏 contract 或造成中英混搭。如果 maintainer 想统一 i18n，可以 follow-up PR。
- **`open -na "Google Chrome" ...`** 等 macOS-only 命令（在 `install.sh:424` 和 `adapter-state.sh:131`）：需要 OS 检测分支 + 各平台 Chrome remote-debug 启动等价命令，逻辑量级不同。

## Trade-off

新的 `ERROR: node is not installed. Install it via:` 丢掉了原 `"图谱 2.0 构建需要 node 运行时"` 这层语境。有意的取舍：install hint 本身已经把工具链说清楚（`OpenJS.NodeJS` 字面就是 Node.js），保持 4 个脚本文案一致更重要。