### PR TITLE
fix(chat): 切视图丢消息 + 工具调用气泡错乱

### DIFF
--- a/workbench/server/src/conversations.test.ts
+++ b/workbench/server/src/conversations.test.ts
@@ -88,6 +88,44 @@ test("piMessagesToUIMessages redacts private paths in historical tool results", 
 	]);
 });
 
+test("piMessagesToUIMessages 把多步 assistant 轮合并成一个气泡", () => {
+	const messages = piMessagesToUIMessages([
+		userMessage("介绍一下"),
+		assistantMessage("让我先看看。", [
+			{ type: "toolCall", id: "t1", name: "read", arguments: { path: "a.md" } },
+		]),
+		toolResultMessage("t1", "read", "内容A", false),
+		assistantMessage("", [
+			{ type: "toolCall", id: "t2", name: "read", arguments: { path: "b.md" } },
+		]),
+		toolResultMessage("t2", "read", "内容B", false),
+		assistantMessage("## 总览\n这是结论。", []),
+	]);
+
+	assert.equal(messages.length, 2);
+	assert.equal(messages[0]?.role, "user");
+	assert.equal(messages[1]?.role, "assistant");
+	assert.equal(messages[1]?.tools.length, 2);
+	assert.match(messages[1]?.content ?? "", /让我先看看/);
+	assert.match(messages[1]?.content ?? "", /这是结论/);
+});
+
+test("piMessagesToUIMessages 不跨 user 边界合并（多轮保持独立）", () => {
+	const messages = piMessagesToUIMessages([
+		userMessage("Q1"),
+		assistantMessage("A1", []),
+		userMessage("Q2"),
+		assistantMessage("A2", []),
+	]);
+
+	assert.deepEqual(
+		messages.map((m) => m.role),
+		["user", "assistant", "user", "assistant"],
+	);
+	assert.equal(messages[1]?.content, "A1");
+	assert.equal(messages[3]?.content, "A2");
+});
+
 function userMessage(text: string): AgentMessage {
 	return {
 		role: "user",

--- a/workbench/server/src/conversations.ts
+++ b/workbench/server/src/conversations.ts
@@ -92,8 +92,27 @@ export function piMessagesToUIMessages(messages: AgentMessage[]): UIMessage[] {
 	const result: UIMessage[] = [];
 	const toolResults = indexToolResults(messages);
 
+	// 一轮（两条 user 消息之间）里 pi 往往产出多条 assistant 消息：文字 → 工具调用 →
+	// 续写 …… 直播态把整轮聚合进一个气泡，这里合并成一个 UIMessage 以与直播保持一致。
+	let pending: { texts: string[]; tools: string[] } | null = null;
+	const flushAssistant = () => {
+		if (!pending) return;
+		const content = pending.texts.filter((t) => t.trim()).join("\n\n");
+		const tools = pending.tools;
+		if (content.trim() || tools.length > 0) {
+			result.push({
+				id: `a-${result.length}`,
+				role: "assistant",
+				content,
+				tools: tools.map((name) => ({ name, status: "done" as const })),
+			});
+		}
+		pending = null;
+	};
+
 	for (const msg of messages) {
 		if (msg.role === "user") {
+			flushAssistant();
 			const text = stripKnowledgeContextForDisplay(extractText(msg));
 			if (text.trim()) {
 				result.push({
@@ -106,17 +125,13 @@ export function piMessagesToUIMessages(messages: AgentMessage[]): UIMessage[] {
 		} else if (msg.role === "assistant") {
 			const text = extractText(msg);
 			const tools = extractToolSummaries(msg, toolResults);
-			if (text.trim() || tools.length > 0) {
-				result.push({
-					id: `a-${result.length}`,
-					role: "assistant",
-					content: text,
-					tools: tools.map((name) => ({ name, status: "done" as const })),
-				});
-			}
+			if (!pending) pending = { texts: [], tools: [] };
+			if (text.trim()) pending.texts.push(text);
+			pending.tools.push(...tools);
 		}
-		// 忽略 toolResult 等其他类型
+		// toolResult 等：忽略，且不 flush（它夹在 assistant 工具调用与续写之间，flush 会错误拆轮）
 	}
+	flushAssistant();
 
 	return result;
 }

--- a/workbench/web/src/App.tsx
+++ b/workbench/web/src/App.tsx
@@ -1067,7 +1067,28 @@ function App() {
 							onSelectView={setMainView}
 						/>
 						<div className="main-view-content">
-							{mainView === "graph" ? (
+							<div className={mainView === "graph" ? "chat-host chat-host-hidden" : "chat-host"}>
+								<ChatPanel
+									key={chatKey}
+									hidden={mainView === "graph"}
+									currentKnowledgeBaseName={active?.kb.name ?? null}
+									initialMessages={initialMessages}
+									onMessageSent={handleMessageSent}
+									onStatusChange={setChatStatus}
+									currentKnowledgeBasePath={active?.kb.path ?? null}
+									onOpenPage={handleOpenPage}
+									onWikiLinkSeen={handleWikiLinkSeen}
+									onArtifactCreated={handleArtifactCreated}
+									artifactCount={artifacts.length}
+									onOpenArtifacts={handleOpenArtifacts}
+									onStartBatchDigest={handleStartBatchDigest}
+									pendingPrompt={pendingGraphPrompt}
+									onPendingPromptConsumed={() => setPendingGraphPrompt(null)}
+									pendingInsertRef={pendingInsertRef}
+									onPendingInsertRefConsumed={() => setPendingInsertRef(null)}
+								/>
+							</div>
+							{mainView === "graph" && (
 								<GraphPanel
 									currentKnowledgeBaseName={active?.kb.name ?? null}
 									currentKnowledgeBasePath={active?.kb.path ?? null}
@@ -1085,25 +1106,6 @@ function App() {
 									pendingDiff={pendingGraphDiff}
 									refreshToken={graphRefreshToken}
 									onDiffConsumed={() => setPendingGraphDiff(null)}
-								/>
-							) : (
-								<ChatPanel
-									key={chatKey}
-									currentKnowledgeBaseName={active?.kb.name ?? null}
-									initialMessages={initialMessages}
-									onMessageSent={handleMessageSent}
-									onStatusChange={setChatStatus}
-									currentKnowledgeBasePath={active?.kb.path ?? null}
-									onOpenPage={handleOpenPage}
-									onWikiLinkSeen={handleWikiLinkSeen}
-									onArtifactCreated={handleArtifactCreated}
-									artifactCount={artifacts.length}
-									onOpenArtifacts={handleOpenArtifacts}
-									onStartBatchDigest={handleStartBatchDigest}
-									pendingPrompt={pendingGraphPrompt}
-									onPendingPromptConsumed={() => setPendingGraphPrompt(null)}
-									pendingInsertRef={pendingInsertRef}
-									onPendingInsertRefConsumed={() => setPendingInsertRef(null)}
 								/>
 							)}
 						</div>

--- a/workbench/web/src/components/ChatPanel.tsx
+++ b/workbench/web/src/components/ChatPanel.tsx
@@ -73,6 +73,7 @@ function isExportCommand(name: string): name is ExportKind {
  *   - 删除"等待 agent 响应…"文字，改用 ▍ 光标
  */
 interface Props {
+	hidden?: boolean;
 	currentKnowledgeBaseName: string | null;
 	currentKnowledgeBasePath: string | null;
 	initialMessages: UIMessage[];
@@ -103,6 +104,7 @@ interface Props {
 }
 
 export function ChatPanel({
+	hidden = false,
 	currentKnowledgeBaseName,
 	currentKnowledgeBasePath,
 	initialMessages,
@@ -231,6 +233,13 @@ export function ChatPanel({
 			scrollMessagesToBottom("auto");
 		}
 	}, [messages, scrollMessagesToBottom]);
+
+	// 隐藏（display:none）期间 scrollHeight 为 0，流式输出滚不动；重新显示时若仍在跟随底部，补一次滚到底。
+	useEffect(() => {
+		if (!hidden && followBottomRef.current) {
+			scrollMessagesToBottom("auto");
+		}
+	}, [hidden, scrollMessagesToBottom]);
 
 	useEffect(() => {
 		if (!refMenu.open || !currentKnowledgeBasePath) {

--- a/workbench/web/src/index.css
+++ b/workbench/web/src/index.css
@@ -965,6 +965,15 @@
     overflow: hidden;
   }
 
+  .chat-host {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .chat-host-hidden {
+    display: none;
+  }
+
   .sidebar-header {
     position: absolute;
     top: 10px;

--- a/workbench/web/test/chat-host-source.test.tsx
+++ b/workbench/web/test/chat-host-source.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("主视图切换：ChatPanel 常驻挂载契约", () => {
+	it("App.tsx 不再用三元在 chat/graph 间卸载 ChatPanel，而是 CSS 隐藏", () => {
+		const source = readFileSync(resolve(import.meta.dirname, "../src/App.tsx"), "utf8");
+		// ChatPanel 外层包了 chat-host，且用 chat-host-hidden 做隐藏（而非整段卸载）
+		assert.match(source, /className=\{mainView === "graph" \? "chat-host chat-host-hidden" : "chat-host"\}/);
+		// GraphPanel 仍按需挂载
+		assert.match(source, /mainView === "graph" && \(\s*<GraphPanel/);
+		// 不再存在"graph 时把 ChatPanel 整段从树上摘掉"的三元
+		assert.doesNotMatch(source, /mainView === "graph" \? \(\s*<GraphPanel[\s\S]*?\) : \(\s*<ChatPanel/);
+	});
+
+	it("index.css 提供 chat-host 填充与隐藏类", () => {
+		const css = readFileSync(resolve(import.meta.dirname, "../src/index.css"), "utf8");
+		assert.match(css, /\.chat-host\s*\{[^}]*height:\s*100%/);
+		assert.match(css, /\.chat-host-hidden\s*\{[^}]*display:\s*none/);
+	});
+});


### PR DESCRIPTION
## 问题

对话区切视图后"每轮显示的内容不固定"，两个症状同源：

1. **工具调用一行变多个**：直播态把整轮回答聚合进一个 assistant 气泡，但切对话/刷新后，服务端重载按 pi 的每条 assistant 消息拆成多个气泡。
2. **最新用户消息临时消失**：切到图谱再切回会卸载 ChatPanel，丢掉只存在本地 state、尚未并入 `initialMessages` 的直播轮（最新用户消息+回复整轮消失，刷新才恢复）。

## 修复

- **症状1（服务端）**：`piMessagesToUIMessages` 把两条 user 消息之间的连续 assistant 消息合并为一个气泡（文本以空行拼接、工具按序合并、toolResult 不触发拆轮），与直播一致。
- **症状2（前端）**：主区由"三元二选一卸载"改为 ChatPanel 常驻挂载 + `.chat-host-hidden` 隐藏，GraphPanel 仍按需挂载；ChatPanel 加 `hidden` prop，重显且仍跟随底部时补一次滚到底。
- 附带净改善：切视图不再重挂载，消除多余 `GET /api/commands`；切到图谱不再 abort 进行中的回复。

## 已知接受的残留

合成的 `knowledge_search`（直播态"搜索1"）只活在 SSE 流、从不写进 session，重载后工具计数 11→10。经确认接受（该步对实时查看有用，差异小不丢数据，对齐要碰 ADR-7 注入机制不划算）。

## 验证

- server 测试 39/39（含 2 条新聚合用例）、web 测试 64/64（含新 `chat-host-source` 守约测试）
- 两个 workspace typecheck 通过
- 浏览器实测：症状1 Q1 由 4 气泡合并为 1（已完成 10 项）；症状2 切图谱再回 live 消息保活（5→5），整页刷新一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)