### PR TITLE
refactor(graph): split sigma global renderer boundaries

### DIFF
--- a/docs/superpowers/plans/2026-06-27-sigma-global-renderer-refactor.md
+++ b/docs/superpowers/plans/2026-06-27-sigma-global-renderer-refactor.md
@@ -14,6 +14,64 @@
 
 This plan implements only #77. It does not implement #79 or #80, and it does not fix #70, #74, #75, #71, or #72. The expected behavior after every task is unchanged graph behavior with a smaller, clearer Sigma global renderer entrypoint.
 
+## NOT In Scope
+
+- #79 Sigma global route boundary documentation and long-term test taxonomy. This branch may leave notes for it, but should not expand into a documentation re-architecture.
+- #80 facade / gesture / controller / renderer redesign. This plan keeps the current public route and lifecycle entrypoint.
+- #70 label overflow behavior. Label placement and truncation can use the new model boundary later, but no user-facing label behavior changes here.
+- #74 / #71 multi-select and shift-click semantics. Hit projection gets a cleaner home, but selection semantics remain unchanged.
+- #75 camera animation performance tuning. This plan preserves current motion behavior and only moves the code.
+- New renderer dependencies or renderer selection changes. Sigma/Graphology remain the production global route.
+
+## What Already Exists
+
+- `sigma-zoom.ts` already owns pure zoom math. `sigma-wheel-zoom.ts` must call it and must not duplicate ratio constants.
+- `sigma-global-drag.ts` already owns drag sessions and document-level pointer/mouse listeners. After this refactor it should keep drag-session mechanics only; hit-target translation and overlay label selection should move out.
+- `sigma-coordinates.ts` already owns Sigma/fallback projection helpers. It should import Sigma-like types from `sigma-global-types.ts`, not from the renderer.
+- `community-cloud-geometry.ts` already owns cloud hull/bounds geometry and reuse signatures. `sigma-overlay-dom.ts` should call it through the existing renderer-owned `communityCloudFor` callback and must not duplicate hull math.
+- `sigma-overlay-svg.ts` already owns low-level SVG/DOM element factories. `sigma-overlay-dom.ts` should orchestrate lifecycle, not recreate SVG helpers.
+- `renderer-boundary.test.ts` already guards raw event ownership. Task 6 must update this test when pointerdown moves from the renderer into `sigma-overlay-dom.ts`.
+- `tests/graph-sigma-global-production.regression-1.sh` already provides production-path Sigma browser regression with FPS, p95 frame, memory, route, and artifact validation. Task 7 must use it before any manual smoke claim.
+
+## Ownership Diagram
+
+```text
+createSigmaGlobalRenderer
+  |
+  |-- lifecycle: runtime, Sigma instance, update/destroy, fatal errors
+  |-- live state: adapterData, graph, pins, active drag, generation guard
+  |
+  +--> sigma-graphology-model
+  |      adapter data + theme + edge style -> Graphology graph / patch
+  |
+  +--> sigma-hit-projector
+  |      Sigma payload/rendered object/screen point -> GraphGestureTarget
+  |
+  +--> sigma-global-camera
+  |      explicit community id + Sigma camera -> target state / movement
+  |
+  +--> sigma-wheel-zoom
+  |      mouse captor wheel -> zoom point + ratio -> renderer callback
+  |
+  +--> sigma-overlay-dom
+         overlay maps + labels + hit targets + drag DOM listeners
+```
+
+Rule: helper modules may import each other only in the direction above. They must not import `sigma-global-renderer.ts`.
+
+## Review Corrections
+
+These corrections are binding for the implementation tasks below.
+
+- The main renderer, not `sigma-global-camera.ts`, decides which community is selected. Camera helpers receive an explicit `communityId`.
+- `SigmaGlobalRenderedObject` and `gestureTargetFromSigmaRenderedObject` move to `sigma-hit-projector.ts` so hit projection does not depend on drag.
+- `sigmaOverlayNodes`, `SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT`, `SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT`, and `sigmaCommunityLabels` move with `sigma-overlay-dom.ts`, not with the Graphology model.
+- `sigma-overlay-dom.ts` owns document-level overlay drag listener cleanup through an explicit `clearActiveDragListeners()` method. Renderer commit/cancel/update/destroy paths call it before ending a drag.
+- `sigma-wheel-zoom.ts` receives `isDestroyed` and must no-op after destroy even if a fake or third-party captor fails to unregister the listener.
+- Tiny numeric helpers such as `finiteNumber`, `clamp`, and `roundNumber` may be copied as private helpers inside extracted modules. Do not remove the renderer-local `finiteNumber` while resize and drag code still uses it.
+- The plan must add direct module tests. Existing `sigma-global-renderer.test.ts` stays as integration coverage, but it is not the only proof for extracted modules.
+- Final verification must include the existing production Sigma browser regression script, not only manual `npm run dev` smoke.
+
 ## File Structure
 
 ### Create
@@ -42,6 +100,21 @@ This plan implements only #77. It does not implement #79 or #80, and it does not
 - `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
   Internal boundary test for helper existence, no runtime import cycles back to `sigma-global-renderer`, and no package-barrel export drift.
 
+- `packages/graph-engine/test/sigma-graphology-model.test.ts`
+  Direct model tests for graph build, patch eligibility, patch application, and raw data boundary.
+
+- `packages/graph-engine/test/sigma-hit-projector.test.ts`
+  Direct hit tests for Sigma node payloads, rendered objects, screen-point payloads, and blank fallback.
+
+- `packages/graph-engine/test/sigma-global-camera.test.ts`
+  Direct camera tests for invalid state, reduced motion, missing animation, projection fallback, and no-wash community centers.
+
+- `packages/graph-engine/test/sigma-wheel-zoom.test.ts`
+  Direct wheel controller tests for listener bind/off, invalid payloads, fallback center, zoom-control exclusion, and post-destroy no-op.
+
+- `packages/graph-engine/test/sigma-overlay-dom.test.ts`
+  Direct overlay controller tests for node click, pointer drag, mouse fallback drag, cancel, cleanup, prune, and reposition without DOM creation.
+
 ### Modify
 
 - `packages/graph-engine/src/render/sigma-global-renderer.ts`
@@ -56,8 +129,17 @@ This plan implements only #77. It does not implement #79 or #80, and it does not
 - `packages/graph-engine/src/render/index.ts`
   Should not export the new helper modules.
 
+- `packages/graph-engine/src/render/sigma-global-drag.ts`
+  Keep drag-session and document-listener mechanics. Move non-drag hit translation and label selection out.
+
 - `packages/graph-engine/test/sigma-global-renderer.test.ts`
   Keep integration/lifecycle tests. Direct model/camera/wheel behavior remains covered here unless a task explicitly creates a dedicated test file.
+
+- `packages/graph-engine/test/sigma-coordinates.test.ts`
+  Import Sigma-like types from `sigma-global-types.ts`.
+
+- `packages/graph-engine/test/renderer-boundary.test.ts`
+  Update raw Sigma pointer exception ownership after overlay DOM extraction.
 
 ## Task 0: Branch And Baseline
 
@@ -137,11 +219,16 @@ const helperFiles = [
   "sigma-events.ts"
 ];
 
+const existingTypeOnlyFiles = [
+  "sigma-coordinates.ts",
+  "community-cloud-geometry.ts"
+];
+
 describe("Sigma global renderer refactor boundaries", () => {
-  it("keeps shared helper modules from importing the renderer runtime", async () => {
-    for (const file of helperFiles) {
+  it("keeps shared helper modules from importing the renderer", async () => {
+    for (const file of [...helperFiles, ...existingTypeOnlyFiles]) {
       const source = await readFile(new URL(`../src/render/${file}`, import.meta.url), "utf8");
-      assert.doesNotMatch(source, /from\s+["']\.\/sigma-global-renderer["']/);
+      assert.doesNotMatch(source, /from\s+["']\.\/sigma-global-renderer(?:\.[jt]s)?["']/);
     }
   });
 
@@ -149,8 +236,13 @@ describe("Sigma global renderer refactor boundaries", () => {
     const source = await readFile(new URL("../src/render/index.ts", import.meta.url), "utf8");
     for (const file of helperFiles) {
       const moduleName = file.replace(/\.ts$/, "");
-      assert.doesNotMatch(source, new RegExp(`["']\\\\./${moduleName}["']`));
+      assert.doesNotMatch(source, new RegExp(`from\\s+["']\\\\./${moduleName}(?:\\\\.js)?["']`));
     }
+  });
+
+  it("keeps the shared type file type-only", async () => {
+    const source = await readFile(new URL("../src/render/sigma-global-types.ts", import.meta.url), "utf8");
+    assert.doesNotMatch(source, /^\s*export\s+(?!type\b|interface\b)/m);
   });
 });
 ```
@@ -338,6 +430,7 @@ Run:
 
 ```bash
 node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-coordinates.test.ts
 node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
 npm run typecheck -w @llm-wiki/graph-engine
 ```
@@ -354,6 +447,7 @@ git add packages/graph-engine/src/render/sigma-global-types.ts \
   packages/graph-engine/src/render/sigma-global-renderer.ts \
   packages/graph-engine/src/render/sigma-coordinates.ts \
   packages/graph-engine/src/render/community-cloud-geometry.ts \
+  packages/graph-engine/test/sigma-coordinates.test.ts \
   packages/graph-engine/test/sigma-refactor-boundaries.test.ts
 git commit -m "refactor(graph): extract sigma global shared types and events"
 ```
@@ -362,7 +456,9 @@ git commit -m "refactor(graph): extract sigma global shared types and events"
 
 **Files:**
 - Create: `packages/graph-engine/src/render/sigma-graphology-model.ts`
+- Create: `packages/graph-engine/test/sigma-graphology-model.test.ts`
 - Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/test/sigma-global-renderer.test.ts`
 - Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
 
 - [ ] **Step 1: Extend boundary test**
@@ -412,7 +508,6 @@ rgbaColor
 sigmaGlobalCommunityAttributes
 sigmaGlobalAggregationAttributes
 sigmaGlobalNodeSize
-sigmaOverlayNodes
 sigmaGlobalNodeColor
 finiteNumber
 clamp
@@ -435,11 +530,7 @@ import { getThemeTokens } from "../themes";
 import type { SigmaGlobalGraphologyGraph, SigmaGlobalGraphologyRuntime } from "./sigma-global-types";
 ```
 
-Export `SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT` because `sigma-overlay-dom.ts` consumes it in Task 6:
-
-```ts
-export const SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT = 160;
-```
+Keep `sigmaOverlayNodes`, `SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT`, `SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT`, and `sigmaCommunityLabels` out of this module. They are overlay policy and move in Task 6.
 
 - [ ] **Step 4: Update renderer imports and re-exports**
 
@@ -451,7 +542,6 @@ import {
   canPatchSigmaGlobalGraphAttributes,
   patchSigmaGlobalGraphAttributes,
   sigmaGlobalNodeSize,
-  sigmaOverlayNodes,
   sigmaSelectedCommunityIds,
   sigmaSpotlightCommunityId,
   sigmaSpotlightCommunityIds,
@@ -471,25 +561,47 @@ export {
 export type { SigmaGlobalEdgeStyle } from "./sigma-graphology-model";
 ```
 
-- [ ] **Step 5: Run targeted tests**
+- [ ] **Step 5: Add direct model tests**
+
+Create `packages/graph-engine/test/sigma-graphology-model.test.ts` by moving direct Graphology model assertions out of `sigma-global-renderer.test.ts` where practical:
+
+- build graph entirely from `GraphRendererAdapterData`
+- selected community focus edge styling
+- node spotlight dimming / force-visible behavior
+- semantic emphasis and focus-highlight edge styling
+- patch eligibility true for same node/edge structure
+- patch eligibility false for theme changes, node id changes, edge id/source/target changes
+- patch application refreshes graph attributes without replacing the graph
+
+Also update the raw-data boundary assertion so it inspects `sigma-graphology-model.ts` and the renderer:
+
+```text
+sigma-graphology-model.ts must type buildSigmaGlobalGraphologyGraph(adapterData: GraphRendererAdapterData, ...)
+sigma-graphology-model.ts and sigma-global-renderer.ts must not import or mention raw GraphData/buildGraphRendererAdapterData/data.nodes/data.edges
+```
+
+- [ ] **Step 6: Run targeted tests**
 
 Run:
 
 ```bash
 node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-graphology-model.test.ts
 node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
 npm run typecheck -w @llm-wiki/graph-engine
 ```
 
 Expected: all pass.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 Run:
 
 ```bash
 git add packages/graph-engine/src/render/sigma-graphology-model.ts \
   packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-graphology-model.test.ts \
+  packages/graph-engine/test/sigma-global-renderer.test.ts \
   packages/graph-engine/test/sigma-refactor-boundaries.test.ts
 git commit -m "refactor(graph): extract sigma graphology render model"
 ```
@@ -498,7 +610,10 @@ git commit -m "refactor(graph): extract sigma graphology render model"
 
 **Files:**
 - Create: `packages/graph-engine/src/render/sigma-hit-projector.ts`
+- Create: `packages/graph-engine/test/sigma-hit-projector.test.ts`
 - Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/src/render/sigma-global-drag.ts`
+- Modify: `packages/graph-engine/test/sigma-global-renderer.test.ts`
 - Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
 
 - [ ] **Step 1: Extend boundary test**
@@ -536,6 +651,8 @@ createSigmaGlobalHitProjector
 sigmaNodeIdFromPayload
 sigmaScreenPointFromPayload
 spatialInputFromAdapterData
+SigmaGlobalRenderedObject
+gestureTargetFromSigmaRenderedObject
 ```
 
 Use these imports:
@@ -546,11 +663,9 @@ import type { GraphRendererAdapterData } from "./adapter";
 import { screenPointToWorldPoint, type GraphScreenPoint } from "./geometry";
 import { graphSpatialHitToGestureTarget, type GraphGestureTarget } from "./gestures";
 import type { RendererViewport, RendererViewportSize } from "./viewport";
-import {
-  gestureTargetFromSigmaRenderedObject,
-  type SigmaGlobalRenderedObject
-} from "./sigma-global-drag";
 ```
+
+Remove `SigmaGlobalRenderedObject` and `gestureTargetFromSigmaRenderedObject` from `sigma-global-drag.ts`; that file should keep drag-session and document-listener mechanics only.
 
 - [ ] **Step 4: Update renderer imports and re-exports**
 
@@ -573,29 +688,45 @@ export { createSigmaGlobalHitProjector } from "./sigma-hit-projector";
 export type {
   SigmaGlobalHitInput,
   SigmaGlobalHitProjector,
-  SigmaGlobalHitProjectorInput
+  SigmaGlobalHitProjectorInput,
+  SigmaGlobalRenderedObject
 } from "./sigma-hit-projector";
 ```
 
-- [ ] **Step 5: Run targeted tests**
+- [ ] **Step 5: Add direct hit projector tests**
+
+Create `packages/graph-engine/test/sigma-hit-projector.test.ts` covering:
+
+- known Sigma node id wins before overlapping community region
+- unknown Sigma node id falls back to rendered object or spatial screen point
+- rendered node, edge, community wash, and aggregation container objects translate to `GraphGestureTarget`
+- invalid rendered object ids return `graph-blank` through fallback behavior
+- top-level `x/y` payload and nested `event.x/event.y` payload both parse
+- missing screen point returns `graph-blank`
+
+- [ ] **Step 6: Run targeted tests**
 
 Run:
 
 ```bash
 node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-hit-projector.test.ts
 node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
 npm run typecheck -w @llm-wiki/graph-engine
 ```
 
 Expected: all pass.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 Run:
 
 ```bash
 git add packages/graph-engine/src/render/sigma-hit-projector.ts \
+  packages/graph-engine/src/render/sigma-global-drag.ts \
   packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-hit-projector.test.ts \
+  packages/graph-engine/test/sigma-global-renderer.test.ts \
   packages/graph-engine/test/sigma-refactor-boundaries.test.ts
 git commit -m "refactor(graph): extract sigma hit projector"
 ```
@@ -604,6 +735,7 @@ git commit -m "refactor(graph): extract sigma hit projector"
 
 **Files:**
 - Create: `packages/graph-engine/src/render/sigma-global-camera.ts`
+- Create: `packages/graph-engine/test/sigma-global-camera.test.ts`
 - Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
 - Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
 
@@ -646,25 +778,33 @@ sigmaGraphPointToCameraPoint
 sigmaCameraDistanceForGraphDistance
 sigmaCommunitySpotlightCenter
 prefersReducedMotion
-finiteNumber
-clamp
-roundNumber
 ```
+
+Move or copy private numeric helpers inside `sigma-global-camera.ts` as needed, but keep a local `finiteNumber` in `sigma-global-renderer.ts` while resize and drag code still uses it.
 
 Use these imports:
 
 ```ts
 import type { GraphRendererAdapterData } from "./adapter";
-import {
-  sigmaSpotlightCommunityId
-} from "./sigma-graphology-model";
 import type {
   SigmaGlobalCameraState,
   SigmaGlobalSigmaLike
 } from "./sigma-global-types";
 ```
 
-Export all moved camera functions that `sigma-global-renderer.ts` uses.
+Do not import `sigmaSpotlightCommunityId` into `sigma-global-camera.ts`. The main renderer computes the selected/spotlight community id and passes it into camera helpers.
+
+Export all moved camera functions that `sigma-global-renderer.ts` uses. `maybeAnimateSigmaCommunitySpotlightCamera` should take this shape:
+
+```ts
+export function maybeAnimateSigmaCommunitySpotlightCamera(
+  sigma: SigmaGlobalSigmaLike,
+  root: HTMLElement,
+  adapterData: GraphRendererAdapterData,
+  communityId: string | null,
+  previousCommunityId: string | null
+): string | null
+```
 
 - [ ] **Step 4: Update renderer imports**
 
@@ -683,25 +823,52 @@ import {
 
 Remove the moved function definitions from `sigma-global-renderer.ts`.
 
-- [ ] **Step 5: Run targeted tests**
+When calling `maybeAnimateSigmaCommunitySpotlightCamera`, compute the id in the renderer:
+
+```ts
+cameraSpotlightCommunityId = maybeAnimateSigmaCommunitySpotlightCamera(
+  sigma,
+  sigmaRoot,
+  adapterData,
+  sigmaSpotlightCommunityId(adapterData),
+  previousCameraSpotlightCommunityId
+);
+```
+
+- [ ] **Step 5: Add direct camera tests**
+
+Create `packages/graph-engine/test/sigma-global-camera.test.ts` covering:
+
+- `readCameraState` normalizes missing/non-finite values
+- `restoreCameraState` no-ops on null state
+- reduced motion uses `setState` instead of `animate`
+- missing `animate` falls back to `setState`
+- graph-to-camera projection falls back to raw graph point when Sigma projection is missing or non-finite
+- community center uses wash center when available
+- community center averages node points when no wash exists
+- camera helper does not decide selected community by reading adapter selection internally
+
+- [ ] **Step 6: Run targeted tests**
 
 Run:
 
 ```bash
 node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-global-camera.test.ts
 node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
 npm run typecheck -w @llm-wiki/graph-engine
 ```
 
 Expected: all pass, including existing tests for community spotlight camera animation, reduced motion, already-framed community, and reset view.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 Run:
 
 ```bash
 git add packages/graph-engine/src/render/sigma-global-camera.ts \
   packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-global-camera.test.ts \
   packages/graph-engine/test/sigma-refactor-boundaries.test.ts
 git commit -m "refactor(graph): extract sigma global camera logic"
 ```
@@ -710,7 +877,9 @@ git commit -m "refactor(graph): extract sigma global camera logic"
 
 **Files:**
 - Create: `packages/graph-engine/src/render/sigma-wheel-zoom.ts`
+- Create: `packages/graph-engine/test/sigma-wheel-zoom.test.ts`
 - Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/test/sigma-global-renderer.test.ts`
 - Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
 
 - [ ] **Step 1: Extend boundary test**
@@ -767,20 +936,27 @@ export interface SigmaWheelZoomController {
 export interface SigmaWheelZoomControllerInput {
   sigma: SigmaGlobalSigmaLike;
   root: HTMLElement;
+  isDestroyed: () => boolean;
   currentRatio: () => number;
   onZoomAtPoint: (point: GraphScreenPoint, nextRatio: number) => void;
+  onFatalError?: (error: unknown) => void;
 }
 
 export function bindSigmaWheelZoomController(input: SigmaWheelZoomControllerInput): SigmaWheelZoomController {
   const captor = input.sigma.getMouseCaptor?.();
   if (!captor?.on) return { destroy: () => undefined };
   const listener = (payload?: unknown): void => {
-    const wheel = sigmaWheelInputFromPayload(payload, sigmaViewportCenter(input.root));
-    if (!wheel) return;
-    preventSigmaDefault(payload);
-    if (sigmaWheelTargetIsZoomControl(payload)) return;
-    const nextRatio = sigmaWheelZoomRatio(input.currentRatio(), wheel.delta);
-    input.onZoomAtPoint(wheel.point, nextRatio);
+    if (input.isDestroyed()) return;
+    try {
+      const wheel = sigmaWheelInputFromPayload(payload, sigmaViewportCenter(input.root));
+      if (!wheel) return;
+      preventSigmaDefault(payload);
+      if (sigmaWheelTargetIsZoomControl(payload)) return;
+      const nextRatio = sigmaWheelZoomRatio(input.currentRatio(), wheel.delta);
+      input.onZoomAtPoint(wheel.point, nextRatio);
+    } catch (error) {
+      input.onFatalError?.(error);
+    }
   };
   captor.on("wheel", listener);
   return {
@@ -860,8 +1036,10 @@ let sigmaWheelZoomController: { destroy(): void } | null = null;
 sigmaWheelZoomController = bindSigmaWheelZoomController({
   sigma,
   root: sigmaRoot,
+  isDestroyed: () => destroyed,
   currentRatio: () => readCameraState(sigma)?.ratio ?? 1,
-  onZoomAtPoint: (point, nextRatio) => zoomSigmaCameraAtViewportPoint(point, nextRatio, false)
+  onZoomAtPoint: (point, nextRatio) => zoomSigmaCameraAtViewportPoint(point, nextRatio, false),
+  onFatalError: options.onFatalError
 });
 ```
 
@@ -883,12 +1061,28 @@ import {
 
 5. Remove local `SigmaGlobalWheelPayload`, `bindSigmaWheelZoom`, `unbindSigmaWheelZoom`, `handleSigmaWheelZoom`, `sigmaWheelInputFromPayload`, `sigmaWheelTargetIsZoomControl`, and `sigmaViewportCenter`.
 
-- [ ] **Step 5: Run targeted tests**
+- [ ] **Step 5: Add direct wheel tests**
+
+Create `packages/graph-engine/test/sigma-wheel-zoom.test.ts` covering:
+
+- controller binds one wheel listener and `destroy()` unregisters the same listener
+- `isDestroyed()` makes late wheel events no-op even if the captor still invokes the listener
+- invalid payloads do not call `onZoomAtPoint`
+- `original.deltaY` wins over fallback `delta`
+- fallback `delta` is converted to pixel-like wheel input
+- missing pointer coordinates use viewport center
+- zoom-control targets are prevented but do not zoom
+- thrown zoom callback errors are passed to `onFatalError`
+
+Update `sigma-global-renderer.test.ts` or its fake captor so renderer-level `destroy()` proves wheel listeners are removed and post-destroy wheel events do not change camera state.
+
+- [ ] **Step 6: Run targeted tests**
 
 Run:
 
 ```bash
 node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-wheel-zoom.test.ts
 node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
 node --import tsx --test packages/graph-engine/test/sigma-zoom.test.ts
 npm run typecheck -w @llm-wiki/graph-engine
@@ -896,13 +1090,15 @@ npm run typecheck -w @llm-wiki/graph-engine
 
 Expected: all pass, including existing wheel zoom tests.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 Run:
 
 ```bash
 git add packages/graph-engine/src/render/sigma-wheel-zoom.ts \
   packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-wheel-zoom.test.ts \
+  packages/graph-engine/test/sigma-global-renderer.test.ts \
   packages/graph-engine/test/sigma-refactor-boundaries.test.ts
 git commit -m "refactor(graph): extract sigma wheel zoom controller"
 ```
@@ -911,7 +1107,11 @@ git commit -m "refactor(graph): extract sigma wheel zoom controller"
 
 **Files:**
 - Create: `packages/graph-engine/src/render/sigma-overlay-dom.ts`
+- Create: `packages/graph-engine/test/sigma-overlay-dom.test.ts`
 - Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/src/render/sigma-global-drag.ts`
+- Modify: `packages/graph-engine/test/sigma-global-renderer.test.ts`
+- Modify: `packages/graph-engine/test/renderer-boundary.test.ts`
 - Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
 
 - [ ] **Step 1: Extend boundary test**
@@ -947,14 +1147,14 @@ Create `packages/graph-engine/src/render/sigma-overlay-dom.ts` with this exporte
 ```ts
 import type { GraphRendererAdapterData } from "./adapter";
 import type { GraphScreenPoint } from "./geometry";
-import type { PinPosition } from "../types";
 import type { SigmaCommunityCloud } from "./community-cloud-geometry";
-import type { SigmaGlobalRenderedObject } from "./sigma-global-drag";
+import type { SigmaGlobalRenderedObject } from "./sigma-hit-projector";
 import type { SigmaGlobalRendererCreateOptions, SigmaGlobalSigmaLike } from "./sigma-global-types";
 
 export interface SigmaOverlayDomController {
   rebuild(): void;
   reposition(): void;
+  clearActiveDragListeners(): void;
   destroy(): void;
 }
 
@@ -971,6 +1171,7 @@ export interface SigmaOverlayDomControllerInput {
   moveNodeDrag: (point: GraphScreenPoint, payload?: unknown) => void;
   commitNodeDrag: (point: GraphScreenPoint | null, payload?: unknown) => void;
   cancelNodeDrag: () => void;
+  screenPointFromEvent: (event: MouseEvent | PointerEvent) => GraphScreenPoint;
   consumeSuppressedNodeClick: (nodeId: string | null) => boolean;
   activeNodeDragId: () => string | null;
 }
@@ -991,6 +1192,8 @@ bindOverlayPointerDragListeners
 bindOverlayMouseDragListeners
 isActiveOverlayDrag
 clearOverlayPointerDragListeners
+sigmaOverlayNodes
+sigmaCommunityLabels
 ```
 
 Keep the same behavior:
@@ -1000,6 +1203,11 @@ Keep the same behavior:
 - `reposition()` must not create DOM elements.
 - click handlers call `input.onHit(...)`.
 - drag handlers call the passed drag callbacks.
+- `clearActiveDragListeners()` must be idempotent and must run on drag commit, drag cancel, update cancellation, and destroy.
+- Define `SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT = 160` and `SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT = 8` inside `sigma-overlay-dom.ts`.
+- Import `sigmaGlobalNodeSize` and `sigmaGlobalNodeSpotlightState` from `sigma-graphology-model.ts`; do not import overlay policy back into the model.
+
+Update `packages/graph-engine/src/render/sigma-global-drag.ts` so it no longer exports `sigmaCommunityLabels`.
 
 - [ ] **Step 4: Update renderer to use overlay controller**
 
@@ -1027,6 +1235,7 @@ overlayDomController = createSigmaOverlayDomController({
   moveNodeDrag,
   commitNodeDrag,
   cancelNodeDrag,
+  screenPointFromEvent: (event) => overlayPointerScreenPoint(event, sigmaRoot),
   consumeSuppressedNodeClick,
   activeNodeDragId: () => activeNodeDrag?.nodeId ?? null
 });
@@ -1053,7 +1262,15 @@ overlayDomController?.destroy();
 overlayDomController = null;
 ```
 
-5. Import:
+5. In renderer drag lifecycle, replace local `clearOverlayPointerDragListeners()` calls with:
+
+```ts
+overlayDomController?.clearActiveDragListeners();
+```
+
+This call must remain in commit, cancel, update cancellation, and destroy paths before the active drag is dropped.
+
+6. Import:
 
 ```ts
 import {
@@ -1062,27 +1279,58 @@ import {
 } from "./sigma-overlay-dom";
 ```
 
-6. Remove the moved local functions and maps.
+7. Remove the moved local functions and maps.
 
-- [ ] **Step 5: Run targeted tests**
+- [ ] **Step 5: Update boundary tests for overlay ownership**
+
+Update `packages/graph-engine/test/renderer-boundary.test.ts`:
+
+- allow `render/sigma-overlay-dom.ts` as the Sigma overlay DOM pointerdown owner
+- keep document-level `pointermove` / `pointerup` / `pointercancel` ownership in `sigma-global-drag.ts`
+- assert `sigma-global-renderer.ts` no longer contains `.sigma-global-node-hit-target` creation or `addEventListener("pointerdown")`
+- assert `sigma-overlay-dom.ts` contains `.sigma-global-node-hit-target` and `addEventListener("pointerdown")`
+- assert `sigma-overlay-dom.ts` does not directly call host callbacks or own graph selection semantics
+
+- [ ] **Step 6: Add direct overlay tests**
+
+Create `packages/graph-engine/test/sigma-overlay-dom.test.ts` covering:
+
+- node hit-target `click` calls `onHit({ kind: "node", id })`
+- community cloud shape click calls `onHit({ kind: "community-wash", id })`
+- pointer drag path dispatches `pointerdown` on `.sigma-global-node-hit-target`, document `pointermove`, document `pointerup`, and clears document listeners
+- pointer cancel clears document listeners and calls cancel
+- mouse fallback path works when `PointerEvent` is unavailable
+- `destroy()` clears element maps and active drag listeners
+- `rebuild()` prunes stale community/node/label elements and refreshes data attributes
+- `reposition()` updates boxes/geometry without `replaceChildren`, DOM creation, or listener rebinding
+- label cap remains 8 and selected labels are prioritized
+- node hit-target cap remains 160 and selected/search/pinned anchors are kept
+
+- [ ] **Step 7: Run targeted tests**
 
 Run:
 
 ```bash
 node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/renderer-boundary.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-overlay-dom.test.ts
 node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
 npm run typecheck -w @llm-wiki/graph-engine
 ```
 
 Expected: all pass, including tests that prove overlay elements are reused on camera updates and data updates.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 8: Commit**
 
 Run:
 
 ```bash
 git add packages/graph-engine/src/render/sigma-overlay-dom.ts \
+  packages/graph-engine/src/render/sigma-global-drag.ts \
   packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-overlay-dom.test.ts \
+  packages/graph-engine/test/sigma-global-renderer.test.ts \
+  packages/graph-engine/test/renderer-boundary.test.ts \
   packages/graph-engine/test/sigma-refactor-boundaries.test.ts
 git commit -m "refactor(graph): extract sigma overlay dom controller"
 ```
@@ -1135,7 +1383,35 @@ npm run typecheck -w @llm-wiki/graph-engine
 
 Expected: both pass.
 
-- [ ] **Step 5: Run workbench smoke**
+- [ ] **Step 5: Run production Sigma browser regression**
+
+Run the existing production-path browser gate:
+
+```bash
+GRAPH_SIGMA_PRODUCTION_ARTIFACT_DIR="/tmp/llm-wiki-sigma-global-refactor-$(date +%Y%m%d-%H%M%S)" \
+GRAPH_SIGMA_PRODUCTION_SHAPES="real-snapshot-proxy,nodes-1000-sparse,nodes-1000-dense" \
+bash tests/graph-sigma-global-production.regression-1.sh
+```
+
+Expected:
+
+```text
+PASS: production-path artifact fields
+PASS: Sigma global production performance trial
+```
+
+The generated `sigma-global-production-results.json` must pass validation with:
+
+- failed records: `0`
+- production path: `true`
+- global records return `sigma-global-ready`
+- wheel FPS at or above the script threshold
+- wheel frame p95 at or below the script threshold
+- repeated-cycle memory growth within the script threshold
+
+If Playwright or Chrome is unavailable, record the exact blocker. Do not replace this with manual smoke unless the blocker is environment-only and all graph-engine tests/typecheck already passed.
+
+- [ ] **Step 6: Run workbench smoke**
 
 Run:
 
@@ -1156,26 +1432,154 @@ Then open the workbench and verify these paths manually:
 
 Expected: all paths behave like current main. If browser verification is blocked by port, Chrome, or local data, record the exact blocker in the final response and do not claim browser verification passed.
 
-- [ ] **Step 6: Comment on #77**
+- [ ] **Step 7: Comment on #77**
 
 Run:
 
 ```bash
-gh issue comment 77 --repo sdyckjq-lab/llm-wiki-skill --body "Implemented the Sigma global renderer split from the design spec. Extracted shared Sigma types/events, Graphology render model, hit projector, camera logic, wheel zoom controller, and overlay DOM controller. Verified graph-engine tests/typecheck and browser smoke where available. PR will close this issue after review."
+gh issue comment 77 --repo sdyckjq-lab/llm-wiki-skill --body "Implemented the Sigma global renderer split from the design spec. Extracted shared Sigma types/events, Graphology render model, hit projector, camera logic, wheel zoom controller, and overlay DOM controller. Verified graph-engine tests/typecheck plus the Sigma production browser regression where available. PR will close this issue after review."
 ```
 
 Expected: issue comment is created.
 
-- [ ] **Step 7: Commit final cleanup**
+- [ ] **Step 8: Commit final cleanup**
 
-If Step 1-6 changed files, run:
+If Step 1-7 changed files, run:
 
 ```bash
 git add packages/graph-engine/src/render packages/graph-engine/test
 git commit -m "test(graph): verify sigma renderer refactor boundaries"
 ```
 
-If Step 1-6 did not change files, do not create an empty commit.
+If Step 1-7 did not change files, do not create an empty commit.
+
+## Test Coverage Map
+
+```text
+CODE PATHS                                            COVERAGE REQUIRED
+[+] Shared types/events
+  |-- type-only runtime boundary                       [NEW] sigma-refactor-boundaries.test.ts
+  |-- prevent Sigma default payload shapes             [NEW] sigma-events coverage via wheel/hit tests
+
+[+] Graphology model
+  |-- adapterData -> nodes/edges/attrs                 [EXISTING -> MOVE] sigma-graphology-model.test.ts
+  |-- selected-community node dimming                  [EXISTING -> MOVE] sigma-graphology-model.test.ts
+  |-- edge relation/focus styling                      [EXISTING -> MOVE] sigma-graphology-model.test.ts
+  |-- patchable same structure                         [NEW] sigma-graphology-model.test.ts
+  |-- theme/shape change rebuild path                  [EXISTING + NEW] renderer + model tests
+
+[+] Hit projector
+  |-- known node id                                    [EXISTING -> MOVE] sigma-hit-projector.test.ts
+  |-- rendered node/edge/community/aggregation object  [NEW] sigma-hit-projector.test.ts
+  |-- screen point spatial fallback                    [EXISTING -> MOVE] sigma-hit-projector.test.ts
+  |-- blank / invalid payload                          [EXISTING + NEW] sigma-hit-projector.test.ts
+
+[+] Camera
+  |-- read/restore camera state                        [NEW] sigma-global-camera.test.ts
+  |-- selected community target from explicit id       [EXISTING + NEW] renderer + camera tests
+  |-- reduced motion / missing animate fallback        [EXISTING -> MOVE] sigma-global-camera.test.ts
+  |-- no-wash community center fallback                [NEW] sigma-global-camera.test.ts
+
+[+] Wheel zoom
+  |-- captor bind/off                                  [NEW] sigma-wheel-zoom.test.ts
+  |-- delta parsing and viewport center fallback       [EXISTING + NEW] zoom + wheel tests
+  |-- zoom-control exclusion                           [EXISTING + NEW] wheel tests
+  |-- late event after destroy                         [NEW] wheel + renderer tests
+  |-- real browser wheel/button path                   [REQUIRED] graph-sigma-global-production regression
+
+[+] Overlay DOM
+  |-- rebuild creates/reuses/prunes elements            [EXISTING + NEW] sigma-overlay-dom.test.ts
+  |-- reposition does not create/replace/rebind         [EXISTING + NEW] sigma-overlay-dom.test.ts
+  |-- node hit-target click                            [NEW] sigma-overlay-dom.test.ts
+  |-- pointer drag, cancel, mouse fallback             [NEW] sigma-overlay-dom.test.ts
+  |-- listener cleanup                                 [NEW] sigma-overlay-dom.test.ts
+  |-- 8 label cap / 160 hit-target cap                 [EXISTING + NEW] renderer + overlay tests
+
+USER FLOWS
+[+] Open global graph                                  [REQUIRED] production browser regression
+[+] Wheel/trackpad zoom                                [REQUIRED] production browser regression
+[+] Left-bottom zoom buttons                           [REQUIRED] production browser regression + manual smoke
+[+] Click community, stay global, drawer sync          [REQUIRED] production browser regression + manual smoke
+[+] Return global                                      [REQUIRED] production browser regression + manual smoke
+[+] Drag node and persist pin                          [REQUIRED] production browser regression + manual smoke
+```
+
+Coverage target: every moved branch is covered by a direct module test, an existing integration test, or the production browser regression. No moved module should rely only on `sigma-global-renderer.test.ts`.
+
+## Failure Modes
+
+| New codepath | Realistic failure | Required coverage / handling |
+|---|---|---|
+| Shared type extraction | helper imports renderer at runtime and creates a cycle | `sigma-refactor-boundaries.test.ts` scans helper imports and package barrel exports |
+| Graphology model extraction | raw `GraphData` leaks into renderer model path | model boundary test reads `sigma-graphology-model.ts` and renderer source |
+| Graph patching | patch path misses updated community/aggregation attributes | direct model patch test plus renderer lifecycle integration test |
+| Hit projector extraction | rendered object translation stays hidden in drag module | hit projector direct tests and drag module cleanup |
+| Camera extraction | camera module reads selection state and duplicates selection ownership | camera direct test plus explicit renderer-passed community id |
+| Camera motion | reduced-motion users still get animation | camera reduced-motion test |
+| Wheel extraction | stale captor listener zooms after destroy | direct wheel test and renderer destroy test |
+| Wheel / animation | real Sigma animation overwrites wheel state | production browser regression plus manual smoke if local browser available |
+| Overlay extraction | document drag listeners leak after commit/cancel/destroy | overlay direct tests count listener cleanup paths |
+| Overlay reposition | camera updates rebuild DOM and rebind listeners every frame | existing and direct overlay tests assert no create/replace/rebind |
+| Browser production path | unit tests pass but real Sigma canvas/route regresses | `tests/graph-sigma-global-production.regression-1.sh` is a hard final gate |
+
+No failure mode above is allowed to be silent with no test and no cleanup path.
+
+## Worktree Parallelization Strategy
+
+This refactor touches one primary module and many shared tests, so the safest execution is mostly sequential. Limited parallel review is useful; parallel implementation is not.
+
+| Step | Modules touched | Depends on |
+|---|---|---|
+| Task 1 shared types/events | `packages/graph-engine/src/render`, `packages/graph-engine/test` | Task 0 |
+| Task 2 graphology model | `packages/graph-engine/src/render`, `packages/graph-engine/test` | Task 1 |
+| Task 3 hit projector | `packages/graph-engine/src/render`, `packages/graph-engine/test` | Task 1, Task 2 for shared types |
+| Task 4 camera | `packages/graph-engine/src/render`, `packages/graph-engine/test` | Task 2 for spotlight helper import |
+| Task 5 wheel | `packages/graph-engine/src/render`, `packages/graph-engine/test` | Task 1 |
+| Task 6 overlay DOM | `packages/graph-engine/src/render`, `packages/graph-engine/test` | Tasks 2, 3, 4, 5 |
+| Task 7 final verification | repo-wide tests/browser | Tasks 1-6 |
+
+Parallel lanes:
+
+- Lane A: Task 1 -> Task 2 -> Task 3 -> Task 4 -> Task 5 -> Task 6 -> Task 7.
+- Lane B: read-only review / QA scripts can run in parallel after Task 5, but should not edit files.
+
+Execution order: implement sequentially in one branch. Use subagents only for read-only review or for isolated test drafting after a task has landed.
+
+Conflict flags: all implementation tasks touch `sigma-global-renderer.ts` and shared fake runtime tests. Parallel code edits would create avoidable merge conflicts.
+
+## Implementation Tasks
+
+Synthesized from this review's findings. Each task derives from a specific finding above.
+
+- [ ] **T1 (P1, human: ~30min / CC: ~8min)** — Camera boundary — Pass explicit community id into camera helpers
+  - Surfaced by: architecture review — camera module must not decide selected community.
+  - Files: `packages/graph-engine/src/render/sigma-global-camera.ts`, `packages/graph-engine/src/render/sigma-global-renderer.ts`, `packages/graph-engine/test/sigma-global-camera.test.ts`
+  - Verify: `node --import tsx --test packages/graph-engine/test/sigma-global-camera.test.ts packages/graph-engine/test/sigma-global-renderer.test.ts`
+
+- [ ] **T2 (P1, human: ~45min / CC: ~12min)** — Overlay cleanup — Add explicit active drag listener cleanup contract
+  - Surfaced by: architecture/performance review — extracted overlay controller otherwise loses commit/cancel cleanup ownership.
+  - Files: `packages/graph-engine/src/render/sigma-overlay-dom.ts`, `packages/graph-engine/src/render/sigma-global-renderer.ts`, `packages/graph-engine/test/sigma-overlay-dom.test.ts`
+  - Verify: `node --import tsx --test packages/graph-engine/test/sigma-overlay-dom.test.ts packages/graph-engine/test/sigma-global-renderer.test.ts`
+
+- [ ] **T3 (P1, human: ~30min / CC: ~8min)** — Boundary tests — Update renderer boundary test for overlay DOM pointer ownership
+  - Surfaced by: architecture review — current `renderer-boundary.test.ts` expects pointerdown in the old file.
+  - Files: `packages/graph-engine/test/renderer-boundary.test.ts`, `packages/graph-engine/src/render/sigma-overlay-dom.ts`
+  - Verify: `node --import tsx --test packages/graph-engine/test/renderer-boundary.test.ts`
+
+- [ ] **T4 (P1, human: ~30min / CC: ~8min)** — Wheel cleanup — Add post-destroy no-op and listener unregister tests
+  - Surfaced by: test/performance review — wheel controller must not act after destroy even if captor cleanup fails.
+  - Files: `packages/graph-engine/src/render/sigma-wheel-zoom.ts`, `packages/graph-engine/test/sigma-wheel-zoom.test.ts`, `packages/graph-engine/test/sigma-global-renderer.test.ts`
+  - Verify: `node --import tsx --test packages/graph-engine/test/sigma-wheel-zoom.test.ts packages/graph-engine/test/sigma-global-renderer.test.ts`
+
+- [ ] **T5 (P2, human: ~45min / CC: ~12min)** — Direct module tests — Split high-value behavior checks out of the integration file
+  - Surfaced by: test review — moved branches need direct tests, not only old integration coverage.
+  - Files: `packages/graph-engine/test/sigma-graphology-model.test.ts`, `packages/graph-engine/test/sigma-hit-projector.test.ts`, `packages/graph-engine/test/sigma-global-camera.test.ts`, `packages/graph-engine/test/sigma-wheel-zoom.test.ts`, `packages/graph-engine/test/sigma-overlay-dom.test.ts`
+  - Verify: `node --import tsx --test packages/graph-engine/test/sigma-*.test.ts`
+
+- [ ] **T6 (P2, human: ~20min / CC: ~5min)** — Production browser gate — Run existing Sigma production regression as final acceptance
+  - Surfaced by: performance review and prior learning `sigma_plan_must_name_production_perf_gate`.
+  - Files: no source changes expected; record artifact path in final issue comment.
+  - Verify: `bash tests/graph-sigma-global-production.regression-1.sh`
 
 ## Final Self-Review Checklist
 
@@ -1186,3 +1590,38 @@ If Step 1-6 did not change files, do not create an empty commit.
 - [ ] Existing graph-engine behavior tests pass.
 - [ ] Browser smoke result is recorded honestly.
 - [ ] #77 has an implementation comment.
+
+## GSTACK REVIEW REPORT
+
+Runs:
+
+| Reviewer | Status | Result |
+|---|---|---|
+| Main engineering review | complete | Plan needed hardening before implementation |
+| Architecture / feasibility subagent | complete | Found camera boundary, overlay cleanup, boundary-test, hit-projector, overlay-policy, and wheel stale-event issues |
+| Performance / reliability subagent | complete | Found overlay cleanup, wheel post-destroy, production browser gate, label cap, and animation/wheel proof gaps |
+| Testing subagent | complete | Found wheel cleanup, overlay DOM interaction, browser repeatability, raw-data boundary, boundary-test strength, and direct module-test gaps |
+
+Findings:
+
+| Severity | Finding | Resolution in this plan |
+|---|---|---|
+| P1 | Camera module would decide selected community itself | Renderer now computes community id and passes it into camera helpers |
+| P1 | Overlay drag listener cleanup lacked an explicit owner | `sigma-overlay-dom.ts` now has `clearActiveDragListeners()` and required tests |
+| P1 | Existing renderer boundary test would fail after overlay extraction | Task 6 now updates `renderer-boundary.test.ts` |
+| P1 | Wheel controller could act after destroy | `isDestroyed` guard and post-destroy tests added |
+| P1 | Manual browser smoke was not repeatable enough | Existing Sigma production browser regression is now a hard final gate |
+| P2 | Hit projector remained coupled to drag | rendered-object translation now moves to `sigma-hit-projector.ts` |
+| P2 | Overlay policy was misplaced in Graphology model | overlay node/label caps and selection move with `sigma-overlay-dom.ts` |
+| P2 | Direct tests were missing for extracted modules | five direct module test files added to the plan |
+| P2 | Raw-data boundary assertion would become false confidence | Task 2 now inspects `sigma-graphology-model.ts` directly |
+
+Prior learnings applied:
+
+- `sigma_plan_must_name_production_perf_gate` (confidence 9/10): final acceptance now runs `tests/graph-sigma-global-production.regression-1.sh`.
+- `sigma_camera_setstate_does_not_cancel_animation` (confidence 9/10): wheel/camera behavior remains covered by production browser regression and explicit wheel no-op tests.
+- `graph_refactor_interaction_chain_before_facade` (confidence 9/10): plan preserves the real Sigma interaction path and does not jump to facade redesign.
+
+VERDICT: proceed with implementation after this reviewed plan commit. Complexity is medium-high but justified for #77 because the goal is durable renderer boundaries before more global Sigma features land.
+
+NO UNRESOLVED DECISIONS

--- a/docs/superpowers/plans/2026-06-27-sigma-global-renderer-refactor.md
+++ b/docs/superpowers/plans/2026-06-27-sigma-global-renderer-refactor.md
@@ -1,0 +1,1188 @@
+# Sigma Global Renderer Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `sigma-global-renderer.ts` into stable Sigma global submodules without changing user-visible graph behavior.
+
+**Architecture:** Keep `createSigmaGlobalRenderer` as the lifecycle orchestration entrypoint. Move Sigma types/events, Graphology render model, hit projection, camera logic, wheel zoom ownership, and overlay DOM ownership into focused internal modules that are not exported from the public package barrel.
+
+**Tech Stack:** TypeScript ESM, Node `node:test`, Graphology, Sigma, existing graph-engine fake runtime tests.
+
+---
+
+## Scope Check
+
+This plan implements only #77. It does not implement #79 or #80, and it does not fix #70, #74, #75, #71, or #72. The expected behavior after every task is unchanged graph behavior with a smaller, clearer Sigma global renderer entrypoint.
+
+## File Structure
+
+### Create
+
+- `packages/graph-engine/src/render/sigma-global-types.ts`
+  Shared Sigma global runtime and renderer TypeScript types only. No runtime code.
+
+- `packages/graph-engine/src/render/sigma-events.ts`
+  Stateless event payload helpers shared by wheel, drag, and hit handling.
+
+- `packages/graph-engine/src/render/sigma-graphology-model.ts`
+  Graphology graph construction, attribute mapping, edge styling, patch checks, and patch application.
+
+- `packages/graph-engine/src/render/sigma-hit-projector.ts`
+  Hit projector and Sigma event payload translation to `GraphGestureTarget`.
+
+- `packages/graph-engine/src/render/sigma-global-camera.ts`
+  Camera state read/restore/reset, community spotlight camera target, and reduced-motion camera movement.
+
+- `packages/graph-engine/src/render/sigma-wheel-zoom.ts`
+  Sigma mouse captor wheel binding, wheel payload parsing, zoom-control exclusion, viewport-center fallback, and cleanup.
+
+- `packages/graph-engine/src/render/sigma-overlay-dom.ts`
+  Overlay DOM controller for rebuild/reposition/destroy of community regions, node hit targets, and community labels.
+
+- `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
+  Internal boundary test for helper existence, no runtime import cycles back to `sigma-global-renderer`, and no package-barrel export drift.
+
+### Modify
+
+- `packages/graph-engine/src/render/sigma-global-renderer.ts`
+  Keep lifecycle orchestration and public direct-source re-exports needed by existing tests. Remove moved implementation details.
+
+- `packages/graph-engine/src/render/sigma-coordinates.ts`
+  Import shared types from `sigma-global-types.ts` instead of `sigma-global-renderer.ts`.
+
+- `packages/graph-engine/src/render/community-cloud-geometry.ts`
+  Import shared Sigma-like types from `sigma-global-types.ts` instead of `sigma-global-renderer.ts`.
+
+- `packages/graph-engine/src/render/index.ts`
+  Should not export the new helper modules.
+
+- `packages/graph-engine/test/sigma-global-renderer.test.ts`
+  Keep integration/lifecycle tests. Direct model/camera/wheel behavior remains covered here unless a task explicitly creates a dedicated test file.
+
+## Task 0: Branch And Baseline
+
+**Files:**
+- Read: `docs/superpowers/specs/2026-06-27-sigma-global-renderer-refactor-design.md`
+- Read: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Read: `packages/graph-engine/test/sigma-global-renderer.test.ts`
+
+- [ ] **Step 1: Confirm implementation branch**
+
+Run:
+
+```bash
+current_branch="$(git branch --show-current)"
+if [ "$current_branch" != "codex/refactor-sigma-global-renderer-boundaries" ]; then
+  git switch codex/refactor-sigma-global-renderer-boundaries
+fi
+git branch --show-current
+```
+
+Expected output:
+
+```text
+codex/refactor-sigma-global-renderer-boundaries
+```
+
+- [ ] **Step 2: Confirm clean working tree**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected:
+
+```text
+## codex/refactor-sigma-global-renderer-boundaries
+```
+
+- [ ] **Step 3: Run baseline targeted tests**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+Expected: both commands pass before refactoring.
+
+- [ ] **Step 4: Commit is not needed**
+
+No files should change in Task 0. Do not commit.
+
+## Task 1: Extract Shared Types And Event Helpers
+
+**Files:**
+- Create: `packages/graph-engine/src/render/sigma-global-types.ts`
+- Create: `packages/graph-engine/src/render/sigma-events.ts`
+- Create: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
+- Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/src/render/sigma-coordinates.ts`
+- Modify: `packages/graph-engine/src/render/community-cloud-geometry.ts`
+
+- [ ] **Step 1: Write failing boundary test**
+
+Create `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`:
+
+```ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const helperFiles = [
+  "sigma-global-types.ts",
+  "sigma-events.ts"
+];
+
+describe("Sigma global renderer refactor boundaries", () => {
+  it("keeps shared helper modules from importing the renderer runtime", async () => {
+    for (const file of helperFiles) {
+      const source = await readFile(new URL(`../src/render/${file}`, import.meta.url), "utf8");
+      assert.doesNotMatch(source, /from\s+["']\.\/sigma-global-renderer["']/);
+    }
+  });
+
+  it("keeps new Sigma internal helpers out of the render package barrel", async () => {
+    const source = await readFile(new URL("../src/render/index.ts", import.meta.url), "utf8");
+    for (const file of helperFiles) {
+      const moduleName = file.replace(/\.ts$/, "");
+      assert.doesNotMatch(source, new RegExp(`["']\\\\./${moduleName}["']`));
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run boundary test and verify it fails**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+```
+
+Expected: FAIL because `sigma-global-types.ts` and `sigma-events.ts` do not exist yet.
+
+- [ ] **Step 3: Create `sigma-global-types.ts`**
+
+Create `packages/graph-engine/src/render/sigma-global-types.ts` by moving these type declarations out of `sigma-global-renderer.ts`:
+
+```ts
+import type { GraphEdgeStyleOptions, PinMap, ThemeId } from "../types";
+import type { GraphRendererAdapterData } from "./adapter";
+import type { GraphScreenPoint } from "./geometry";
+import type { GraphGestureTarget } from "./gestures";
+import type { RendererViewport, RendererViewportSize } from "./viewport";
+
+export interface SigmaGlobalRendererRuntimeBoundary {
+  Sigma: typeof import("sigma").default;
+  GraphologyGraph: typeof import("graphology").default;
+}
+
+export type SigmaGlobalGraphologyGraph = InstanceType<SigmaGlobalRendererRuntimeBoundary["GraphologyGraph"]>;
+
+export interface SigmaGlobalCameraState {
+  x: number;
+  y: number;
+  angle: number;
+  ratio: number;
+}
+
+export interface SigmaGlobalCameraLike {
+  getState?: () => SigmaGlobalCameraState;
+  setState?: (state: Partial<SigmaGlobalCameraState>) => unknown;
+  isAnimated?: () => boolean;
+  animate?: (
+    state: Partial<SigmaGlobalCameraState>,
+    options?: { duration?: number; easing?: string }
+  ) => unknown;
+}
+
+export interface SigmaGlobalMouseCaptorLike {
+  on?: (event: "wheel", listener: (payload?: unknown) => void) => unknown;
+  off?: (event: "wheel", listener: (payload?: unknown) => void) => unknown;
+}
+
+export interface SigmaGlobalSigmaLike {
+  getCamera?: () => SigmaGlobalCameraLike;
+  getMouseCaptor?: () => SigmaGlobalMouseCaptorLike;
+  getViewportZoomedState?: (viewportTarget: GraphScreenPoint, newRatio: number) => SigmaGlobalCameraState;
+  getGraph?: () => unknown;
+  setGraph?: (graph: SigmaGlobalGraphologyGraph) => unknown;
+  getSetting?: (key: string) => unknown;
+  setSetting?: (key: string, value: unknown) => unknown;
+  viewportToGraph?: (point: GraphScreenPoint) => { x: number; y: number };
+  viewportToFramedGraph?: (point: GraphScreenPoint) => { x: number; y: number };
+  graphToViewport?: (point: { x: number; y: number }) => GraphScreenPoint;
+  refresh?: () => unknown;
+  on?: (event: string, listener: (payload?: unknown) => void) => unknown;
+  off?: (event: string, listener: (payload?: unknown) => void) => unknown;
+  kill?: () => unknown;
+}
+
+export interface SigmaGlobalGraphologyRuntime {
+  GraphologyGraph: SigmaGlobalRendererRuntimeBoundary["GraphologyGraph"];
+}
+
+export interface SigmaGlobalRendererRuntime extends SigmaGlobalGraphologyRuntime {
+  Sigma: new (graph: SigmaGlobalGraphologyGraph, container: HTMLElement, settings?: Record<string, unknown>) => SigmaGlobalSigmaLike;
+}
+
+export interface SigmaGlobalRendererCreateOptions {
+  container: HTMLElement;
+  adapterData: GraphRendererAdapterData;
+  theme: ThemeId;
+  edgeStyle?: GraphEdgeStyleOptions;
+  onHitTarget?: (target: GraphGestureTarget) => void;
+  onPinsChanged?: (pins: PinMap) => void;
+  onDragActiveChange?: (dragging: boolean) => void;
+  onFatalError?: (error: unknown) => void;
+  pins?: PinMap;
+  runtime?: SigmaGlobalRendererRuntime;
+  viewport?: RendererViewport;
+  viewportSize?: RendererViewportSize;
+}
+
+export interface SigmaGlobalRendererUpdateOptions {
+  adapterData: GraphRendererAdapterData;
+  theme?: ThemeId;
+  edgeStyle?: GraphEdgeStyleOptions;
+  pins?: PinMap;
+}
+
+export interface SigmaGlobalRenderer {
+  readonly id: "sigma-global";
+  readonly root: HTMLElement;
+  readonly overlayRoot: HTMLElement;
+  readonly graph: SigmaGlobalGraphologyGraph;
+  readonly updateStrategy: "rebuild-graph-preserve-camera";
+  readonly lastHitTarget: GraphGestureTarget | null;
+  isDragging(): boolean;
+  resetView(): void;
+  zoomIn(): void;
+  zoomOut(): void;
+  update(options: SigmaGlobalRendererUpdateOptions): void;
+  destroy(): void;
+}
+```
+
+- [ ] **Step 4: Create `sigma-events.ts`**
+
+Create `packages/graph-engine/src/render/sigma-events.ts`:
+
+```ts
+export interface SigmaGlobalPointerEventPayload {
+  node?: unknown;
+  event?: { x?: unknown; y?: unknown; preventSigmaDefault?: () => void };
+  x?: unknown;
+  y?: unknown;
+  preventSigmaDefault?: () => void;
+}
+
+export function preventSigmaDefault(payload: unknown): void {
+  const eventPayload = payload as SigmaGlobalPointerEventPayload | null;
+  eventPayload?.preventSigmaDefault?.();
+  eventPayload?.event?.preventSigmaDefault?.();
+  if (payload instanceof Event) payload.preventDefault();
+}
+```
+
+- [ ] **Step 5: Update imports and re-exports**
+
+In `sigma-global-renderer.ts`, remove the moved type/interface declarations and add imports:
+
+```ts
+import type {
+  SigmaGlobalCameraState,
+  SigmaGlobalGraphologyGraph,
+  SigmaGlobalGraphologyRuntime,
+  SigmaGlobalRenderer,
+  SigmaGlobalRendererCreateOptions,
+  SigmaGlobalRendererRuntime,
+  SigmaGlobalRendererRuntimeBoundary,
+  SigmaGlobalRendererUpdateOptions,
+  SigmaGlobalSigmaLike
+} from "./sigma-global-types";
+import { preventSigmaDefault } from "./sigma-events";
+
+export type {
+  SigmaGlobalCameraState,
+  SigmaGlobalGraphologyGraph,
+  SigmaGlobalGraphologyRuntime,
+  SigmaGlobalRenderer,
+  SigmaGlobalRendererCreateOptions,
+  SigmaGlobalRendererRuntime,
+  SigmaGlobalRendererRuntimeBoundary,
+  SigmaGlobalRendererUpdateOptions,
+  SigmaGlobalSigmaLike
+} from "./sigma-global-types";
+```
+
+In `sigma-coordinates.ts`, change the type import to:
+
+```ts
+import type { SigmaGlobalRendererCreateOptions, SigmaGlobalSigmaLike } from "./sigma-global-types";
+```
+
+In `community-cloud-geometry.ts`, change the type import to:
+
+```ts
+import type { SigmaGlobalRendererCreateOptions, SigmaGlobalSigmaLike } from "./sigma-global-types";
+```
+
+- [ ] **Step 6: Run targeted tests**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add packages/graph-engine/src/render/sigma-global-types.ts \
+  packages/graph-engine/src/render/sigma-events.ts \
+  packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/src/render/sigma-coordinates.ts \
+  packages/graph-engine/src/render/community-cloud-geometry.ts \
+  packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+git commit -m "refactor(graph): extract sigma global shared types and events"
+```
+
+## Task 2: Extract Graphology Render Model
+
+**Files:**
+- Create: `packages/graph-engine/src/render/sigma-graphology-model.ts`
+- Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
+
+- [ ] **Step 1: Extend boundary test**
+
+Add `"sigma-graphology-model.ts"` to `helperFiles` in `sigma-refactor-boundaries.test.ts`:
+
+```ts
+const helperFiles = [
+  "sigma-global-types.ts",
+  "sigma-events.ts",
+  "sigma-graphology-model.ts"
+];
+```
+
+- [ ] **Step 2: Run boundary test and verify it fails**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+```
+
+Expected: FAIL because `sigma-graphology-model.ts` does not exist yet.
+
+- [ ] **Step 3: Create `sigma-graphology-model.ts`**
+
+Create `packages/graph-engine/src/render/sigma-graphology-model.ts` by moving these exact declarations and functions out of `sigma-global-renderer.ts`:
+
+```text
+SigmaGlobalGraphologyNodeAttributes
+SigmaGlobalGraphologyEdgeAttributes
+SigmaGlobalGraphologyCommunityAttributes
+SigmaGlobalGraphologyAggregationAttributes
+SigmaGlobalEdgeStyle
+buildSigmaGlobalGraphologyGraph
+canPatchSigmaGlobalGraphAttributes
+patchSigmaGlobalGraphAttributes
+sigmaGlobalNodeAttributes
+sigmaSelectedCommunityIds
+sigmaSpotlightCommunityIds
+sigmaSpotlightCommunityId
+sigmaGlobalNodeSpotlightState
+sigmaGlobalEdgeAttributes
+sigmaGlobalEdgeStyle
+sigmaGlobalEdgeRelationColor
+rgbaColor
+sigmaGlobalCommunityAttributes
+sigmaGlobalAggregationAttributes
+sigmaGlobalNodeSize
+sigmaOverlayNodes
+sigmaGlobalNodeColor
+finiteNumber
+clamp
+roundNumber
+```
+
+Use these imports at the top of the new file:
+
+```ts
+import type { GraphEdgeStyleOptions, ThemeId } from "../types";
+import type {
+  GraphRendererAdapterAggregation,
+  GraphRendererAdapterCommunity,
+  GraphRendererAdapterData,
+  GraphRendererAdapterEdge,
+  GraphRendererAdapterNode
+} from "./adapter";
+import { edgeRelationClass } from "./model";
+import { getThemeTokens } from "../themes";
+import type { SigmaGlobalGraphologyGraph, SigmaGlobalGraphologyRuntime } from "./sigma-global-types";
+```
+
+Export `SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT` because `sigma-overlay-dom.ts` consumes it in Task 6:
+
+```ts
+export const SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT = 160;
+```
+
+- [ ] **Step 4: Update renderer imports and re-exports**
+
+In `sigma-global-renderer.ts`, import model functions:
+
+```ts
+import {
+  buildSigmaGlobalGraphologyGraph,
+  canPatchSigmaGlobalGraphAttributes,
+  patchSigmaGlobalGraphAttributes,
+  sigmaGlobalNodeSize,
+  sigmaOverlayNodes,
+  sigmaSelectedCommunityIds,
+  sigmaSpotlightCommunityId,
+  sigmaSpotlightCommunityIds,
+  sigmaGlobalNodeSpotlightState,
+  sigmaGlobalEdgeStyle,
+  type SigmaGlobalEdgeStyle
+} from "./sigma-graphology-model";
+```
+
+Keep direct-source compatibility for existing tests:
+
+```ts
+export {
+  buildSigmaGlobalGraphologyGraph,
+  sigmaGlobalEdgeStyle
+} from "./sigma-graphology-model";
+export type { SigmaGlobalEdgeStyle } from "./sigma-graphology-model";
+```
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add packages/graph-engine/src/render/sigma-graphology-model.ts \
+  packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+git commit -m "refactor(graph): extract sigma graphology render model"
+```
+
+## Task 3: Extract Hit Projector
+
+**Files:**
+- Create: `packages/graph-engine/src/render/sigma-hit-projector.ts`
+- Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
+
+- [ ] **Step 1: Extend boundary test**
+
+Add `"sigma-hit-projector.ts"` to `helperFiles`:
+
+```ts
+const helperFiles = [
+  "sigma-global-types.ts",
+  "sigma-events.ts",
+  "sigma-graphology-model.ts",
+  "sigma-hit-projector.ts"
+];
+```
+
+- [ ] **Step 2: Run boundary test and verify it fails**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+```
+
+Expected: FAIL because `sigma-hit-projector.ts` does not exist yet.
+
+- [ ] **Step 3: Create `sigma-hit-projector.ts`**
+
+Create `packages/graph-engine/src/render/sigma-hit-projector.ts` by moving these declarations and functions out of `sigma-global-renderer.ts`:
+
+```text
+SigmaGlobalHitInput
+SigmaGlobalHitProjectorInput
+SigmaGlobalHitProjector
+createSigmaGlobalHitProjector
+sigmaNodeIdFromPayload
+sigmaScreenPointFromPayload
+spatialInputFromAdapterData
+```
+
+Use these imports:
+
+```ts
+import { createGraphSpatialIndex, type GraphSpatialIndex, type GraphSpatialIndexInput } from "../layout";
+import type { GraphRendererAdapterData } from "./adapter";
+import { screenPointToWorldPoint, type GraphScreenPoint } from "./geometry";
+import { graphSpatialHitToGestureTarget, type GraphGestureTarget } from "./gestures";
+import type { RendererViewport, RendererViewportSize } from "./viewport";
+import {
+  gestureTargetFromSigmaRenderedObject,
+  type SigmaGlobalRenderedObject
+} from "./sigma-global-drag";
+```
+
+- [ ] **Step 4: Update renderer imports and re-exports**
+
+In `sigma-global-renderer.ts`, import:
+
+```ts
+import {
+  createSigmaGlobalHitProjector,
+  sigmaNodeIdFromPayload,
+  sigmaScreenPointFromPayload,
+  type SigmaGlobalHitInput,
+  type SigmaGlobalHitProjector
+} from "./sigma-hit-projector";
+```
+
+Keep direct-source compatibility:
+
+```ts
+export { createSigmaGlobalHitProjector } from "./sigma-hit-projector";
+export type {
+  SigmaGlobalHitInput,
+  SigmaGlobalHitProjector,
+  SigmaGlobalHitProjectorInput
+} from "./sigma-hit-projector";
+```
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add packages/graph-engine/src/render/sigma-hit-projector.ts \
+  packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+git commit -m "refactor(graph): extract sigma hit projector"
+```
+
+## Task 4: Extract Camera Logic
+
+**Files:**
+- Create: `packages/graph-engine/src/render/sigma-global-camera.ts`
+- Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
+
+- [ ] **Step 1: Extend boundary test**
+
+Add `"sigma-global-camera.ts"` to `helperFiles`:
+
+```ts
+const helperFiles = [
+  "sigma-global-types.ts",
+  "sigma-events.ts",
+  "sigma-graphology-model.ts",
+  "sigma-hit-projector.ts",
+  "sigma-global-camera.ts"
+];
+```
+
+- [ ] **Step 2: Run boundary test and verify it fails**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+```
+
+Expected: FAIL because `sigma-global-camera.ts` does not exist yet.
+
+- [ ] **Step 3: Create `sigma-global-camera.ts`**
+
+Create `packages/graph-engine/src/render/sigma-global-camera.ts` by moving these functions out of `sigma-global-renderer.ts`:
+
+```text
+readCameraState
+restoreCameraState
+maybeAnimateSigmaCommunitySpotlightCamera
+moveSigmaCamera
+sigmaCommunitySpotlightCameraState
+sigmaGlobalCameraState
+sigmaGraphPointToCameraPoint
+sigmaCameraDistanceForGraphDistance
+sigmaCommunitySpotlightCenter
+prefersReducedMotion
+finiteNumber
+clamp
+roundNumber
+```
+
+Use these imports:
+
+```ts
+import type { GraphRendererAdapterData } from "./adapter";
+import {
+  sigmaSpotlightCommunityId
+} from "./sigma-graphology-model";
+import type {
+  SigmaGlobalCameraState,
+  SigmaGlobalSigmaLike
+} from "./sigma-global-types";
+```
+
+Export all moved camera functions that `sigma-global-renderer.ts` uses.
+
+- [ ] **Step 4: Update renderer imports**
+
+In `sigma-global-renderer.ts`, import:
+
+```ts
+import {
+  maybeAnimateSigmaCommunitySpotlightCamera,
+  readCameraState,
+  restoreCameraState,
+  sigmaGlobalCameraState,
+  sigmaGraphPointToCameraPoint,
+  prefersReducedMotion
+} from "./sigma-global-camera";
+```
+
+Remove the moved function definitions from `sigma-global-renderer.ts`.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+Expected: all pass, including existing tests for community spotlight camera animation, reduced motion, already-framed community, and reset view.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add packages/graph-engine/src/render/sigma-global-camera.ts \
+  packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+git commit -m "refactor(graph): extract sigma global camera logic"
+```
+
+## Task 5: Extract Wheel Zoom Controller
+
+**Files:**
+- Create: `packages/graph-engine/src/render/sigma-wheel-zoom.ts`
+- Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
+
+- [ ] **Step 1: Extend boundary test**
+
+Add `"sigma-wheel-zoom.ts"` to `helperFiles`:
+
+```ts
+const helperFiles = [
+  "sigma-global-types.ts",
+  "sigma-events.ts",
+  "sigma-graphology-model.ts",
+  "sigma-hit-projector.ts",
+  "sigma-global-camera.ts",
+  "sigma-wheel-zoom.ts"
+];
+```
+
+- [ ] **Step 2: Run boundary test and verify it fails**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+```
+
+Expected: FAIL because `sigma-wheel-zoom.ts` does not exist yet.
+
+- [ ] **Step 3: Create `sigma-wheel-zoom.ts`**
+
+Create `packages/graph-engine/src/render/sigma-wheel-zoom.ts`:
+
+```ts
+import type { GraphScreenPoint } from "./geometry";
+import { preventSigmaDefault } from "./sigma-events";
+import { sigmaWheelZoomRatio, type SigmaWheelDeltaLike } from "./sigma-zoom";
+import type { SigmaGlobalSigmaLike } from "./sigma-global-types";
+
+interface SigmaGlobalWheelPayload {
+  x?: unknown;
+  y?: unknown;
+  delta?: unknown;
+  original?: {
+    deltaY?: unknown;
+    deltaMode?: unknown;
+    target?: unknown;
+  };
+  preventSigmaDefault?: () => void;
+}
+
+export interface SigmaWheelZoomController {
+  destroy(): void;
+}
+
+export interface SigmaWheelZoomControllerInput {
+  sigma: SigmaGlobalSigmaLike;
+  root: HTMLElement;
+  currentRatio: () => number;
+  onZoomAtPoint: (point: GraphScreenPoint, nextRatio: number) => void;
+}
+
+export function bindSigmaWheelZoomController(input: SigmaWheelZoomControllerInput): SigmaWheelZoomController {
+  const captor = input.sigma.getMouseCaptor?.();
+  if (!captor?.on) return { destroy: () => undefined };
+  const listener = (payload?: unknown): void => {
+    const wheel = sigmaWheelInputFromPayload(payload, sigmaViewportCenter(input.root));
+    if (!wheel) return;
+    preventSigmaDefault(payload);
+    if (sigmaWheelTargetIsZoomControl(payload)) return;
+    const nextRatio = sigmaWheelZoomRatio(input.currentRatio(), wheel.delta);
+    input.onZoomAtPoint(wheel.point, nextRatio);
+  };
+  captor.on("wheel", listener);
+  return {
+    destroy() {
+      captor.off?.("wheel", listener);
+    }
+  };
+}
+
+export function sigmaWheelInputFromPayload(payload: unknown, fallbackPoint: GraphScreenPoint): {
+  point: GraphScreenPoint;
+  delta: SigmaWheelDeltaLike;
+} | null {
+  const wheel = payload as SigmaGlobalWheelPayload | null;
+  const originalDeltaY = wheel?.original?.deltaY;
+  const fallbackDelta = wheel?.delta;
+  const deltaY = typeof originalDeltaY === "number"
+    ? originalDeltaY
+    : typeof fallbackDelta === "number"
+      ? -fallbackDelta * 120
+      : null;
+  if (deltaY == null || !Number.isFinite(deltaY)) return null;
+
+  const x = finiteNumber(wheel?.x, Number.NaN);
+  const y = finiteNumber(wheel?.y, Number.NaN);
+  const point = Number.isFinite(x) && Number.isFinite(y) ? { x, y } : fallbackPoint;
+  const originalDeltaMode = wheel?.original?.deltaMode;
+  return {
+    point,
+    delta: {
+      deltaY,
+      deltaMode: typeof originalDeltaMode === "number" ? originalDeltaMode : 0
+    }
+  };
+}
+
+export function sigmaWheelTargetIsZoomControl(payload: unknown): boolean {
+  const wheel = payload as SigmaGlobalWheelPayload | null;
+  const target = wheel?.original?.target as {
+    closest?: (selector: string) => unknown;
+    parentElement?: { closest?: (selector: string) => unknown };
+  } | null | undefined;
+  return Boolean(
+    target?.closest?.("[data-control=\"sigma-zoom\"]") ||
+    target?.parentElement?.closest?.("[data-control=\"sigma-zoom\"]")
+  );
+}
+
+export function sigmaViewportCenter(root: HTMLElement): GraphScreenPoint {
+  const rect = typeof root.getBoundingClientRect === "function" ? root.getBoundingClientRect() : null;
+  const width = finiteNumber(rect?.width, 1000);
+  const height = finiteNumber(rect?.height, 680);
+  return {
+    x: width / 2,
+    y: height / 2
+  };
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+```
+
+- [ ] **Step 4: Update renderer to use controller**
+
+In `sigma-global-renderer.ts`:
+
+1. Replace `sigmaWheelCleanup` with:
+
+```ts
+let sigmaWheelZoomController: { destroy(): void } | null = null;
+```
+
+2. Replace `bindSigmaWheelZoom()` call with:
+
+```ts
+sigmaWheelZoomController = bindSigmaWheelZoomController({
+  sigma,
+  root: sigmaRoot,
+  currentRatio: () => readCameraState(sigma)?.ratio ?? 1,
+  onZoomAtPoint: (point, nextRatio) => zoomSigmaCameraAtViewportPoint(point, nextRatio, false)
+});
+```
+
+3. Replace `unbindSigmaWheelZoom()` call with:
+
+```ts
+sigmaWheelZoomController?.destroy();
+sigmaWheelZoomController = null;
+```
+
+4. Import:
+
+```ts
+import {
+  bindSigmaWheelZoomController,
+  sigmaViewportCenter
+} from "./sigma-wheel-zoom";
+```
+
+5. Remove local `SigmaGlobalWheelPayload`, `bindSigmaWheelZoom`, `unbindSigmaWheelZoom`, `handleSigmaWheelZoom`, `sigmaWheelInputFromPayload`, `sigmaWheelTargetIsZoomControl`, and `sigmaViewportCenter`.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-zoom.test.ts
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+Expected: all pass, including existing wheel zoom tests.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add packages/graph-engine/src/render/sigma-wheel-zoom.ts \
+  packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+git commit -m "refactor(graph): extract sigma wheel zoom controller"
+```
+
+## Task 6: Extract Overlay DOM Controller
+
+**Files:**
+- Create: `packages/graph-engine/src/render/sigma-overlay-dom.ts`
+- Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
+
+- [ ] **Step 1: Extend boundary test**
+
+Add `"sigma-overlay-dom.ts"` to `helperFiles`:
+
+```ts
+const helperFiles = [
+  "sigma-global-types.ts",
+  "sigma-events.ts",
+  "sigma-graphology-model.ts",
+  "sigma-hit-projector.ts",
+  "sigma-global-camera.ts",
+  "sigma-wheel-zoom.ts",
+  "sigma-overlay-dom.ts"
+];
+```
+
+- [ ] **Step 2: Run boundary test and verify it fails**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+```
+
+Expected: FAIL because `sigma-overlay-dom.ts` does not exist yet.
+
+- [ ] **Step 3: Create overlay controller file**
+
+Create `packages/graph-engine/src/render/sigma-overlay-dom.ts` with this exported controller shape:
+
+```ts
+import type { GraphRendererAdapterData } from "./adapter";
+import type { GraphScreenPoint } from "./geometry";
+import type { PinPosition } from "../types";
+import type { SigmaCommunityCloud } from "./community-cloud-geometry";
+import type { SigmaGlobalRenderedObject } from "./sigma-global-drag";
+import type { SigmaGlobalRendererCreateOptions, SigmaGlobalSigmaLike } from "./sigma-global-types";
+
+export interface SigmaOverlayDomController {
+  rebuild(): void;
+  reposition(): void;
+  destroy(): void;
+}
+
+export interface SigmaOverlayDomControllerInput {
+  overlayRoot: HTMLElement;
+  cloudFilterId: string;
+  getAdapterData: () => GraphRendererAdapterData;
+  getSigma: () => SigmaGlobalSigmaLike;
+  getOptions: () => Pick<SigmaGlobalRendererCreateOptions, "viewport" | "viewportSize" | "adapterData">;
+  communityCloudFor: (communityId: string, wash: { cx: number; cy: number; rx: number; ry: number }) => SigmaCommunityCloud;
+  isDestroyed: () => boolean;
+  onHit: (object: SigmaGlobalRenderedObject) => void;
+  beginNodeDrag: (nodeId: string, point: GraphScreenPoint, payload?: unknown) => void;
+  moveNodeDrag: (point: GraphScreenPoint, payload?: unknown) => void;
+  commitNodeDrag: (point: GraphScreenPoint | null, payload?: unknown) => void;
+  cancelNodeDrag: () => void;
+  consumeSuppressedNodeClick: (nodeId: string | null) => boolean;
+  activeNodeDragId: () => string | null;
+}
+```
+
+Then move these existing renderer functions and maps into the new file, adapting them to use `input.getAdapterData()`, `input.getSigma()`, and callbacks:
+
+```text
+overlayRegionEntries
+overlayNodeEntries
+overlayLabelEntries
+rebuildSigmaOverlays
+repositionSigmaOverlays
+createSigmaNodeHitTarget
+pruneOverlayEntries
+overlayBoxFromWorldEllipse
+bindOverlayPointerDragListeners
+bindOverlayMouseDragListeners
+isActiveOverlayDrag
+clearOverlayPointerDragListeners
+```
+
+Keep the same behavior:
+
+- `rebuild()` may call `replaceChildren`.
+- `reposition()` must not call `replaceChildren`.
+- `reposition()` must not create DOM elements.
+- click handlers call `input.onHit(...)`.
+- drag handlers call the passed drag callbacks.
+
+- [ ] **Step 4: Update renderer to use overlay controller**
+
+In `sigma-global-renderer.ts`:
+
+1. Replace the three overlay maps and `overlayPointerDragCleanup` with:
+
+```ts
+let overlayDomController: SigmaOverlayDomController | null = null;
+```
+
+2. After Sigma is created, initialize the controller:
+
+```ts
+overlayDomController = createSigmaOverlayDomController({
+  overlayRoot,
+  cloudFilterId,
+  getAdapterData: () => adapterData,
+  getSigma: () => sigma,
+  getOptions: () => ({ ...options, adapterData }),
+  communityCloudFor: sigmaCommunityCloudFor,
+  isDestroyed: () => destroyed,
+  onHit: (renderedObject) => handleSigmaHit({ renderedObject }),
+  beginNodeDrag,
+  moveNodeDrag,
+  commitNodeDrag,
+  cancelNodeDrag,
+  consumeSuppressedNodeClick,
+  activeNodeDragId: () => activeNodeDrag?.nodeId ?? null
+});
+```
+
+3. Replace calls:
+
+```ts
+rebuildSigmaOverlays();
+repositionSigmaOverlays();
+```
+
+with:
+
+```ts
+overlayDomController?.rebuild();
+overlayDomController?.reposition();
+```
+
+4. On destroy, call:
+
+```ts
+overlayDomController?.destroy();
+overlayDomController = null;
+```
+
+5. Import:
+
+```ts
+import {
+  createSigmaOverlayDomController,
+  type SigmaOverlayDomController
+} from "./sigma-overlay-dom";
+```
+
+6. Remove the moved local functions and maps.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+Expected: all pass, including tests that prove overlay elements are reused on camera updates and data updates.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add packages/graph-engine/src/render/sigma-overlay-dom.ts \
+  packages/graph-engine/src/render/sigma-global-renderer.ts \
+  packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+git commit -m "refactor(graph): extract sigma overlay dom controller"
+```
+
+## Task 7: Final Cleanup And Verification
+
+**Files:**
+- Modify: `packages/graph-engine/src/render/sigma-global-renderer.ts`
+- Modify: `packages/graph-engine/test/sigma-refactor-boundaries.test.ts`
+- Read: `docs/superpowers/specs/2026-06-27-sigma-global-renderer-refactor-design.md`
+
+- [ ] **Step 1: Check renderer no longer owns moved functions**
+
+Run:
+
+```bash
+rg -n "function (readCameraState|restoreCameraState|maybeAnimateSigmaCommunitySpotlightCamera|sigmaWheelInputFromPayload|sigmaWheelTargetIsZoomControl|rebuildSigmaOverlays|repositionSigmaOverlays|buildSigmaGlobalGraphologyGraph|createSigmaGlobalHitProjector)" packages/graph-engine/src/render/sigma-global-renderer.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 2: Check helper modules do not import renderer runtime**
+
+Run:
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Check line count changed materially**
+
+Run:
+
+```bash
+wc -l packages/graph-engine/src/render/sigma-global-renderer.ts
+```
+
+Expected: line count is significantly lower than 1570. Do not fail the task only on a numeric threshold; use it as a sanity check.
+
+- [ ] **Step 4: Run graph-engine full verification**
+
+Run:
+
+```bash
+npm run test -w @llm-wiki/graph-engine
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Run workbench smoke**
+
+Run:
+
+```bash
+npm run dev
+```
+
+Then open the workbench and verify these paths manually:
+
+```text
+1. Open graph global view.
+2. Wheel or trackpad zoom does not jump.
+3. Left-bottom zoom buttons work.
+4. Click a community: still stays in global graph, drawer opens, community is highlighted.
+5. Click return-global: global composition returns.
+6. Drag a node and release: pin behavior still works.
+```
+
+Expected: all paths behave like current main. If browser verification is blocked by port, Chrome, or local data, record the exact blocker in the final response and do not claim browser verification passed.
+
+- [ ] **Step 6: Comment on #77**
+
+Run:
+
+```bash
+gh issue comment 77 --repo sdyckjq-lab/llm-wiki-skill --body "Implemented the Sigma global renderer split from the design spec. Extracted shared Sigma types/events, Graphology render model, hit projector, camera logic, wheel zoom controller, and overlay DOM controller. Verified graph-engine tests/typecheck and browser smoke where available. PR will close this issue after review."
+```
+
+Expected: issue comment is created.
+
+- [ ] **Step 7: Commit final cleanup**
+
+If Step 1-6 changed files, run:
+
+```bash
+git add packages/graph-engine/src/render packages/graph-engine/test
+git commit -m "test(graph): verify sigma renderer refactor boundaries"
+```
+
+If Step 1-6 did not change files, do not create an empty commit.
+
+## Final Self-Review Checklist
+
+- [ ] Spec coverage: every module from the design has a task.
+- [ ] No helper imports `./sigma-global-renderer` at runtime.
+- [ ] New helpers are not exported from `packages/graph-engine/src/render/index.ts`.
+- [ ] `sigma-global-renderer.ts` still exports existing direct-source symbols used by tests.
+- [ ] Existing graph-engine behavior tests pass.
+- [ ] Browser smoke result is recorded honestly.
+- [ ] #77 has an implementation comment.

--- a/docs/superpowers/specs/2026-06-27-sigma-global-renderer-refactor-design.md
+++ b/docs/superpowers/specs/2026-06-27-sigma-global-renderer-refactor-design.md
@@ -1,0 +1,365 @@
+# Sigma Global Renderer 中深度拆分设计
+
+日期：2026-06-27
+状态：已自检，准备进入实施计划
+关联 issue：#77
+后续方向：#79、#80
+
+## 背景
+
+`packages/graph-engine/src/render/sigma-global-renderer.ts` 已经从 PR #66 结束时的约 1065 行增长到 1570 行以上。增长主要来自后续全局 Sigma 功能：
+
+- PR #76：全局社区高亮，引入相机读取、回全图、社区高亮构图动画。
+- PR #78 / #73：平滑 wheel 缩放与左下缩放按钮，引入 wheel 接管、缩放锚点、相机边界。
+- PR #67：覆盖层 rebuild / reposition 双路径，改善相机移动时的 DOM 重建问题。
+
+#77 原建议是继续抽 `sigma-camera.ts`、`sigma-wheel-zoom.ts`、`sigma-overlay-dom.ts`。本设计在这个方向上加深一层：除了相机、缩放、覆盖层，还要把 Graphology 属性映射和 hit projector 拆出去。原因是它们未来也会继续承载标签、边样式、多选、命中优先级等功能，如果继续留在主文件，会成为下一轮膨胀源头。
+
+本次不是大架构重整。更大的“Sigma 全局路线子系统边界文档化”已记录为 #79；更长期的 facade / gesture / controller / renderer 边界收口已记录为 #80。
+
+## 目标
+
+本次目标是把 `sigma-global-renderer.ts` 从“大杂烩”收束成 Sigma 全局图的装配入口。
+
+完成后它仍负责：
+
+- Sigma runtime 懒加载入口。
+- `createSigmaGlobalRenderer` 生命周期。
+- 对外 `SigmaGlobalRenderer` 接口。
+- update / destroy / reset / zoom 的流程编排。
+- 当前活状态串联，例如 `adapterData`、`graph`、`pins`、drag session、destroy guard、generation guard。
+- 统一错误上报。
+
+它不再长期承载：
+
+- 相机算法和社区高亮构图计算。
+- wheel payload 解析与 wheel 监听细节。
+- overlay DOM 元素表、rebuild / reposition 细节。
+- Graphology 节点/边/社区/聚合属性映射。
+- hit projector 和 Sigma event payload 解析。
+
+## 非目标
+
+- 不改变用户可见行为。
+- 不改变 workbench / facade 调用的公开入口。
+- 不重写 facade、controller、gestures 或图谱七层架构。
+- 不新增 npm 依赖。
+- 不重选渲染技术。
+- 不把社区阅读视图迁移到 Sigma。
+- 不顺手修复 #70、#74、#75、#71、#72；这些后续按各自 issue 处理。
+
+## 模块拆分
+
+### 1. `sigma-global-camera.ts`
+
+负责 Sigma 全局相机相关逻辑：
+
+- 读取和恢复相机状态。
+- 回全图相机目标。
+- 社区高亮相机构图目标。
+- 相机移动执行。
+- `prefers-reduced-motion` 降级。
+- graph point 到 camera point 的投影兜底。
+
+后续 #75 的相机动画性能优化，优先落在这个模块。
+
+### 2. `sigma-wheel-zoom.ts`
+
+负责把 Sigma wheel 输入变成项目自己的缩放动作：
+
+- wheel payload 解析。
+- 缺失 pointer 坐标时的视口中心 fallback。
+- 缩放控件区域防误触。
+- mouse captor wheel 监听绑定与解绑。
+- 调用传入的 `onZoomAtPoint` 回调。
+
+现有 `sigma-zoom.ts` 继续只保存纯缩放数学，例如 wheel delta 标准化、ratio 计算、边界常量、按钮步长。`sigma-wheel-zoom.ts` 不重复这些数学，只负责事件接管。
+
+### 3. `sigma-overlay-dom.ts`
+
+负责 Sigma 覆盖层 DOM controller：
+
+- 管理社区云团 region、节点 hit target、社区标签三类元素表。
+- `rebuild()`：按数据更新元素结构、dataset、文本、颜色和监听。
+- `reposition()`：只更新位置和云团几何，不创建 DOM、不 replace children、不重绑监听。
+- 节点 hit target 创建。
+- overlay 元素 prune。
+- `destroy()`：清理内部元素表。
+
+它可以持有 overlay 元素表，因为这是它自己的 DOM 生命周期状态；但不持有业务真相，不写 graph，不写 pins，不直接调用 host callbacks。
+
+现有 `sigma-overlay-svg.ts` 保持为更底层的 SVG / DOM 工厂；`sigma-overlay-dom.ts` 负责“什么时候创建、什么时候移动、什么时候销毁”。
+
+### 4. `sigma-graphology-model.ts`
+
+负责把 `GraphRendererAdapterData` 转成 Graphology 渲染模型：
+
+- `buildSigmaGlobalGraphologyGraph`
+- Graphology node / edge / community / aggregation attributes
+- edge style
+- selected / spotlight community helper
+- same-structure patch 判断
+- patch graph attributes
+- node size / node color / rgba helper 等渲染模型函数
+
+这个模块不碰 DOM、不碰 Sigma 实例、不知道抽屉、不处理事件。后续标签截断、边样式、高亮规则等应优先落在这里。
+
+### 5. `sigma-hit-projector.ts`
+
+负责把渲染命中翻译成图谱语义对象：
+
+- `createSigmaGlobalHitProjector`
+- Sigma node id payload 解析
+- Sigma screen point payload 解析
+- spatial index input from adapter data
+- rendered object 到 `GraphGestureTarget` 的投射
+- 空白 / node / community wash / aggregation 等命中优先级
+
+它只做翻译，不拥有选择语义。主文件收到 hit target 后再调用 `onHitTarget`。
+
+### 6. `sigma-events.ts`
+
+这是轻量支撑文件，不是新的业务子系统。它只放多个模块都会用到的 Sigma event payload 防御工具，避免 wheel、hit、drag 之间互相 import：
+
+- `preventSigmaDefault`
+- Sigma pointer event payload 类型
+- 其他无业务语义、无状态、仅用于解包事件 payload 的工具
+
+它不做 hit 判断，不做 wheel 缩放，不做选择语义。
+
+### 7. 继续沿用的既有 helper
+
+- `sigma-zoom.ts`：纯缩放数学。
+- `sigma-global-drag.ts`：拖拽会话、overlay pointer/mouse 拖拽绑定、拖拽后的 adapter data 更新。
+- `sigma-coordinates.ts`：Sigma 与 fallback 坐标转换。
+- `community-cloud-geometry.ts`：云团几何与 hull。
+- `sigma-overlay-svg.ts`：SVG / DOM 基础工厂。
+
+## 模块通信
+
+### 主文件持有活状态
+
+`sigma-global-renderer.ts` 继续持有高频变化的状态：
+
+- 当前 `adapterData`
+- 当前 Graphology `graph`
+- 当前 theme / edge style
+- 当前 pins
+- 当前 drag session
+- destroyed flag
+- generation guard
+- 当前 overlay controller / wheel controller cleanup
+
+子模块不偷偷复制这些业务状态。需要最新数据时，通过函数参数或 getter 读取。
+
+### 纯模型模块无副作用
+
+`sigma-graphology-model.ts` 输入 adapter data、theme、edge style，输出 graph 或 patch。它不关心 DOM 与 Sigma lifecycle。
+
+### 相机模块只处理相机
+
+`sigma-global-camera.ts` 输入 Sigma 实例、adapter data、root/window，输出或应用相机状态。它不决定哪个社区被选中；社区 id 由主文件从 adapter data 推导后传入。
+
+### wheel 模块只管事件接管
+
+`sigma-wheel-zoom.ts` 创建时传入：
+
+- Sigma-like 实例。
+- root element。
+- `onZoomAtPoint(point, target, animated)` 回调。
+- fatal error 回调。
+
+它负责监听和解绑，不直接保存业务选择，不直接更新 overlay。
+
+### overlay 模块只管覆盖层 DOM
+
+`sigma-overlay-dom.ts` 创建时传入：
+
+- overlay root。
+- filter id。
+- 获取当前 adapter data / cloud basis / Sigma / options 的函数。
+- hit 回调。
+- drag begin/move/end/cancel 回调。
+- 点击抑制回调。
+
+它暴露：
+
+- `rebuild()`
+- `reposition()`
+- `destroy()`
+
+它内部可以复用元素表，但不写 graph / pins / adapter data。
+
+### 避免运行时循环依赖
+
+允许 `import type` 引用，但要避免 helper 运行时反向 import 主文件。若 `sigma-global-renderer.ts` 里的 Sigma-like 类型导致 helper 必须反向依赖主文件，则把这些类型抽到轻量类型文件，例如 `sigma-global-types.ts`。
+
+类型和事件工具的约束：
+
+- `sigma-global-types.ts` 只放类型，不放运行时代码。
+- `sigma-events.ts` 只放无状态事件解包工具，不 import camera / wheel / overlay / graphology / hit projector。
+- 新 helper 默认不从 `render/index.ts` 对外导出；测试可以从 `src/render/...` 直接 import。
+- workbench 和 facade 仍然只能通过现有 `createSigmaGlobalRenderer` 入口使用 Sigma 全局渲染器。
+
+## 实施顺序
+
+实现开始前先从当前主线创建代码分支，建议命名为 `codex/refactor-sigma-global-renderer-boundaries`。本文档提交本身是纯文档提交，不代表可以在 `main` 上继续改代码。
+
+### Step 1：抽纯模型
+
+新建：
+
+- `sigma-graphology-model.ts`
+- `sigma-hit-projector.ts`
+- 必要时新建 `sigma-global-types.ts` 和 `sigma-events.ts`
+
+把 Graphology 构建、属性映射、edge style、hit projector、payload 解析先搬出去。这个阶段最接近纯搬迁，风险最低。
+
+验证：
+
+- `node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts`
+- `npm run typecheck -w @llm-wiki/graph-engine`
+
+### Step 2：抽相机与 wheel controller
+
+新建：
+
+- `sigma-global-camera.ts`
+- `sigma-wheel-zoom.ts`
+
+保留现有缩放手感和社区高亮相机行为。`sigma-zoom.ts` 继续保存纯数学。
+
+验证重点：
+
+- wheel 连续缩放仍按 deltaY 工作。
+- 缩放控件区域不误触。
+- `zoomIn` / `zoomOut` 仍按中心点缩放。
+- 社区高亮相机动画仍按现状运行。
+- 减少动态效果仍直接 setState。
+
+### Step 3：抽 overlay controller
+
+新建：
+
+- `sigma-overlay-dom.ts`
+
+把 rebuild / reposition、元素表、节点 hit target 创建和 prune 移出主文件。保留现有双路径不变量：
+
+- rebuild 是元素生命周期唯一权威。
+- reposition 只读结构，只更新位置和云团几何。
+- 相机移动不 replace children、不 create element、不重绑监听。
+- drag 过程继续由 Sigma refresh / afterRender 驱动 reposition。
+- drag commit / cancel 继续通过 rebuild 刷新 dataset 和 pin 状态。
+
+验证重点：
+
+- camera update 不重建 overlay DOM。
+- data update 复用可复用元素并 prune stale 元素。
+- 点击社区云团仍触发社区 hit。
+- 节点 hit target 点击仍触发 node hit。
+- overlay 节点拖拽仍写入 pin。
+- destroy 后清理内部引用。
+
+### Step 4：收尾整理
+
+- 清理临时重复 helper。
+- 检查循环依赖。
+- 检查主文件职责是否收束成生命周期编排。
+- 更新 #77 评论，说明实际拆分边界与验证结果。
+- 若全程纯重构且行为未变，不更新 README / CHANGELOG。
+- 若实施过程中出现行为调整或公开能力变化，按仓库规则更新文档。
+
+## 测试计划
+
+### 每步局部验证
+
+每个 step 完成后至少运行：
+
+```bash
+node --import tsx --test packages/graph-engine/test/sigma-global-renderer.test.ts
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+### 最终自动验证
+
+最终必须运行：
+
+```bash
+npm run test -w @llm-wiki/graph-engine
+npm run typecheck -w @llm-wiki/graph-engine
+```
+
+如实现过程中新增独立测试文件，推荐命名：
+
+- `sigma-graphology-model.test.ts`
+- `sigma-global-camera.test.ts`
+- `sigma-wheel-zoom.test.ts`
+- `sigma-overlay-dom.test.ts`
+
+若某个模块继续依赖 fake Sigma runtime 或 fake DOM 基础设施，也可以暂时把测试留在 `sigma-global-renderer.test.ts`，但测试名称必须写清楚模块边界。
+
+### 浏览器验证
+
+因为这是全局图交互地基，最终还需要启动工作台实际验证：
+
+- 打开全局图。
+- wheel / trackpad 缩放不猛跳。
+- 左下缩放按钮可用。
+- 点击社区后仍停留全局图，社区高亮和抽屉同步。
+- 回全图恢复普通全局构图。
+- 节点拖拽后 pin 仍生效。
+- 切换主题或更新选择时没有明显破坏。
+
+若浏览器验证因端口、Chrome、环境等原因不能运行，最终汇报必须明确说明。
+
+## 完成标准
+
+本任务完成时必须同时满足：
+
+- `sigma-global-renderer.ts` 主要保留生命周期和流程编排。
+- 新增模块的责任单一、命名清楚、后续功能有明确落点。
+- 新增 helper 没有运行时循环依赖。
+- 新增 helper 没有扩大公开 API。
+- 用户可见行为不变。
+- graph-engine 全量测试通过。
+- graph-engine 类型检查通过。
+- 浏览器关键路径验证通过，或明确记录无法验证的环境原因。
+- #77 可关闭，并有评论说明拆分内容与验证结果。
+
+## 风险与应对
+
+### 风险 1：跨文件循环依赖
+
+应对：优先用 `import type`；必要时抽 `sigma-global-types.ts`。不让 helper 运行时反向依赖主文件。
+
+### 风险 2：overlay controller 与拖拽耦合深
+
+应对：overlay 放在第三步，前两步稳定后再动；沿用现有测试，新增针对 overlay 元素复用、点击、拖拽的边界测试。
+
+### 风险 3：纯搬迁时误改行为
+
+应对：每步小提交；每步跑局部测试和类型检查；最终跑全量测试和浏览器验证。
+
+### 风险 4：主文件行数下降但边界仍不清
+
+应对：完成标准不只看行数。主文件应读起来像装配入口；Graphology model、camera、wheel、overlay、hit projector 都要有清晰落点。
+
+## 与后续 issue 的关系
+
+- #77：本次实施目标。
+- #79：在本次拆分后，进一步文档化 Sigma 全局路线的子系统边界和测试分层。
+- #80：更长期的图谱渲染层重整，不阻塞本次任务。
+- #75：后续相机动画性能优化，预计受益于 `sigma-global-camera.ts` 和 `sigma-overlay-dom.ts`。
+- #74 / #71：多选与 shift 行为，后续应受益于更清楚的 hit projector / renderer 边界。
+- #70：标签长度兜底，后续应优先落在 `sigma-graphology-model.ts` 或更专门的标签模块中。
+
+## 自检结论
+
+已按“方便后续写 plan”的标准复核：
+
+- 范围清楚：本次只做 #77 的中深度拆分，不吞并 #79 / #80。
+- 模块落点清楚：相机、wheel、overlay、Graphology model、hit projector 分工明确。
+- 共享事件工具已单独收口，避免 wheel 与 hit projector 互相依赖。
+- 实施顺序清楚：先纯模型，再相机和 wheel，最后 overlay，最后收尾。
+- 验证门槛清楚：每步局部测试，最终 graph-engine 全量测试、类型检查和浏览器关键路径验证。
+- 分支边界清楚：后续代码实现需要先开 `codex/` 分支。

--- a/packages/graph-engine/src/render/community-cloud-geometry.ts
+++ b/packages/graph-engine/src/render/community-cloud-geometry.ts
@@ -1,7 +1,7 @@
 import type { GraphRendererAdapterData } from "./adapter";
 import type { GraphScreenPoint } from "./geometry";
 import { sigmaWorldPointToScreenPoint } from "./sigma-coordinates";
-import type { SigmaGlobalRendererCreateOptions, SigmaGlobalSigmaLike } from "./sigma-global-renderer";
+import type { SigmaGlobalRendererCreateOptions, SigmaGlobalSigmaLike } from "./sigma-global-types";
 
 export interface SigmaCommunityCloud {
   box: { left: number; top: number; width: number; height: number };

--- a/packages/graph-engine/src/render/sigma-coordinates.ts
+++ b/packages/graph-engine/src/render/sigma-coordinates.ts
@@ -1,6 +1,6 @@
 import { rootClientPointToScreenPoint, screenPointToWorldPoint, worldPointToCssPercentPoint, type GraphScreenPoint } from "./geometry";
 import { DEFAULT_RENDERER_VIEWPORT } from "./viewport";
-import type { SigmaGlobalRendererCreateOptions, SigmaGlobalSigmaLike } from "./sigma-global-renderer";
+import type { SigmaGlobalRendererCreateOptions, SigmaGlobalSigmaLike } from "./sigma-global-types";
 
 export function overlayPointerScreenPoint(event: MouseEvent | PointerEvent, root: HTMLElement): GraphScreenPoint {
   return rootClientPointToScreenPoint({

--- a/packages/graph-engine/src/render/sigma-events.ts
+++ b/packages/graph-engine/src/render/sigma-events.ts
@@ -1,0 +1,14 @@
+export interface SigmaGlobalPointerEventPayload {
+  node?: unknown;
+  event?: { x?: unknown; y?: unknown; preventSigmaDefault?: () => void };
+  x?: unknown;
+  y?: unknown;
+  preventSigmaDefault?: () => void;
+}
+
+export function preventSigmaDefault(payload: unknown): void {
+  const eventPayload = payload as SigmaGlobalPointerEventPayload | null;
+  eventPayload?.preventSigmaDefault?.();
+  eventPayload?.event?.preventSigmaDefault?.();
+  if (payload instanceof Event) payload.preventDefault();
+}

--- a/packages/graph-engine/src/render/sigma-global-camera.ts
+++ b/packages/graph-engine/src/render/sigma-global-camera.ts
@@ -1,0 +1,162 @@
+import type { GraphRendererAdapterData } from "./adapter";
+import type {
+  SigmaGlobalCameraState,
+  SigmaGlobalSigmaLike
+} from "./sigma-global-types";
+
+export function readCameraState(sigma: SigmaGlobalSigmaLike): SigmaGlobalCameraState | null {
+  const state = sigma.getCamera?.().getState?.();
+  if (!state) return null;
+  return {
+    x: finiteNumber(state.x, 0),
+    y: finiteNumber(state.y, 0),
+    angle: finiteNumber(state.angle, 0),
+    ratio: finiteNumber(state.ratio, 1)
+  };
+}
+
+export function restoreCameraState(sigma: SigmaGlobalSigmaLike, state: SigmaGlobalCameraState | null): void {
+  if (!state) return;
+  sigma.getCamera?.().setState?.(state);
+}
+
+export function maybeAnimateSigmaCommunitySpotlightCamera(
+  sigma: SigmaGlobalSigmaLike,
+  root: HTMLElement,
+  adapterData: GraphRendererAdapterData,
+  communityId: string | null,
+  previousCommunityId: string | null
+): string | null {
+  if (!communityId) return null;
+  if (communityId === previousCommunityId) return communityId;
+  const target = sigmaCommunitySpotlightCameraState(sigma, adapterData, communityId);
+  if (!target) return communityId;
+  moveSigmaCamera(sigma, target, prefersReducedMotion(root.ownerDocument.defaultView));
+  return communityId;
+}
+
+export function moveSigmaCamera(
+  sigma: SigmaGlobalSigmaLike,
+  target: Partial<SigmaGlobalCameraState>,
+  reducedMotion: boolean
+): void {
+  const camera = sigma.getCamera?.();
+  if (!camera) return;
+  if (reducedMotion || !camera.animate) {
+    camera.setState?.(target);
+    return;
+  }
+  void camera.animate(target, { duration: 380, easing: "quadraticInOut" });
+}
+
+export function sigmaCommunitySpotlightCameraState(
+  sigma: SigmaGlobalSigmaLike,
+  adapterData: GraphRendererAdapterData,
+  communityId: string
+): Partial<SigmaGlobalCameraState> | null {
+  const current = readCameraState(sigma) ?? { x: 0, y: 0, angle: 0, ratio: 1 };
+  const center = sigmaCommunitySpotlightCenter(adapterData, communityId);
+  if (!center) return null;
+  const bounds = adapterData.renderable.worldBounds;
+  const worldWidth = Math.max(0, finiteNumber(bounds.maxX, center.x) - finiteNumber(bounds.minX, center.x));
+  const drawerOffset = worldWidth * 0.08;
+  const graphTargetPoint = { x: center.x + drawerOffset, y: center.y };
+  const targetPoint = sigmaGraphPointToCameraPoint(sigma, graphTargetPoint);
+  const targetX = roundNumber(targetPoint.x, 3);
+  const targetY = roundNumber(targetPoint.y, 3);
+  const settledThreshold = sigmaCameraDistanceForGraphDistance(sigma, graphTargetPoint, Math.max(worldWidth * 0.015, 4));
+  const positionSettled = Math.abs(current.x - targetX) <= settledThreshold
+    && Math.abs(current.y - targetY) <= settledThreshold;
+  const target = {
+    x: targetX,
+    y: targetY,
+    angle: current.angle,
+    ratio: positionSettled || current.ratio <= 0.9
+      ? current.ratio
+      : roundNumber(clamp(current.ratio * 0.92, 0.72, current.ratio), 3)
+  };
+  const settled = positionSettled
+    && Math.abs(current.ratio - target.ratio) <= 0.025;
+  return settled ? null : target;
+}
+
+export function sigmaGlobalCameraState(
+  sigma: SigmaGlobalSigmaLike,
+  adapterData: GraphRendererAdapterData
+): Partial<SigmaGlobalCameraState> {
+  const bounds = adapterData.renderable.worldBounds;
+  const center = sigmaGraphPointToCameraPoint(sigma, {
+    x: (finiteNumber(bounds.minX, 0) + finiteNumber(bounds.maxX, 0)) / 2,
+    y: (finiteNumber(bounds.minY, 0) + finiteNumber(bounds.maxY, 0)) / 2
+  });
+  return {
+    x: roundNumber(center.x, 3),
+    y: roundNumber(center.y, 3),
+    angle: 0,
+    ratio: 1
+  };
+}
+
+export function sigmaGraphPointToCameraPoint(
+  sigma: SigmaGlobalSigmaLike,
+  point: { x: number; y: number }
+): { x: number; y: number } {
+  const viewportPoint = sigma.graphToViewport?.(point);
+  if (viewportPoint && (!Number.isFinite(viewportPoint.x) || !Number.isFinite(viewportPoint.y))) {
+    return point;
+  }
+  const cameraPoint = viewportPoint ? sigma.viewportToFramedGraph?.(viewportPoint) : null;
+  if (cameraPoint && Number.isFinite(cameraPoint.x) && Number.isFinite(cameraPoint.y)) {
+    return cameraPoint;
+  }
+  return point;
+}
+
+export function sigmaCameraDistanceForGraphDistance(
+  sigma: SigmaGlobalSigmaLike,
+  point: { x: number; y: number },
+  graphDistance: number
+): number {
+  if (graphDistance <= 0) return 0;
+  const base = sigmaGraphPointToCameraPoint(sigma, point);
+  const shifted = sigmaGraphPointToCameraPoint(sigma, { x: point.x + graphDistance, y: point.y });
+  const distance = Math.abs(shifted.x - base.x);
+  return Number.isFinite(distance) && distance > 0 ? distance : graphDistance;
+}
+
+export function sigmaCommunitySpotlightCenter(
+  adapterData: GraphRendererAdapterData,
+  communityId: string
+): { x: number; y: number } | null {
+  const renderableCommunity = adapterData.renderable.communities.find((community) => community.id === communityId);
+  if (renderableCommunity?.wash) {
+    return {
+      x: finiteNumber(renderableCommunity.wash.cx, 0),
+      y: finiteNumber(renderableCommunity.wash.cy, 0)
+    };
+  }
+  const nodes = adapterData.nodes.filter((node) => node.communityId === communityId);
+  if (nodes.length === 0) return null;
+  const sum = nodes.reduce((acc, node) => ({
+    x: acc.x + finiteNumber(node.point.x, 0),
+    y: acc.y + finiteNumber(node.point.y, 0)
+  }), { x: 0, y: 0 });
+  return { x: sum.x / nodes.length, y: sum.y / nodes.length };
+}
+
+export function prefersReducedMotion(view: Window | null | undefined): boolean {
+  return Boolean(view?.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function roundNumber(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}

--- a/packages/graph-engine/src/render/sigma-global-drag.ts
+++ b/packages/graph-engine/src/render/sigma-global-drag.ts
@@ -198,21 +198,3 @@ function sigmaAdapterNodeWithPoint(
     }
   };
 }
-
-export function sigmaCommunityLabels(adapterData: GraphRendererAdapterData, limit: number): GraphRendererAdapterData["renderable"]["communities"] {
-  const selectedCommunityIds = new Set(adapterData.communities.filter((community) => community.selected).map((community) => community.id));
-  return adapterData.renderable.communities
-    .filter((community) => community.wash)
-    .map((community, index) => ({
-      community,
-      index,
-      selected: selectedCommunityIds.has(community.id)
-    }))
-    .sort((left, right) => {
-      if (left.selected !== right.selected) return left.selected ? -1 : 1;
-      if (left.community.nodeCount !== right.community.nodeCount) return right.community.nodeCount - left.community.nodeCount;
-      return left.index - right.index;
-    })
-    .slice(0, limit)
-    .map((candidate) => candidate.community);
-}

--- a/packages/graph-engine/src/render/sigma-global-drag.ts
+++ b/packages/graph-engine/src/render/sigma-global-drag.ts
@@ -1,13 +1,6 @@
 import type { PinPosition } from "../types";
 import type { GraphRendererAdapterData, GraphRendererAdapterNode } from "./adapter";
 import type { GraphScreenPoint } from "./geometry";
-import type { GraphGestureTarget } from "./gestures";
-
-export type SigmaGlobalRenderedObject =
-  | { kind: "node"; id: string }
-  | { kind: "edge"; id: string }
-  | { kind: "community-wash"; id: string }
-  | { kind: "aggregation-container"; id: string; communityId?: string | null };
 
 export const SIGMA_GLOBAL_NODE_DRAG_START_THRESHOLD = 2;
 
@@ -222,25 +215,4 @@ export function sigmaCommunityLabels(adapterData: GraphRendererAdapterData, limi
     })
     .slice(0, limit)
     .map((candidate) => candidate.community);
-}
-
-export function gestureTargetFromSigmaRenderedObject(
-  object: SigmaGlobalRenderedObject,
-  adapterData: GraphRendererAdapterData
-): GraphGestureTarget | null {
-  switch (object.kind) {
-    case "node":
-      return adapterData.nodes.some((node) => node.id === object.id) ? { kind: "node", id: object.id } : null;
-    case "edge":
-      return adapterData.edges.some((edge) => edge.id === object.id) ? { kind: "edge", id: object.id } : null;
-    case "community-wash":
-      return adapterData.communities.some((community) => community.id === object.id) ? { kind: "community-wash", id: object.id } : null;
-    case "aggregation-container": {
-      const aggregation = adapterData.aggregations.find((item) => item.id === object.id);
-      if (!aggregation) return null;
-      return { kind: "aggregation-container", id: object.id, communityId: object.communityId ?? aggregation.communityId };
-    }
-    default:
-      return null;
-  }
 }

--- a/packages/graph-engine/src/render/sigma-global-renderer.ts
+++ b/packages/graph-engine/src/render/sigma-global-renderer.ts
@@ -1,15 +1,8 @@
 import type { PinMap, PinPosition, ThemeId } from "../types";
-import type {
-  GraphRendererAdapterData,
-  GraphRendererAdapterNode
-} from "./adapter";
 import {
-  bindSigmaGlobalOverlayMouseDrag,
-  bindSigmaGlobalOverlayPointerDrag,
   createSigmaGlobalNodeDragSession,
   moveSigmaGlobalNodeDragSession,
   sigmaAdapterDataWithNodePoint,
-  sigmaCommunityLabels,
   type SigmaGlobalNodeDragSession
 } from "./sigma-global-drag";
 import type { GraphScreenPoint } from "./geometry";
@@ -25,16 +18,9 @@ import {
   type SigmaCommunityCloud
 } from "./community-cloud-geometry";
 import {
-  applyOverlayBox,
-  applySigmaCloudColor,
-  applySigmaCloudGeometry,
-  createSigmaCloudSvg,
   createSigmaOverlayRoot,
   nextSigmaCloudFilterSequence,
-  sigmaOverlayButton,
-  sigmaOverlayPassiveElement,
-  sigmaSharedCloudFilterDef,
-  type SigmaCloudKind
+  sigmaSharedCloudFilterDef
 } from "./sigma-overlay-svg";
 import {
   SIGMA_BUTTON_ZOOM_DURATION_MS,
@@ -59,11 +45,7 @@ import {
   buildSigmaGlobalGraphologyGraph,
   canPatchSigmaGlobalGraphAttributes,
   patchSigmaGlobalGraphAttributes,
-  sigmaGlobalNodeSize,
-  sigmaGlobalNodeSpotlightState,
-  sigmaSelectedCommunityIds,
-  sigmaSpotlightCommunityId,
-  sigmaSpotlightCommunityIds
+  sigmaSpotlightCommunityId
 } from "./sigma-graphology-model";
 import {
   createSigmaGlobalHitProjector,
@@ -84,6 +66,10 @@ import {
   sigmaViewportCenter,
   type SigmaWheelZoomController
 } from "./sigma-wheel-zoom";
+import {
+  createSigmaOverlayDomController,
+  type SigmaOverlayDomController
+} from "./sigma-overlay-dom";
 
 export type {
   SigmaGlobalCameraState,
@@ -113,9 +99,6 @@ export type {
 export const SIGMA_GLOBAL_RENDERER_ID = "sigma-global" as const;
 
 export const SIGMA_GLOBAL_RENDERER_ROUTE_MANAGER_OWNER = "facade" as const;
-
-const SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT = 8;
-const SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT = 160;
 
 export const SIGMA_GLOBAL_RENDERER_BUNDLE_BOUNDARY = {
   sigma: "runtime-loaded-by-sigma-global-renderer",
@@ -176,20 +159,32 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
   let currentPins: PinMap = { ...(options.pins ?? {}) };
   let cameraSpotlightCommunityId: string | null = sigmaSpotlightCommunityId(adapterData);
   let suppressNextNodeClickId: string | null = null;
-  let overlayPointerDragCleanup: (() => void) | null = null;
+  let overlayDomController: SigmaOverlayDomController | null = null;
   let sigmaWheelZoomController: SigmaWheelZoomController | null = null;
   let eventBindings: Array<{ event: string; listener: (payload?: unknown) => void }> = [];
   let resizeObserver: ResizeObserver | null = null;
   let resizeAnimationFrame: number | null = null;
   let lastObservedRootSize: RendererViewportSize | null = null;
-  // 覆盖层元素按 id 复用：rebuild 维护这三张表（增删元素、绑监听一次），
-  // reposition 只读它们更新位置，相机移动时不重建 DOM。
-  const overlayRegionEntries = new Map<string, { element: HTMLElement; shape: SVGElement; kind: SigmaCloudKind }>();
-  const overlayNodeEntries = new Map<string, HTMLButtonElement>();
-  const overlayLabelEntries = new Map<string, HTMLElement>();
 
   try {
     sigma = new runtime.Sigma(graph, sigmaRoot, sigmaSettingsForTheme(currentTheme));
+    overlayDomController = createSigmaOverlayDomController({
+      overlayRoot,
+      cloudFilterId,
+      getAdapterData: () => adapterData,
+      getSigma: () => sigma,
+      getOptions: () => ({ ...options, adapterData }),
+      communityCloudFor: sigmaCommunityCloudFor,
+      isDestroyed: () => destroyed,
+      onHit: (renderedObject) => handleSigmaHit({ renderedObject }),
+      beginNodeDrag,
+      moveNodeDrag,
+      commitNodeDrag,
+      cancelNodeDrag,
+      screenPointFromEvent: (event) => overlayPointerScreenPoint(event, sigmaRoot),
+      consumeSuppressedNodeClick,
+      activeNodeDragId: () => activeNodeDrag?.nodeId ?? null
+    });
     sigmaWheelZoomController = bindSigmaWheelZoomController({
       sigma,
       root: sigmaRoot,
@@ -200,7 +195,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     });
     bindSigmaEvents();
     bindSigmaResizeObserver();
-    rebuildSigmaOverlays();
+    overlayDomController.rebuild();
   } catch (error) {
     options.onFatalError?.(error);
     sigmaRoot.remove();
@@ -244,7 +239,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
         try {
           restoreCameraState(sigma, cameraState);
           sigma.refresh?.();
-          rebuildSigmaOverlays();
+          overlayDomController?.rebuild();
           cameraSpotlightCommunityId = maybeAnimateSigmaCommunitySpotlightCamera(
             sigma,
             sigmaRoot,
@@ -305,6 +300,8 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       generation += 1;
       sigmaWheelZoomController?.destroy();
       sigmaWheelZoomController = null;
+      overlayDomController?.destroy();
+      overlayDomController = null;
       unbindSigmaEvents();
       cancelScheduledResizeRefresh();
       resizeObserver?.disconnect();
@@ -315,9 +312,6 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
         options.onFatalError?.(error);
       }
       sigmaRoot.remove();
-      overlayRegionEntries.clear();
-      overlayNodeEntries.clear();
-      overlayLabelEntries.clear();
     }
   };
 
@@ -330,7 +324,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       handleSigmaHit({ nodeId });
     };
     const stageClick = (payload?: unknown): void => handleSigmaHit({ screenPoint: sigmaScreenPointFromPayload(payload) });
-    const cameraUpdated = (): void => repositionSigmaOverlays();
+    const cameraUpdated = (): void => overlayDomController?.reposition();
     const nodeDown = (payload?: unknown): void => beginNodeDrag(sigmaNodeIdFromPayload(payload), sigmaScreenPointFromPayload(payload), payload);
     const nodeMove = (payload?: unknown): void => moveNodeDrag(sigmaScreenPointFromPayload(payload), payload);
     const nodeUp = (payload?: unknown): void => commitNodeDrag(sigmaScreenPointFromPayload(payload), payload);
@@ -401,7 +395,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       try {
         if (destroyed) return;
         sigma.refresh?.();
-        repositionSigmaOverlays();
+        overlayDomController?.reposition();
       } catch (error) {
         options.onFatalError?.(error);
       }
@@ -482,7 +476,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     if (!drag || destroyed) return;
     preventSigmaDefault(payload);
     if (screenPoint) moveNodeDrag(screenPoint, payload);
-    clearOverlayPointerDragListeners();
+    overlayDomController?.clearActiveDragListeners();
     restoreNodeDragCamera(drag);
     activeNodeDrag = null;
     delete sigmaRoot.dataset.draggingNodeId;
@@ -507,7 +501,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
   function cancelNodeDrag(): void {
     const drag = activeNodeDrag;
     if (!drag) return;
-    clearOverlayPointerDragListeners();
+    overlayDomController?.clearActiveDragListeners();
     restoreNodeDragCamera(drag);
     activeNodeDrag = null;
     delete sigmaRoot.dataset.draggingNodeId;
@@ -534,7 +528,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       cloudBasisByCommunityId = sigmaCommunityCloudBasisByIdWithNodePoint(cloudBasisByCommunityId, adapterData, nodeId);
       // 拖拽提交/取消是终态数据变化（pin 状态、永久坐标），走 rebuild 刷新 dataset 等属性；
       // 拖拽过程中的每帧位置更新由 afterRender → reposition 负责。
-      rebuildSigmaOverlays();
+      overlayDomController?.rebuild();
     }
   }
 
@@ -561,170 +555,12 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     return true;
   }
 
-  // 结构更新：仅在数据/选中变化时调用。按 id 复用元素、绑监听一次、写数据态属性，
-  // 最后调用 reposition 完成定位（定位逻辑只存在于 reposition，避免两条路径分叉）。
-  function rebuildSigmaOverlays(): void {
-    if (destroyed) return;
-    const ordered: HTMLElement[] = [];
-    const selectedCommunityIds = sigmaSelectedCommunityIds(adapterData);
-    const spotlightCommunityIds = sigmaSpotlightCommunityIds(adapterData);
-
-    const nextRegionIds = new Set<string>();
-    for (const community of adapterData.renderable.communities) {
-      if (!community.wash) continue;
-      nextRegionIds.add(community.id);
-      const cloud = sigmaCommunityCloudFor(community.id, community.wash);
-      const kind: SigmaCloudKind = cloud.localPoints ? "polygon" : "ellipse";
-      let entry = overlayRegionEntries.get(community.id);
-      if (!entry || entry.kind !== kind) {
-        const element = sigmaOverlayPassiveElement(overlayRoot.ownerDocument, "community-region", community.id);
-        element.className = "sigma-global-community-region";
-        element.dataset.communityId = community.id;
-        element.style.overflow = "visible";
-        const handle = createSigmaCloudSvg(overlayRoot.ownerDocument, cloud, cloudFilterId, () => {
-          handleSigmaHit({ renderedObject: { kind: "community-wash", id: community.id } });
-        });
-        element.append(handle.svg);
-        entry = { element, shape: handle.shape, kind: handle.kind };
-        overlayRegionEntries.set(community.id, entry);
-      }
-      const selected = selectedCommunityIds.has(community.id);
-      const dim = selectedCommunityIds.size > 0 && !selected;
-      entry.element.dataset.selected = selected ? "true" : "false";
-      applySigmaCloudColor(entry.shape, community.color, dim);
-      ordered.push(entry.element);
-    }
-    pruneOverlayEntries(overlayRegionEntries, nextRegionIds);
-
-    const nextNodeIds = new Set<string>();
-    for (const node of sigmaOverlayNodes(adapterData)) {
-      nextNodeIds.add(node.id);
-      let element = overlayNodeEntries.get(node.id);
-      if (!element) {
-        element = createSigmaNodeHitTarget(node.id, node.label || node.id);
-        overlayNodeEntries.set(node.id, element);
-      }
-      element.setAttribute("aria-label", node.label || node.id);
-      element.dataset.nodeId = node.id;
-      element.dataset.searchHit = node.searchHit ? "true" : "false";
-      element.dataset.selected = node.selected ? "true" : "false";
-      element.dataset.pinned = node.pinHint.pinned ? "true" : "false";
-      element.dataset.communityDimmed = sigmaGlobalNodeSpotlightState(node, spotlightCommunityIds).dimmed ? "true" : "false";
-      ordered.push(element);
-    }
-    pruneOverlayEntries(overlayNodeEntries, nextNodeIds);
-
-    const nextLabelIds = new Set<string>();
-    for (const community of sigmaCommunityLabels(adapterData, SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT)) {
-      if (!community.wash) continue;
-      nextLabelIds.add(community.id);
-      let element = overlayLabelEntries.get(community.id);
-      if (!element) {
-        element = sigmaOverlayPassiveElement(overlayRoot.ownerDocument, "community-label", community.id);
-        element.className = "sigma-global-community-label";
-        element.dataset.communityId = community.id;
-        overlayLabelEntries.set(community.id, element);
-      }
-      const labelSelected = selectedCommunityIds.has(community.id);
-      element.dataset.selected = labelSelected ? "true" : "false";
-      element.dataset.dim = selectedCommunityIds.size > 0 && !labelSelected ? "true" : "false";
-      element.textContent = community.label || community.id;
-      ordered.push(element);
-    }
-    pruneOverlayEntries(overlayLabelEntries, nextLabelIds);
-
-    overlayRoot.replaceChildren(...ordered);
-    repositionSigmaOverlays();
-  }
-
-  // 位置更新：相机/缩放/拖拽每帧调用。只读已存在元素更新位置与云层几何，
-  // 不创建元素、不重绑监听、不调用 replaceChildren；缺失的 id 安全跳过。
-  function repositionSigmaOverlays(): void {
-    if (destroyed) return;
-    for (const community of adapterData.renderable.communities) {
-      if (!community.wash) continue;
-      const entry = overlayRegionEntries.get(community.id);
-      if (!entry) continue;
-      const cloud = sigmaCommunityCloudFor(community.id, community.wash);
-      applyOverlayBox(entry.element, cloud.box);
-      applySigmaCloudGeometry(entry.shape, entry.kind, cloud);
-    }
-    for (const node of sigmaOverlayNodes(adapterData)) {
-      const element = overlayNodeEntries.get(node.id);
-      if (!element) continue;
-      const size = Math.max(16, sigmaGlobalNodeSize(node) * 3);
-      const center = sigmaWorldPointToScreenPoint(sigma, node.point, options);
-      applyOverlayBox(element, {
-        left: center.x - size / 2,
-        top: center.y - size / 2,
-        width: size,
-        height: size
-      });
-    }
-    for (const community of sigmaCommunityLabels(adapterData, SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT)) {
-      if (!community.wash) continue;
-      const element = overlayLabelEntries.get(community.id);
-      if (!element) continue;
-      const center = sigmaWorldPointToScreenPoint(sigma, {
-        x: community.wash.cx,
-        y: community.wash.cy - community.wash.ry * 0.16
-      }, options);
-      applyOverlayBox(element, {
-        left: center.x,
-        top: center.y,
-        width: 160,
-        height: 22
-      });
-    }
-  }
-
   function sigmaCommunityCloudFor(communityId: string, wash: { cx: number; cy: number; rx: number; ry: number }): SigmaCommunityCloud {
     const fallbackBox = overlayBoxFromWorldEllipse(wash.cx, wash.cy, wash.rx, wash.ry);
     return sigmaCommunityCloud(
       sigmaProjectedCloudHullPoints(cloudBasisByCommunityId.get(communityId), sigma, options),
       fallbackBox
     );
-  }
-
-  function createSigmaNodeHitTarget(nodeId: string, label: string): HTMLButtonElement {
-    const element = sigmaOverlayButton(overlayRoot.ownerDocument, "node", nodeId, label);
-    element.className = "sigma-global-node-hit-target";
-    element.addEventListener("click", (event) => {
-      event.stopPropagation();
-      if (consumeSuppressedNodeClick(nodeId)) return;
-      handleSigmaHit({ renderedObject: { kind: "node", id: nodeId } });
-    });
-    element.addEventListener("pointerdown", (event) => {
-      if (event.button !== 0) return;
-      event.preventDefault();
-      event.stopPropagation();
-      beginNodeDrag(nodeId, overlayPointerScreenPoint(event, sigmaRoot), event);
-      if (activeNodeDrag?.nodeId === nodeId) {
-        bindOverlayPointerDragListeners(element.ownerDocument, element, nodeId, event.pointerId);
-      }
-    });
-    element.addEventListener("mousedown", (event) => {
-      if (event.button !== 0) return;
-      if (element.ownerDocument.defaultView?.PointerEvent) return;
-      event.preventDefault();
-      event.stopPropagation();
-      if (activeNodeDrag?.nodeId !== nodeId) {
-        beginNodeDrag(nodeId, overlayPointerScreenPoint(event, sigmaRoot), event);
-      }
-      if (activeNodeDrag?.nodeId === nodeId) {
-        bindOverlayMouseDragListeners(element.ownerDocument, nodeId);
-      }
-    });
-    element.addEventListener("dragstart", (event) => {
-      event.preventDefault();
-    });
-    return element;
-  }
-
-  function pruneOverlayEntries(entries: Map<string, unknown>, keep: Set<string>): void {
-    for (const id of [...entries.keys()]) {
-      if (!keep.has(id)) entries.delete(id);
-    }
   }
 
   function overlayBoxFromWorldEllipse(x: number, y: number, rx: number, ry: number): { left: number; top: number; width: number; height: number } {
@@ -738,49 +574,6 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       width: Math.max(8, Math.abs(bottomRight.x - topLeft.x)),
       height: Math.max(8, Math.abs(bottomRight.y - topLeft.y))
     };
-  }
-
-  function bindOverlayPointerDragListeners(ownerDocument: Document, element: HTMLElement, nodeId: string, pointerId: number): void {
-    clearOverlayPointerDragListeners();
-    const cleanup = bindSigmaGlobalOverlayPointerDrag({
-      ownerDocument,
-      element,
-      nodeId,
-      pointerId,
-      isActive: isActiveOverlayDrag,
-      screenPointFromEvent: (event) => overlayPointerScreenPoint(event, sigmaRoot),
-      onMove: moveNodeDrag,
-      onEnd: commitNodeDrag,
-      onCancel: cancelNodeDrag
-    });
-    overlayPointerDragCleanup = () => {
-      cleanup();
-      overlayPointerDragCleanup = null;
-    };
-  }
-
-  function bindOverlayMouseDragListeners(ownerDocument: Document, nodeId: string): void {
-    clearOverlayPointerDragListeners();
-    const cleanup = bindSigmaGlobalOverlayMouseDrag({
-      ownerDocument,
-      nodeId,
-      isActive: isActiveOverlayDrag,
-      screenPointFromEvent: (event) => overlayPointerScreenPoint(event, sigmaRoot),
-      onMove: moveNodeDrag,
-      onEnd: commitNodeDrag
-    });
-    overlayPointerDragCleanup = () => {
-      cleanup();
-      overlayPointerDragCleanup = null;
-    };
-  }
-
-  function isActiveOverlayDrag(nodeId: string): boolean {
-    return activeNodeDrag?.nodeId === nodeId;
-  }
-
-  function clearOverlayPointerDragListeners(): void {
-    overlayPointerDragCleanup?.();
   }
 
   function assertActive(): void {
@@ -820,40 +613,10 @@ function sigmaLabelColor(theme: ThemeId): { color: string } {
   return { color: theme === "mo-ye" ? "#f8fafc" : "#6b6256" };
 }
 
-function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphRendererAdapterNode[] {
-  const nodes = adapterData.nodes;
-  const seen = new Set<string>();
-  const output: GraphRendererAdapterNode[] = [];
-  const append = (candidates: GraphRendererAdapterNode[], limit: number) => {
-    let count = 0;
-    for (const node of candidates) {
-      if (output.length >= SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT || count >= limit || seen.has(node.id)) continue;
-      seen.add(node.id);
-      output.push(node);
-      count += 1;
-    }
-  };
-  if (adapterData.selection.input?.kind !== "community") {
-    append(nodes.filter((node) => node.selected), Number.POSITIVE_INFINITY);
-  }
-  append(nodes.filter((node) => node.searchHit), 80);
-  append(nodes.filter((node) => node.pinHint.pinned), 80);
-  return output;
-}
-
 function finiteNumber(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
 function sameRendererViewportSize(left: RendererViewportSize, right: RendererViewportSize): boolean {
   return Math.abs(left.width - right.width) < 1 && Math.abs(left.height - right.height) < 1;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-function roundNumber(value: number, digits: number): number {
-  const factor = 10 ** digits;
-  return Math.round(value * factor) / factor;
 }

--- a/packages/graph-engine/src/render/sigma-global-renderer.ts
+++ b/packages/graph-engine/src/render/sigma-global-renderer.ts
@@ -74,6 +74,13 @@ import {
   type SigmaGlobalHitInput,
   type SigmaGlobalHitProjector
 } from "./sigma-hit-projector";
+import {
+  maybeAnimateSigmaCommunitySpotlightCamera,
+  prefersReducedMotion,
+  readCameraState,
+  restoreCameraState,
+  sigmaGlobalCameraState
+} from "./sigma-global-camera";
 
 export type {
   SigmaGlobalCameraState,
@@ -244,6 +251,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
             sigma,
             sigmaRoot,
             adapterData,
+            sigmaSpotlightCommunityId(adapterData),
             previousCameraSpotlightCommunityId
           );
         } catch (error) {
@@ -837,17 +845,6 @@ function sigmaLabelColor(theme: ThemeId): { color: string } {
   return { color: theme === "mo-ye" ? "#f8fafc" : "#6b6256" };
 }
 
-function readCameraState(sigma: SigmaGlobalSigmaLike): SigmaGlobalCameraState | null {
-  const state = sigma.getCamera?.().getState?.();
-  if (!state) return null;
-  return {
-    x: finiteNumber(state.x, 0),
-    y: finiteNumber(state.y, 0),
-    angle: finiteNumber(state.angle, 0),
-    ratio: finiteNumber(state.ratio, 1)
-  };
-}
-
 function sigmaWheelInputFromPayload(payload: unknown, fallbackPoint: GraphScreenPoint): {
   point: GraphScreenPoint;
   delta: SigmaWheelDeltaLike;
@@ -899,136 +896,6 @@ function sigmaViewportCenter(root: HTMLElement): GraphScreenPoint {
     x: width / 2,
     y: height / 2
   };
-}
-
-function restoreCameraState(sigma: SigmaGlobalSigmaLike, state: SigmaGlobalCameraState | null): void {
-  if (!state) return;
-  sigma.getCamera?.().setState?.(state);
-}
-
-function maybeAnimateSigmaCommunitySpotlightCamera(
-  sigma: SigmaGlobalSigmaLike,
-  root: HTMLElement,
-  adapterData: GraphRendererAdapterData,
-  previousCommunityId: string | null
-): string | null {
-  const communityId = sigmaSpotlightCommunityId(adapterData);
-  if (!communityId) return null;
-  if (communityId === previousCommunityId) return communityId;
-  const target = sigmaCommunitySpotlightCameraState(sigma, adapterData, communityId);
-  if (!target) return communityId;
-  moveSigmaCamera(sigma, target, prefersReducedMotion(root.ownerDocument.defaultView));
-  return communityId;
-}
-
-function moveSigmaCamera(
-  sigma: SigmaGlobalSigmaLike,
-  target: Partial<SigmaGlobalCameraState>,
-  reducedMotion: boolean
-): void {
-  const camera = sigma.getCamera?.();
-  if (!camera) return;
-  if (reducedMotion || !camera.animate) {
-    camera.setState?.(target);
-    return;
-  }
-  void camera.animate(target, { duration: 380, easing: "quadraticInOut" });
-}
-
-function sigmaCommunitySpotlightCameraState(
-  sigma: SigmaGlobalSigmaLike,
-  adapterData: GraphRendererAdapterData,
-  communityId: string
-): Partial<SigmaGlobalCameraState> | null {
-  const current = readCameraState(sigma) ?? { x: 0, y: 0, angle: 0, ratio: 1 };
-  const center = sigmaCommunitySpotlightCenter(adapterData, communityId);
-  if (!center) return null;
-  const bounds = adapterData.renderable.worldBounds;
-  const worldWidth = Math.max(0, finiteNumber(bounds.maxX, center.x) - finiteNumber(bounds.minX, center.x));
-  const drawerOffset = worldWidth * 0.08;
-  const graphTargetPoint = { x: center.x + drawerOffset, y: center.y };
-  const targetPoint = sigmaGraphPointToCameraPoint(sigma, graphTargetPoint);
-  const targetX = roundNumber(targetPoint.x, 3);
-  const targetY = roundNumber(targetPoint.y, 3);
-  const settledThreshold = sigmaCameraDistanceForGraphDistance(sigma, graphTargetPoint, Math.max(worldWidth * 0.015, 4));
-  const positionSettled = Math.abs(current.x - targetX) <= settledThreshold
-    && Math.abs(current.y - targetY) <= settledThreshold;
-  const target = {
-    x: targetX,
-    y: targetY,
-    angle: current.angle,
-    ratio: positionSettled || current.ratio <= 0.9
-      ? current.ratio
-      : roundNumber(clamp(current.ratio * 0.92, 0.72, current.ratio), 3)
-  };
-  const settled = positionSettled
-    && Math.abs(current.ratio - target.ratio) <= 0.025;
-  return settled ? null : target;
-}
-
-function sigmaGlobalCameraState(
-  sigma: SigmaGlobalSigmaLike,
-  adapterData: GraphRendererAdapterData
-): Partial<SigmaGlobalCameraState> {
-  const bounds = adapterData.renderable.worldBounds;
-  const center = sigmaGraphPointToCameraPoint(sigma, {
-    x: (finiteNumber(bounds.minX, 0) + finiteNumber(bounds.maxX, 0)) / 2,
-    y: (finiteNumber(bounds.minY, 0) + finiteNumber(bounds.maxY, 0)) / 2
-  });
-  return {
-    x: roundNumber(center.x, 3),
-    y: roundNumber(center.y, 3),
-    angle: 0,
-    ratio: 1
-  };
-}
-
-function sigmaGraphPointToCameraPoint(
-  sigma: SigmaGlobalSigmaLike,
-  point: { x: number; y: number }
-): { x: number; y: number } {
-  const viewportPoint = sigma.graphToViewport?.(point);
-  const cameraPoint = viewportPoint ? sigma.viewportToFramedGraph?.(viewportPoint) : null;
-  if (cameraPoint && Number.isFinite(cameraPoint.x) && Number.isFinite(cameraPoint.y)) {
-    return cameraPoint;
-  }
-  return point;
-}
-
-function sigmaCameraDistanceForGraphDistance(
-  sigma: SigmaGlobalSigmaLike,
-  point: { x: number; y: number },
-  graphDistance: number
-): number {
-  if (graphDistance <= 0) return 0;
-  const base = sigmaGraphPointToCameraPoint(sigma, point);
-  const shifted = sigmaGraphPointToCameraPoint(sigma, { x: point.x + graphDistance, y: point.y });
-  const distance = Math.abs(shifted.x - base.x);
-  return Number.isFinite(distance) && distance > 0 ? distance : graphDistance;
-}
-
-function sigmaCommunitySpotlightCenter(
-  adapterData: GraphRendererAdapterData,
-  communityId: string
-): { x: number; y: number } | null {
-  const renderableCommunity = adapterData.renderable.communities.find((community) => community.id === communityId);
-  if (renderableCommunity?.wash) {
-    return {
-      x: finiteNumber(renderableCommunity.wash.cx, 0),
-      y: finiteNumber(renderableCommunity.wash.cy, 0)
-    };
-  }
-  const nodes = adapterData.nodes.filter((node) => node.communityId === communityId);
-  if (nodes.length === 0) return null;
-  const sum = nodes.reduce((acc, node) => ({
-    x: acc.x + finiteNumber(node.point.x, 0),
-    y: acc.y + finiteNumber(node.point.y, 0)
-  }), { x: 0, y: 0 });
-  return { x: sum.x / nodes.length, y: sum.y / nodes.length };
-}
-
-function prefersReducedMotion(view: Window | null | undefined): boolean {
-  return Boolean(view?.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
 }
 
 function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphRendererAdapterNode[] {

--- a/packages/graph-engine/src/render/sigma-global-renderer.ts
+++ b/packages/graph-engine/src/render/sigma-global-renderer.ts
@@ -1,11 +1,7 @@
-import type { GraphEdgeStyleOptions, PinMap, PinPosition, ThemeId } from "../types";
+import type { PinMap, PinPosition, ThemeId } from "../types";
 import { createGraphSpatialIndex, type GraphSpatialIndex, type GraphSpatialIndexInput } from "../layout";
-import { getThemeTokens } from "../themes";
 import type {
-  GraphRendererAdapterAggregation,
-  GraphRendererAdapterCommunity,
   GraphRendererAdapterData,
-  GraphRendererAdapterEdge,
   GraphRendererAdapterNode
 } from "./adapter";
 import {
@@ -21,7 +17,6 @@ import {
 } from "./sigma-global-drag";
 import { screenPointToWorldPoint, type GraphScreenPoint } from "./geometry";
 import { graphSpatialHitToGestureTarget, type GraphGestureTarget } from "./gestures";
-import { edgeRelationClass } from "./model";
 import { DEFAULT_RENDERER_VIEWPORT, type RendererViewport, type RendererViewportSize } from "./viewport";
 import { overlayPointerScreenPoint, sigmaScreenPointToWorldPoint, sigmaWorldPointToScreenPoint } from "./sigma-coordinates";
 import {
@@ -65,6 +60,16 @@ import type {
   SigmaGlobalRendererUpdateOptions,
   SigmaGlobalSigmaLike
 } from "./sigma-global-types";
+import {
+  buildSigmaGlobalGraphologyGraph,
+  canPatchSigmaGlobalGraphAttributes,
+  patchSigmaGlobalGraphAttributes,
+  sigmaGlobalNodeSize,
+  sigmaGlobalNodeSpotlightState,
+  sigmaSelectedCommunityIds,
+  sigmaSpotlightCommunityId,
+  sigmaSpotlightCommunityIds
+} from "./sigma-graphology-model";
 
 export type {
   SigmaGlobalCameraState,
@@ -77,6 +82,12 @@ export type {
   SigmaGlobalRendererUpdateOptions,
   SigmaGlobalSigmaLike
 } from "./sigma-global-types";
+
+export {
+  buildSigmaGlobalGraphologyGraph,
+  sigmaGlobalEdgeStyle
+} from "./sigma-graphology-model";
+export type { SigmaGlobalEdgeStyle } from "./sigma-graphology-model";
 
 export const SIGMA_GLOBAL_RENDERER_ID = "sigma-global" as const;
 
@@ -104,70 +115,6 @@ interface SigmaGlobalWheelPayload {
   preventSigmaDefault?: () => void;
 }
 
-export interface SigmaGlobalGraphologyNodeAttributes {
-  x: number;
-  y: number;
-  label: string;
-  size: number;
-  color: string;
-  type: string;
-  graphNodeType: string;
-  communityId: string | null;
-  sourcePath: string;
-  selected: boolean;
-  searchHit: boolean;
-  pinned: boolean;
-  communityDimmed: boolean;
-  communitySpotlightVisible: boolean;
-  aggregationIds: string[];
-  labelVisible: boolean;
-  displayMode: string;
-  visualRole: string;
-  priority: number;
-  drawerTarget: GraphRendererAdapterNode["drawerTarget"];
-}
-
-export interface SigmaGlobalGraphologyEdgeAttributes {
-  size: number;
-  color: string;
-  relationType: string | null;
-  confidence: string | null;
-  weight: number;
-  sourceCommunityId: string | null;
-  targetCommunityId: string | null;
-}
-
-export interface SigmaGlobalGraphologyCommunityAttributes {
-  id: string;
-  label: string;
-  color: string;
-  nodeIds: string[];
-  nodeCount: number;
-  selected: boolean;
-  searchResultIds: string[];
-  pinnedNodeIds: string[];
-  aggregationIds: string[];
-  drawerTarget: GraphRendererAdapterCommunity["drawerTarget"];
-  commands: GraphRendererAdapterCommunity["commands"];
-}
-
-export interface SigmaGlobalGraphologyAggregationAttributes {
-  id: string;
-  label: string;
-  communityId: string | null;
-  nodeIds: string[];
-  selectedNodeIds: string[];
-  searchResultIds: string[];
-  pinnedNodeIds: string[];
-  totalCount: number;
-  selected: boolean;
-  color: string;
-  point: { x: number; y: number } | null;
-  radius: number | null;
-  drawerTarget: GraphRendererAdapterAggregation["drawerTarget"];
-  commands: GraphRendererAdapterAggregation["commands"];
-}
-
 export interface SigmaGlobalHitInput {
   nodeId?: string | null;
   screenPoint?: GraphScreenPoint | null;
@@ -186,11 +133,6 @@ export interface SigmaGlobalHitProjector {
   index(): GraphSpatialIndex;
 }
 
-export interface SigmaGlobalEdgeStyle {
-  color: string;
-  size: number;
-}
-
 export async function sigmaGlobalRendererRuntimeBoundary(): Promise<SigmaGlobalRendererRuntimeBoundary> {
   const [{ default: Sigma }, { default: GraphologyGraph }] = await Promise.all([
     import("sigma"),
@@ -201,40 +143,6 @@ export async function sigmaGlobalRendererRuntimeBoundary(): Promise<SigmaGlobalR
     Sigma,
     GraphologyGraph
   };
-}
-
-export function buildSigmaGlobalGraphologyGraph(
-  adapterData: GraphRendererAdapterData,
-  runtime: SigmaGlobalGraphologyRuntime,
-  theme: ThemeId = "shan-shui",
-  edgeStyle?: GraphEdgeStyleOptions
-): SigmaGlobalGraphologyGraph {
-  const graph = new runtime.GraphologyGraph({ multi: true, type: "mixed" });
-  const communityColorById = new Map(adapterData.renderable.communities.map((community) => [community.id, community.color]));
-  const aggregationRenderById = new Map(adapterData.renderable.aggregationContainers.map((aggregation) => [aggregation.id, aggregation]));
-  const selectedCommunityIds = sigmaSelectedCommunityIds(adapterData);
-  const spotlightCommunityIds = sigmaSpotlightCommunityIds(adapterData);
-
-  for (const node of adapterData.nodes) {
-    graph.addNode(node.id, sigmaGlobalNodeAttributes(node, communityColorById, spotlightCommunityIds));
-  }
-
-  for (const edge of adapterData.edges) {
-    graph.addEdgeWithKey(edge.id, edge.sourceNodeId, edge.targetNodeId, sigmaGlobalEdgeAttributes(edge, theme, edgeStyle, selectedCommunityIds));
-  }
-
-  graph.setAttribute("counts", adapterData.counts);
-  graph.setAttribute("selection", adapterData.selection);
-  graph.setAttribute(
-    "communities",
-    adapterData.communities.map((community) => sigmaGlobalCommunityAttributes(community, communityColorById))
-  );
-  graph.setAttribute(
-    "aggregations",
-    adapterData.aggregations.map((aggregation) => sigmaGlobalAggregationAttributes(aggregation, aggregationRenderById))
-  );
-
-  return graph;
 }
 
 export function createSigmaGlobalHitProjector(input: SigmaGlobalHitProjectorInput): SigmaGlobalHitProjector {
@@ -1163,54 +1071,6 @@ function prefersReducedMotion(view: Window | null | undefined): boolean {
   return Boolean(view?.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
 }
 
-function canPatchSigmaGlobalGraphAttributes(
-  current: GraphRendererAdapterData,
-  next: GraphRendererAdapterData,
-  currentTheme: ThemeId,
-  nextTheme: ThemeId
-): boolean {
-  if (currentTheme !== nextTheme) return false;
-  if (current.nodes.length !== next.nodes.length || current.edges.length !== next.edges.length) return false;
-  return current.nodes.every((node, index) => node.id === next.nodes[index]?.id)
-    && current.edges.every((edge, index) => {
-      const nextEdge = next.edges[index];
-      return Boolean(nextEdge)
-        && edge.id === nextEdge.id
-        && edge.sourceNodeId === nextEdge.sourceNodeId
-        && edge.targetNodeId === nextEdge.targetNodeId;
-    });
-}
-
-function patchSigmaGlobalGraphAttributes(
-  graph: SigmaGlobalGraphologyGraph,
-  adapterData: GraphRendererAdapterData,
-  theme: ThemeId,
-  edgeStyle?: GraphEdgeStyleOptions
-): void {
-  const communityColorById = new Map(adapterData.renderable.communities.map((community) => [community.id, community.color]));
-  const aggregationRenderById = new Map(adapterData.renderable.aggregationContainers.map((aggregation) => [aggregation.id, aggregation]));
-  const selectedCommunityIds = sigmaSelectedCommunityIds(adapterData);
-  const spotlightCommunityIds = sigmaSpotlightCommunityIds(adapterData);
-
-  for (const node of adapterData.nodes) {
-    if (!graph.hasNode(node.id)) continue;
-    graph.mergeNodeAttributes(node.id, sigmaGlobalNodeAttributes(node, communityColorById, spotlightCommunityIds));
-  }
-  for (const edge of adapterData.edges) {
-    graph.mergeEdgeAttributes(edge.id, sigmaGlobalEdgeAttributes(edge, theme, edgeStyle, selectedCommunityIds));
-  }
-  graph.setAttribute("counts", adapterData.counts);
-  graph.setAttribute("selection", adapterData.selection);
-  graph.setAttribute(
-    "communities",
-    adapterData.communities.map((community) => sigmaGlobalCommunityAttributes(community, communityColorById))
-  );
-  graph.setAttribute(
-    "aggregations",
-    adapterData.aggregations.map((aggregation) => sigmaGlobalAggregationAttributes(aggregation, aggregationRenderById))
-  );
-}
-
 function sigmaNodeIdFromPayload(payload: unknown): string | null {
   const candidate = payload as { node?: unknown } | null;
   return typeof candidate?.node === "string" ? candidate.node : null;
@@ -1253,197 +1113,6 @@ function spatialInputFromAdapterData(adapterData: GraphRendererAdapterData): Gra
   };
 }
 
-function sigmaGlobalNodeAttributes(
-  node: GraphRendererAdapterNode,
-  communityColorById: Map<string, string>,
-  selectedCommunityIds: ReadonlySet<string> = new Set()
-): SigmaGlobalGraphologyNodeAttributes {
-  const spotlight = sigmaGlobalNodeSpotlightState(node, selectedCommunityIds);
-  const baseSize = sigmaGlobalNodeSize(node);
-  const baseColor = sigmaGlobalNodeColor(node, communityColorById);
-  return {
-    x: finiteNumber(node.point.x, 0),
-    y: finiteNumber(node.point.y, 0),
-    label: node.render.labelVisible ? node.label : "",
-    size: spotlight.dimmed ? roundNumber(baseSize * 0.72, 2) : baseSize,
-    color: spotlight.dimmed ? rgbaColor(baseColor, 0.2) : baseColor,
-    type: "circle",
-    graphNodeType: node.type,
-    communityId: node.communityId,
-    sourcePath: node.sourcePath,
-    selected: node.selected,
-    searchHit: node.searchHit,
-    pinned: node.pinHint.pinned,
-    communityDimmed: spotlight.dimmed,
-    communitySpotlightVisible: spotlight.forceVisible,
-    aggregationIds: [...node.aggregationIds],
-    labelVisible: node.render.labelVisible,
-    displayMode: node.render.displayMode,
-    visualRole: node.render.visualRole,
-    priority: finiteNumber(node.render.priority, 0),
-    drawerTarget: node.drawerTarget
-  };
-}
-
-function sigmaSelectedCommunityIds(adapterData: GraphRendererAdapterData): Set<string> {
-  return new Set(adapterData.communities.filter((community) => community.selected).map((community) => community.id));
-}
-
-function sigmaSpotlightCommunityIds(adapterData: GraphRendererAdapterData): Set<string> {
-  const communityId = sigmaSpotlightCommunityId(adapterData);
-  return communityId ? new Set([communityId]) : new Set();
-}
-
-function sigmaSpotlightCommunityId(adapterData: GraphRendererAdapterData): string | null {
-  return adapterData.selection.input?.kind === "community" ? adapterData.selection.input.id : null;
-}
-
-function sigmaGlobalNodeSpotlightState(
-  node: GraphRendererAdapterNode,
-  selectedCommunityIds: ReadonlySet<string>
-): { dimmed: boolean; forceVisible: boolean } {
-  const forceVisible = node.selected || node.searchHit || node.pinHint.pinned;
-  const inSelectedCommunity = Boolean(node.communityId && selectedCommunityIds.has(node.communityId));
-  return {
-    forceVisible,
-    dimmed: selectedCommunityIds.size > 0 && !inSelectedCommunity && !forceVisible
-  };
-}
-
-function sigmaGlobalEdgeAttributes(
-  edge: GraphRendererAdapterEdge,
-  theme: ThemeId = "shan-shui",
-  style?: GraphEdgeStyleOptions,
-  selectedCommunityIds: ReadonlySet<string> = new Set()
-): SigmaGlobalGraphologyEdgeAttributes {
-  const edgeStyle = sigmaGlobalEdgeStyle(edge, theme, style, selectedCommunityIds);
-  return {
-    size: edgeStyle.size,
-    color: edgeStyle.color,
-    relationType: edge.relationType == null ? null : String(edge.relationType),
-    confidence: edge.confidence == null ? null : String(edge.confidence),
-    weight: finiteNumber(edge.weight, 0),
-    sourceCommunityId: edge.sourceCommunityId,
-    targetCommunityId: edge.targetCommunityId
-  };
-}
-
-export function sigmaGlobalEdgeStyle(
-  edge: GraphRendererAdapterEdge,
-  theme: ThemeId = "shan-shui",
-  style?: GraphEdgeStyleOptions,
-  selectedCommunityIds: ReadonlySet<string> = new Set()
-): SigmaGlobalEdgeStyle {
-  const relationClass = edgeRelationClass(edge.relationType);
-  const semantic = relationClass === "relation-contrast" || relationClass === "relation-conflict";
-  const bridge = Boolean(edge.sourceCommunityId && edge.targetCommunityId && edge.sourceCommunityId !== edge.targetCommunityId);
-  const weight = clamp(finiteNumber(edge.weight, 0), 0, 1);
-  let alpha = semantic ? (bridge ? 0.58 : 0.5) + weight * 0.08 : (bridge ? 0.34 : 0.1) + weight * (bridge ? 0.08 : 0.06);
-  let size = semantic ? (bridge ? 1.65 : 1.25) + weight * 0.6 : (bridge ? 1.1 : 0.72) + weight * (bridge ? 0.85 : 0.55);
-
-  if (style?.semanticEmphasis) {
-    if (semantic) {
-      alpha = alpha * 1.16 + 0.04;
-      size += 0.45;
-    } else {
-      alpha *= 0.6;
-      size *= 0.75;
-    }
-  }
-
-  if (style?.focusHighlight && selectedCommunityIds.size > 0) {
-    const touchesSelectedCommunity =
-      Boolean(edge.sourceCommunityId && selectedCommunityIds.has(edge.sourceCommunityId))
-      || Boolean(edge.targetCommunityId && selectedCommunityIds.has(edge.targetCommunityId));
-    if (touchesSelectedCommunity) {
-      alpha = alpha * 1.12 + 0.02;
-      size += semantic ? 0.2 : 0.12;
-    } else {
-      alpha *= 0.05;
-      size *= 0.55;
-    }
-  }
-
-  alpha = roundNumber(clamp(alpha, 0.05, 0.7), 3);
-  size = roundNumber(clamp(size, 0.6, 4), 2);
-
-  return {
-    color: rgbaColor(sigmaGlobalEdgeRelationColor(relationClass, theme), alpha),
-    size
-  };
-}
-
-function sigmaGlobalEdgeRelationColor(relationClass: string, theme: ThemeId): string {
-  const vars = getThemeTokens(theme).vars;
-  if (relationClass === "relation-contrast") return vars["--amber"] ?? (theme === "mo-ye" ? "#e0b35e" : "#b7791f");
-  if (relationClass === "relation-conflict") return theme === "mo-ye" ? "#f472b6" : "#d94693";
-  if (theme === "mo-ye") return vars["--line"] ?? "#8e8778";
-  return vars["--night"] ?? "#315f72";
-}
-
-function rgbaColor(hexColor: string, alpha: number): string {
-  const hex = hexColor.trim().replace(/^#/, "");
-  const normalized = hex.length === 3
-    ? hex.split("").map((part) => `${part}${part}`).join("")
-    : hex;
-  const red = Number.parseInt(normalized.slice(0, 2), 16);
-  const green = Number.parseInt(normalized.slice(2, 4), 16);
-  const blue = Number.parseInt(normalized.slice(4, 6), 16);
-  if (![red, green, blue].every(Number.isFinite)) return `rgba(49, 95, 114, ${alpha})`;
-  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
-}
-
-function sigmaGlobalCommunityAttributes(
-  community: GraphRendererAdapterCommunity,
-  communityColorById: Map<string, string>
-): SigmaGlobalGraphologyCommunityAttributes {
-  return {
-    id: community.id,
-    label: community.label,
-    color: communityColorById.get(community.id) ?? "#64748b",
-    nodeIds: [...community.nodeIds],
-    nodeCount: community.nodeCount,
-    selected: community.selected,
-    searchResultIds: [...community.searchResultIds],
-    pinnedNodeIds: community.pinHints.map((hint) => hint.nodeId),
-    aggregationIds: [...community.aggregationIds],
-    drawerTarget: community.drawerTarget,
-    commands: community.commands
-  };
-}
-
-function sigmaGlobalAggregationAttributes(
-  aggregation: GraphRendererAdapterAggregation,
-  aggregationRenderById: Map<string, GraphRendererAdapterData["renderable"]["aggregationContainers"][number]>
-): SigmaGlobalGraphologyAggregationAttributes {
-  const render = aggregationRenderById.get(aggregation.id);
-  return {
-    id: aggregation.id,
-    label: aggregation.label,
-    communityId: aggregation.communityId,
-    nodeIds: [...aggregation.nodeIds],
-    selectedNodeIds: [...aggregation.selectedNodeIds],
-    searchResultIds: [...aggregation.searchResultIds],
-    pinnedNodeIds: [...aggregation.pinnedNodeIds],
-    totalCount: aggregation.totalCount,
-    selected: aggregation.selected,
-    color: render?.color ?? "#64748b",
-    point: render ? { ...render.point } : null,
-    radius: render ? finiteNumber(render.radius, 0) : null,
-    drawerTarget: aggregation.drawerTarget,
-    commands: aggregation.commands
-  };
-}
-
-function sigmaGlobalNodeSize(node: GraphRendererAdapterNode): number {
-  if (node.pinHint.pinned || node.selected) return 10;
-  if (node.searchHit) return 9;
-  if (node.render.displayMode === "card") return 8;
-  if (node.render.displayMode === "compact-card") return 7;
-  if (node.render.displayMode === "overview") return 6;
-  return 5;
-}
-
 function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphRendererAdapterNode[] {
   const nodes = adapterData.nodes;
   const seen = new Set<string>();
@@ -1463,13 +1132,6 @@ function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphRenderer
   append(nodes.filter((node) => node.searchHit), 80);
   append(nodes.filter((node) => node.pinHint.pinned), 80);
   return output;
-}
-
-function sigmaGlobalNodeColor(node: GraphRendererAdapterNode, communityColorById: Map<string, string>): string {
-  if (node.selected) return "#ef4444";
-  if (node.searchHit) return "#f59e0b";
-  if (node.pinHint.pinned) return "#0ea5e9";
-  return node.communityId ? communityColorById.get(node.communityId) ?? "#64748b" : "#64748b";
 }
 
 function finiteNumber(value: unknown, fallback: number): number {

--- a/packages/graph-engine/src/render/sigma-global-renderer.ts
+++ b/packages/graph-engine/src/render/sigma-global-renderer.ts
@@ -53,6 +53,30 @@ import {
   sigmaWheelZoomRatio,
   type SigmaWheelDeltaLike
 } from "./sigma-zoom";
+import { preventSigmaDefault } from "./sigma-events";
+import type {
+  SigmaGlobalCameraState,
+  SigmaGlobalGraphologyGraph,
+  SigmaGlobalGraphologyRuntime,
+  SigmaGlobalRenderer,
+  SigmaGlobalRendererCreateOptions,
+  SigmaGlobalRendererRuntime,
+  SigmaGlobalRendererRuntimeBoundary,
+  SigmaGlobalRendererUpdateOptions,
+  SigmaGlobalSigmaLike
+} from "./sigma-global-types";
+
+export type {
+  SigmaGlobalCameraState,
+  SigmaGlobalGraphologyGraph,
+  SigmaGlobalGraphologyRuntime,
+  SigmaGlobalRenderer,
+  SigmaGlobalRendererCreateOptions,
+  SigmaGlobalRendererRuntime,
+  SigmaGlobalRendererRuntimeBoundary,
+  SigmaGlobalRendererUpdateOptions,
+  SigmaGlobalSigmaLike
+} from "./sigma-global-types";
 
 export const SIGMA_GLOBAL_RENDERER_ID = "sigma-global" as const;
 
@@ -68,35 +92,6 @@ export const SIGMA_GLOBAL_RENDERER_BUNDLE_BOUNDARY = {
   offlineHtml: "loads through the graph-engine IIFE Sigma runtime boundary when offline global route manager selects Sigma"
 } as const;
 
-export interface SigmaGlobalRendererRuntimeBoundary {
-  Sigma: typeof import("sigma").default;
-  GraphologyGraph: typeof import("graphology").default;
-}
-
-export type SigmaGlobalGraphologyGraph = InstanceType<SigmaGlobalRendererRuntimeBoundary["GraphologyGraph"]>;
-
-export interface SigmaGlobalCameraState {
-  x: number;
-  y: number;
-  angle: number;
-  ratio: number;
-}
-
-export interface SigmaGlobalCameraLike {
-  getState?: () => SigmaGlobalCameraState;
-  setState?: (state: Partial<SigmaGlobalCameraState>) => unknown;
-  isAnimated?: () => boolean;
-  animate?: (
-    state: Partial<SigmaGlobalCameraState>,
-    options?: { duration?: number; easing?: string }
-  ) => unknown;
-}
-
-export interface SigmaGlobalMouseCaptorLike {
-  on?: (event: "wheel", listener: (payload?: unknown) => void) => unknown;
-  off?: (event: "wheel", listener: (payload?: unknown) => void) => unknown;
-}
-
 interface SigmaGlobalWheelPayload {
   x?: unknown;
   y?: unknown;
@@ -107,31 +102,6 @@ interface SigmaGlobalWheelPayload {
     target?: unknown;
   };
   preventSigmaDefault?: () => void;
-}
-
-export interface SigmaGlobalSigmaLike {
-  getCamera?: () => SigmaGlobalCameraLike;
-  getMouseCaptor?: () => SigmaGlobalMouseCaptorLike;
-  getViewportZoomedState?: (viewportTarget: GraphScreenPoint, newRatio: number) => SigmaGlobalCameraState;
-  getGraph?: () => unknown;
-  setGraph?: (graph: SigmaGlobalGraphologyGraph) => unknown;
-  getSetting?: (key: string) => unknown;
-  setSetting?: (key: string, value: unknown) => unknown;
-  viewportToGraph?: (point: GraphScreenPoint) => { x: number; y: number };
-  viewportToFramedGraph?: (point: GraphScreenPoint) => { x: number; y: number };
-  graphToViewport?: (point: { x: number; y: number }) => GraphScreenPoint;
-  refresh?: () => unknown;
-  on?: (event: string, listener: (payload?: unknown) => void) => unknown;
-  off?: (event: string, listener: (payload?: unknown) => void) => unknown;
-  kill?: () => unknown;
-}
-
-export interface SigmaGlobalGraphologyRuntime {
-  GraphologyGraph: SigmaGlobalRendererRuntimeBoundary["GraphologyGraph"];
-}
-
-export interface SigmaGlobalRendererRuntime extends SigmaGlobalGraphologyRuntime {
-  Sigma: new (graph: SigmaGlobalGraphologyGraph, container: HTMLElement, settings?: Record<string, unknown>) => SigmaGlobalSigmaLike;
 }
 
 export interface SigmaGlobalGraphologyNodeAttributes {
@@ -204,14 +174,6 @@ export interface SigmaGlobalHitInput {
   renderedObject?: SigmaGlobalRenderedObject | null;
 }
 
-interface SigmaGlobalPointerEventPayload {
-  node?: unknown;
-  event?: { x?: unknown; y?: unknown; preventSigmaDefault?: () => void };
-  x?: unknown;
-  y?: unknown;
-  preventSigmaDefault?: () => void;
-}
-
 export interface SigmaGlobalHitProjectorInput {
   adapterData: GraphRendererAdapterData;
   viewport: RendererViewport;
@@ -222,43 +184,6 @@ export interface SigmaGlobalHitProjectorInput {
 export interface SigmaGlobalHitProjector {
   targetFromSigmaHit(input: SigmaGlobalHitInput): GraphGestureTarget;
   index(): GraphSpatialIndex;
-}
-
-export interface SigmaGlobalRendererCreateOptions {
-  container: HTMLElement;
-  adapterData: GraphRendererAdapterData;
-  theme: ThemeId;
-  edgeStyle?: GraphEdgeStyleOptions;
-  onHitTarget?: (target: GraphGestureTarget) => void;
-  onPinsChanged?: (pins: PinMap) => void;
-  onDragActiveChange?: (dragging: boolean) => void;
-  onFatalError?: (error: unknown) => void;
-  pins?: PinMap;
-  runtime?: SigmaGlobalRendererRuntime;
-  viewport?: RendererViewport;
-  viewportSize?: RendererViewportSize;
-}
-
-export interface SigmaGlobalRendererUpdateOptions {
-  adapterData: GraphRendererAdapterData;
-  theme?: ThemeId;
-  edgeStyle?: GraphEdgeStyleOptions;
-  pins?: PinMap;
-}
-
-export interface SigmaGlobalRenderer {
-  readonly id: typeof SIGMA_GLOBAL_RENDERER_ID;
-  readonly root: HTMLElement;
-  readonly overlayRoot: HTMLElement;
-  readonly graph: SigmaGlobalGraphologyGraph;
-  readonly updateStrategy: "rebuild-graph-preserve-camera";
-  readonly lastHitTarget: GraphGestureTarget | null;
-  isDragging(): boolean;
-  resetView(): void;
-  zoomIn(): void;
-  zoomOut(): void;
-  update(options: SigmaGlobalRendererUpdateOptions): void;
-  destroy(): void;
 }
 
 export interface SigmaGlobalEdgeStyle {
@@ -1296,13 +1221,6 @@ function sigmaScreenPointFromPayload(payload: unknown): GraphScreenPoint | null 
   const x = candidate?.event?.x ?? candidate?.x;
   const y = candidate?.event?.y ?? candidate?.y;
   return typeof x === "number" && typeof y === "number" ? { x, y } : null;
-}
-
-function preventSigmaDefault(payload: unknown): void {
-  const eventPayload = payload as SigmaGlobalPointerEventPayload | null;
-  eventPayload?.preventSigmaDefault?.();
-  eventPayload?.event?.preventSigmaDefault?.();
-  if (payload instanceof Event) payload.preventDefault();
 }
 
 function spatialInputFromAdapterData(adapterData: GraphRendererAdapterData): GraphSpatialIndexInput {

--- a/packages/graph-engine/src/render/sigma-global-renderer.ts
+++ b/packages/graph-engine/src/render/sigma-global-renderer.ts
@@ -1,5 +1,4 @@
 import type { PinMap, PinPosition, ThemeId } from "../types";
-import { createGraphSpatialIndex, type GraphSpatialIndex, type GraphSpatialIndexInput } from "../layout";
 import type {
   GraphRendererAdapterData,
   GraphRendererAdapterNode
@@ -8,15 +7,13 @@ import {
   bindSigmaGlobalOverlayMouseDrag,
   bindSigmaGlobalOverlayPointerDrag,
   createSigmaGlobalNodeDragSession,
-  gestureTargetFromSigmaRenderedObject,
   moveSigmaGlobalNodeDragSession,
   sigmaAdapterDataWithNodePoint,
   sigmaCommunityLabels,
-  type SigmaGlobalRenderedObject,
   type SigmaGlobalNodeDragSession
 } from "./sigma-global-drag";
-import { screenPointToWorldPoint, type GraphScreenPoint } from "./geometry";
-import { graphSpatialHitToGestureTarget, type GraphGestureTarget } from "./gestures";
+import type { GraphScreenPoint } from "./geometry";
+import type { GraphGestureTarget } from "./gestures";
 import { DEFAULT_RENDERER_VIEWPORT, type RendererViewport, type RendererViewportSize } from "./viewport";
 import { overlayPointerScreenPoint, sigmaScreenPointToWorldPoint, sigmaWorldPointToScreenPoint } from "./sigma-coordinates";
 import {
@@ -70,6 +67,13 @@ import {
   sigmaSpotlightCommunityId,
   sigmaSpotlightCommunityIds
 } from "./sigma-graphology-model";
+import {
+  createSigmaGlobalHitProjector,
+  sigmaNodeIdFromPayload,
+  sigmaScreenPointFromPayload,
+  type SigmaGlobalHitInput,
+  type SigmaGlobalHitProjector
+} from "./sigma-hit-projector";
 
 export type {
   SigmaGlobalCameraState,
@@ -88,6 +92,13 @@ export {
   sigmaGlobalEdgeStyle
 } from "./sigma-graphology-model";
 export type { SigmaGlobalEdgeStyle } from "./sigma-graphology-model";
+export { createSigmaGlobalHitProjector } from "./sigma-hit-projector";
+export type {
+  SigmaGlobalHitInput,
+  SigmaGlobalHitProjector,
+  SigmaGlobalHitProjectorInput,
+  SigmaGlobalRenderedObject
+} from "./sigma-hit-projector";
 
 export const SIGMA_GLOBAL_RENDERER_ID = "sigma-global" as const;
 
@@ -115,24 +126,6 @@ interface SigmaGlobalWheelPayload {
   preventSigmaDefault?: () => void;
 }
 
-export interface SigmaGlobalHitInput {
-  nodeId?: string | null;
-  screenPoint?: GraphScreenPoint | null;
-  renderedObject?: SigmaGlobalRenderedObject | null;
-}
-
-export interface SigmaGlobalHitProjectorInput {
-  adapterData: GraphRendererAdapterData;
-  viewport: RendererViewport;
-  viewportSize: RendererViewportSize;
-  screenPointToWorldPoint?: (point: GraphScreenPoint) => { x: number; y: number };
-}
-
-export interface SigmaGlobalHitProjector {
-  targetFromSigmaHit(input: SigmaGlobalHitInput): GraphGestureTarget;
-  index(): GraphSpatialIndex;
-}
-
 export async function sigmaGlobalRendererRuntimeBoundary(): Promise<SigmaGlobalRendererRuntimeBoundary> {
   const [{ default: Sigma }, { default: GraphologyGraph }] = await Promise.all([
     import("sigma"),
@@ -142,39 +135,6 @@ export async function sigmaGlobalRendererRuntimeBoundary(): Promise<SigmaGlobalR
   return {
     Sigma,
     GraphologyGraph
-  };
-}
-
-export function createSigmaGlobalHitProjector(input: SigmaGlobalHitProjectorInput): SigmaGlobalHitProjector {
-  const knownNodeIds = new Set(input.adapterData.nodes.map((node) => node.id));
-  const spatialIndex = createGraphSpatialIndex(spatialInputFromAdapterData(input.adapterData));
-
-  return {
-    targetFromSigmaHit(hit) {
-      if (hit.nodeId && knownNodeIds.has(hit.nodeId)) {
-        return { kind: "node", id: hit.nodeId };
-      }
-
-      const renderedObjectTarget = hit.renderedObject ? gestureTargetFromSigmaRenderedObject(hit.renderedObject, input.adapterData) : null;
-      if (renderedObjectTarget) return renderedObjectTarget;
-
-      if (hit.screenPoint) {
-        const worldPoint = input.screenPointToWorldPoint
-          ? input.screenPointToWorldPoint(hit.screenPoint)
-          : screenPointToWorldPoint(
-              hit.screenPoint,
-              input.viewport,
-              input.viewportSize,
-              input.adapterData.renderable.worldBounds
-            );
-        return graphSpatialHitToGestureTarget(spatialIndex.hitTest(worldPoint));
-      }
-
-      return { kind: "graph-blank" };
-    },
-    index() {
-      return spatialIndex;
-    }
   };
 }
 
@@ -1069,48 +1029,6 @@ function sigmaCommunitySpotlightCenter(
 
 function prefersReducedMotion(view: Window | null | undefined): boolean {
   return Boolean(view?.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
-}
-
-function sigmaNodeIdFromPayload(payload: unknown): string | null {
-  const candidate = payload as { node?: unknown } | null;
-  return typeof candidate?.node === "string" ? candidate.node : null;
-}
-
-function sigmaScreenPointFromPayload(payload: unknown): GraphScreenPoint | null {
-  const candidate = payload as { event?: { x?: unknown; y?: unknown }; x?: unknown; y?: unknown } | null;
-  const x = candidate?.event?.x ?? candidate?.x;
-  const y = candidate?.event?.y ?? candidate?.y;
-  return typeof x === "number" && typeof y === "number" ? { x, y } : null;
-}
-
-function spatialInputFromAdapterData(adapterData: GraphRendererAdapterData): GraphSpatialIndexInput {
-  const renderableEdgeById = new Map(adapterData.renderable.edges.map((edge) => [edge.id, edge]));
-  return {
-    nodes: adapterData.nodes.map((node) => ({
-      id: node.id,
-      label: node.label,
-      type: node.type,
-      point: node.point,
-      displayMode: node.render.displayMode,
-      visualRole: node.render.visualRole
-    })),
-    edges: adapterData.edges.map((edge) => ({
-      id: edge.id,
-      source: edge.sourceNodeId,
-      target: edge.targetNodeId,
-      curveOffset: renderableEdgeById.get(edge.id)?.curveOffset ?? 0
-    })),
-    communities: adapterData.renderable.communities.map((community) => ({
-      id: community.id,
-      wash: community.wash
-    })),
-    aggregationContainers: adapterData.renderable.aggregationContainers.map((aggregation) => ({
-      id: aggregation.id,
-      communityId: aggregation.communityId,
-      point: aggregation.point,
-      radius: aggregation.radius
-    }))
-  };
 }
 
 function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphRendererAdapterNode[] {

--- a/packages/graph-engine/src/render/sigma-global-renderer.ts
+++ b/packages/graph-engine/src/render/sigma-global-renderer.ts
@@ -41,9 +41,7 @@ import {
   SIGMA_BUTTON_ZOOM_RATIO,
   SIGMA_CAMERA_MAX_RATIO,
   SIGMA_CAMERA_MIN_RATIO,
-  sigmaButtonZoomRatio,
-  sigmaWheelZoomRatio,
-  type SigmaWheelDeltaLike
+  sigmaButtonZoomRatio
 } from "./sigma-zoom";
 import { preventSigmaDefault } from "./sigma-events";
 import type {
@@ -81,6 +79,11 @@ import {
   restoreCameraState,
   sigmaGlobalCameraState
 } from "./sigma-global-camera";
+import {
+  bindSigmaWheelZoomController,
+  sigmaViewportCenter,
+  type SigmaWheelZoomController
+} from "./sigma-wheel-zoom";
 
 export type {
   SigmaGlobalCameraState,
@@ -120,18 +123,6 @@ export const SIGMA_GLOBAL_RENDERER_BUNDLE_BOUNDARY = {
   workbench: "loads through the graph-engine ESM Sigma runtime boundary when global route manager selects Sigma",
   offlineHtml: "loads through the graph-engine IIFE Sigma runtime boundary when offline global route manager selects Sigma"
 } as const;
-
-interface SigmaGlobalWheelPayload {
-  x?: unknown;
-  y?: unknown;
-  delta?: unknown;
-  original?: {
-    deltaY?: unknown;
-    deltaMode?: unknown;
-    target?: unknown;
-  };
-  preventSigmaDefault?: () => void;
-}
 
 export async function sigmaGlobalRendererRuntimeBoundary(): Promise<SigmaGlobalRendererRuntimeBoundary> {
   const [{ default: Sigma }, { default: GraphologyGraph }] = await Promise.all([
@@ -186,7 +177,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
   let cameraSpotlightCommunityId: string | null = sigmaSpotlightCommunityId(adapterData);
   let suppressNextNodeClickId: string | null = null;
   let overlayPointerDragCleanup: (() => void) | null = null;
-  let sigmaWheelCleanup: (() => void) | null = null;
+  let sigmaWheelZoomController: SigmaWheelZoomController | null = null;
   let eventBindings: Array<{ event: string; listener: (payload?: unknown) => void }> = [];
   let resizeObserver: ResizeObserver | null = null;
   let resizeAnimationFrame: number | null = null;
@@ -199,7 +190,14 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
 
   try {
     sigma = new runtime.Sigma(graph, sigmaRoot, sigmaSettingsForTheme(currentTheme));
-    bindSigmaWheelZoom();
+    sigmaWheelZoomController = bindSigmaWheelZoomController({
+      sigma,
+      root: sigmaRoot,
+      isDestroyed: () => destroyed,
+      currentRatio: () => readCameraState(sigma)?.ratio ?? 1,
+      onZoomAtPoint: (point, nextRatio) => zoomSigmaCameraAtViewportPoint(point, nextRatio, false),
+      onFatalError: options.onFatalError
+    });
     bindSigmaEvents();
     bindSigmaResizeObserver();
     rebuildSigmaOverlays();
@@ -305,7 +303,8 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       cancelNodeDrag();
       destroyed = true;
       generation += 1;
-      unbindSigmaWheelZoom();
+      sigmaWheelZoomController?.destroy();
+      sigmaWheelZoomController = null;
       unbindSigmaEvents();
       cancelScheduledResizeRefresh();
       resizeObserver?.disconnect();
@@ -355,30 +354,6 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       sigma.off?.(binding.event, binding.listener);
     }
     eventBindings = [];
-  }
-
-  function bindSigmaWheelZoom(): void {
-    const captor = sigma.getMouseCaptor?.();
-    if (!captor?.on) return;
-    const listener = (payload?: unknown): void => handleSigmaWheelZoom(payload);
-    captor.on("wheel", listener);
-    sigmaWheelCleanup = () => captor.off?.("wheel", listener);
-  }
-
-  function unbindSigmaWheelZoom(): void {
-    sigmaWheelCleanup?.();
-    sigmaWheelCleanup = null;
-  }
-
-  function handleSigmaWheelZoom(payload: unknown): void {
-    if (destroyed) return;
-    const input = sigmaWheelInputFromPayload(payload, sigmaViewportCenter(sigmaRoot));
-    if (!input) return;
-    preventSigmaDefault(payload);
-    if (sigmaWheelTargetIsZoomControl(payload)) return;
-    const current = readCameraState(sigma) ?? { x: 0, y: 0, angle: 0, ratio: 1 };
-    const nextRatio = sigmaWheelZoomRatio(current.ratio, input.delta);
-    zoomSigmaCameraAtViewportPoint(input.point, nextRatio, false);
   }
 
   function zoomSigmaCameraAtViewportPoint(
@@ -832,7 +807,7 @@ function sigmaSettingsForTheme(theme: ThemeId): Record<string, unknown> {
     allowInvalidContainer: false,
     labelColor: sigmaLabelColor(theme),
     zoomingRatio: SIGMA_BUTTON_ZOOM_RATIO,
-    // Sigma 默认 wheel 的兜底参数：wheel 已被 handleSigmaWheelZoom 接管（preventSigmaDefault），
+    // Sigma 默认 wheel 的兜底参数：wheel 已被 sigma-wheel-zoom controller 接管（preventSigmaDefault），
     // zoomingRatio/zoomDuration 只在 Sigma 内置缩放入口（如 animatedZoom）被触发时生效，
     // 日常不走。项目按钮动画用的是 SIGMA_BUTTON_ZOOM_DURATION_MS（140），勿与这里的 120 混淆。
     zoomDuration: 120,
@@ -843,59 +818,6 @@ function sigmaSettingsForTheme(theme: ThemeId): Record<string, unknown> {
 
 function sigmaLabelColor(theme: ThemeId): { color: string } {
   return { color: theme === "mo-ye" ? "#f8fafc" : "#6b6256" };
-}
-
-function sigmaWheelInputFromPayload(payload: unknown, fallbackPoint: GraphScreenPoint): {
-  point: GraphScreenPoint;
-  delta: SigmaWheelDeltaLike;
-} | null {
-  const wheel = payload as SigmaGlobalWheelPayload | null;
-  const originalDeltaY = wheel?.original?.deltaY;
-  const fallbackDelta = wheel?.delta;
-  const deltaY = typeof originalDeltaY === "number"
-    ? originalDeltaY
-    : typeof fallbackDelta === "number"
-      ? -fallbackDelta * 120
-      : null;
-  if (deltaY == null || !Number.isFinite(deltaY)) return null;
-
-  const x = finiteNumber(wheel?.x, Number.NaN);
-  const y = finiteNumber(wheel?.y, Number.NaN);
-  const point = Number.isFinite(x) && Number.isFinite(y) ? { x, y } : fallbackPoint;
-  const originalDeltaMode = wheel?.original?.deltaMode;
-  return {
-    point,
-    delta: {
-      deltaY,
-      deltaMode: typeof originalDeltaMode === "number" ? originalDeltaMode : 0
-    }
-  };
-}
-
-// 防御性检查：判断 wheel 是否发生在左下缩放控件上。实际上 .graph-zoom-controls 是
-// 覆盖在 Sigma canvas 之上的独立 DOM，wheel 事件不会从它冒泡到 Sigma 的 mouse captor
-// （captor 绑在内部 canvas），所以这个分支在当前结构下正常不可达。保留是为了在控件
-// 层级/事件链日后变化时仍能挡住"滚到按钮上误缩放图谱"。
-function sigmaWheelTargetIsZoomControl(payload: unknown): boolean {
-  const wheel = payload as SigmaGlobalWheelPayload | null;
-  const target = wheel?.original?.target as {
-    closest?: (selector: string) => unknown;
-    parentElement?: { closest?: (selector: string) => unknown };
-  } | null | undefined;
-  return Boolean(
-    target?.closest?.("[data-control=\"sigma-zoom\"]") ||
-    target?.parentElement?.closest?.("[data-control=\"sigma-zoom\"]")
-  );
-}
-
-function sigmaViewportCenter(root: HTMLElement): GraphScreenPoint {
-  const rect = typeof root.getBoundingClientRect === "function" ? root.getBoundingClientRect() : null;
-  const width = finiteNumber(rect?.width, 1000);
-  const height = finiteNumber(rect?.height, 680);
-  return {
-    x: width / 2,
-    y: height / 2
-  };
 }
 
 function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphRendererAdapterNode[] {

--- a/packages/graph-engine/src/render/sigma-global-types.ts
+++ b/packages/graph-engine/src/render/sigma-global-types.ts
@@ -1,0 +1,96 @@
+import type { GraphEdgeStyleOptions, PinMap, ThemeId } from "../types";
+import type { GraphRendererAdapterData } from "./adapter";
+import type { GraphScreenPoint } from "./geometry";
+import type { GraphGestureTarget } from "./gestures";
+import type { RendererViewport, RendererViewportSize } from "./viewport";
+
+export interface SigmaGlobalRendererRuntimeBoundary {
+  Sigma: typeof import("sigma").default;
+  GraphologyGraph: typeof import("graphology").default;
+}
+
+export type SigmaGlobalGraphologyGraph = InstanceType<SigmaGlobalRendererRuntimeBoundary["GraphologyGraph"]>;
+
+export interface SigmaGlobalCameraState {
+  x: number;
+  y: number;
+  angle: number;
+  ratio: number;
+}
+
+export interface SigmaGlobalCameraLike {
+  getState?: () => SigmaGlobalCameraState;
+  setState?: (state: Partial<SigmaGlobalCameraState>) => unknown;
+  isAnimated?: () => boolean;
+  animate?: (
+    state: Partial<SigmaGlobalCameraState>,
+    options?: { duration?: number; easing?: string }
+  ) => unknown;
+}
+
+export interface SigmaGlobalMouseCaptorLike {
+  on?: (event: "wheel", listener: (payload?: unknown) => void) => unknown;
+  off?: (event: "wheel", listener: (payload?: unknown) => void) => unknown;
+}
+
+export interface SigmaGlobalSigmaLike {
+  getCamera?: () => SigmaGlobalCameraLike;
+  getMouseCaptor?: () => SigmaGlobalMouseCaptorLike;
+  getViewportZoomedState?: (viewportTarget: GraphScreenPoint, newRatio: number) => SigmaGlobalCameraState;
+  getGraph?: () => unknown;
+  setGraph?: (graph: SigmaGlobalGraphologyGraph) => unknown;
+  getSetting?: (key: string) => unknown;
+  setSetting?: (key: string, value: unknown) => unknown;
+  viewportToGraph?: (point: GraphScreenPoint) => { x: number; y: number };
+  viewportToFramedGraph?: (point: GraphScreenPoint) => { x: number; y: number };
+  graphToViewport?: (point: { x: number; y: number }) => GraphScreenPoint;
+  refresh?: () => unknown;
+  on?: (event: string, listener: (payload?: unknown) => void) => unknown;
+  off?: (event: string, listener: (payload?: unknown) => void) => unknown;
+  kill?: () => unknown;
+}
+
+export interface SigmaGlobalGraphologyRuntime {
+  GraphologyGraph: SigmaGlobalRendererRuntimeBoundary["GraphologyGraph"];
+}
+
+export interface SigmaGlobalRendererRuntime extends SigmaGlobalGraphologyRuntime {
+  Sigma: new (graph: SigmaGlobalGraphologyGraph, container: HTMLElement, settings?: Record<string, unknown>) => SigmaGlobalSigmaLike;
+}
+
+export interface SigmaGlobalRendererCreateOptions {
+  container: HTMLElement;
+  adapterData: GraphRendererAdapterData;
+  theme: ThemeId;
+  edgeStyle?: GraphEdgeStyleOptions;
+  onHitTarget?: (target: GraphGestureTarget) => void;
+  onPinsChanged?: (pins: PinMap) => void;
+  onDragActiveChange?: (dragging: boolean) => void;
+  onFatalError?: (error: unknown) => void;
+  pins?: PinMap;
+  runtime?: SigmaGlobalRendererRuntime;
+  viewport?: RendererViewport;
+  viewportSize?: RendererViewportSize;
+}
+
+export interface SigmaGlobalRendererUpdateOptions {
+  adapterData: GraphRendererAdapterData;
+  theme?: ThemeId;
+  edgeStyle?: GraphEdgeStyleOptions;
+  pins?: PinMap;
+}
+
+export interface SigmaGlobalRenderer {
+  readonly id: "sigma-global";
+  readonly root: HTMLElement;
+  readonly overlayRoot: HTMLElement;
+  readonly graph: SigmaGlobalGraphologyGraph;
+  readonly updateStrategy: "rebuild-graph-preserve-camera";
+  readonly lastHitTarget: GraphGestureTarget | null;
+  isDragging(): boolean;
+  resetView(): void;
+  zoomIn(): void;
+  zoomOut(): void;
+  update(options: SigmaGlobalRendererUpdateOptions): void;
+  destroy(): void;
+}

--- a/packages/graph-engine/src/render/sigma-graphology-model.ts
+++ b/packages/graph-engine/src/render/sigma-graphology-model.ts
@@ -1,0 +1,373 @@
+import type { GraphEdgeStyleOptions, ThemeId } from "../types";
+import { getThemeTokens } from "../themes";
+import type {
+  GraphRendererAdapterAggregation,
+  GraphRendererAdapterCommunity,
+  GraphRendererAdapterData,
+  GraphRendererAdapterEdge,
+  GraphRendererAdapterNode
+} from "./adapter";
+import { edgeRelationClass } from "./model";
+import type { SigmaGlobalGraphologyGraph, SigmaGlobalGraphologyRuntime } from "./sigma-global-types";
+
+export interface SigmaGlobalGraphologyNodeAttributes {
+  x: number;
+  y: number;
+  label: string;
+  size: number;
+  color: string;
+  type: string;
+  graphNodeType: string;
+  communityId: string | null;
+  sourcePath: string;
+  selected: boolean;
+  searchHit: boolean;
+  pinned: boolean;
+  communityDimmed: boolean;
+  communitySpotlightVisible: boolean;
+  aggregationIds: string[];
+  labelVisible: boolean;
+  displayMode: string;
+  visualRole: string;
+  priority: number;
+  drawerTarget: GraphRendererAdapterNode["drawerTarget"];
+}
+
+export interface SigmaGlobalGraphologyEdgeAttributes {
+  size: number;
+  color: string;
+  relationType: string | null;
+  confidence: string | null;
+  weight: number;
+  sourceCommunityId: string | null;
+  targetCommunityId: string | null;
+}
+
+export interface SigmaGlobalGraphologyCommunityAttributes {
+  id: string;
+  label: string;
+  color: string;
+  nodeIds: string[];
+  nodeCount: number;
+  selected: boolean;
+  searchResultIds: string[];
+  pinnedNodeIds: string[];
+  aggregationIds: string[];
+  drawerTarget: GraphRendererAdapterCommunity["drawerTarget"];
+  commands: GraphRendererAdapterCommunity["commands"];
+}
+
+export interface SigmaGlobalGraphologyAggregationAttributes {
+  id: string;
+  label: string;
+  communityId: string | null;
+  nodeIds: string[];
+  selectedNodeIds: string[];
+  searchResultIds: string[];
+  pinnedNodeIds: string[];
+  totalCount: number;
+  selected: boolean;
+  color: string;
+  point: { x: number; y: number } | null;
+  radius: number | null;
+  drawerTarget: GraphRendererAdapterAggregation["drawerTarget"];
+  commands: GraphRendererAdapterAggregation["commands"];
+}
+
+export interface SigmaGlobalEdgeStyle {
+  color: string;
+  size: number;
+}
+
+export function buildSigmaGlobalGraphologyGraph(
+  adapterData: GraphRendererAdapterData,
+  runtime: SigmaGlobalGraphologyRuntime,
+  theme: ThemeId = "shan-shui",
+  edgeStyle?: GraphEdgeStyleOptions
+): SigmaGlobalGraphologyGraph {
+  const graph = new runtime.GraphologyGraph({ multi: true, type: "mixed" });
+  const communityColorById = new Map(adapterData.renderable.communities.map((community) => [community.id, community.color]));
+  const aggregationRenderById = new Map(adapterData.renderable.aggregationContainers.map((aggregation) => [aggregation.id, aggregation]));
+  const selectedCommunityIds = sigmaSelectedCommunityIds(adapterData);
+  const spotlightCommunityIds = sigmaSpotlightCommunityIds(adapterData);
+
+  for (const node of adapterData.nodes) {
+    graph.addNode(node.id, sigmaGlobalNodeAttributes(node, communityColorById, spotlightCommunityIds));
+  }
+
+  for (const edge of adapterData.edges) {
+    graph.addEdgeWithKey(edge.id, edge.sourceNodeId, edge.targetNodeId, sigmaGlobalEdgeAttributes(edge, theme, edgeStyle, selectedCommunityIds));
+  }
+
+  graph.setAttribute("counts", adapterData.counts);
+  graph.setAttribute("selection", adapterData.selection);
+  graph.setAttribute(
+    "communities",
+    adapterData.communities.map((community) => sigmaGlobalCommunityAttributes(community, communityColorById))
+  );
+  graph.setAttribute(
+    "aggregations",
+    adapterData.aggregations.map((aggregation) => sigmaGlobalAggregationAttributes(aggregation, aggregationRenderById))
+  );
+
+  return graph;
+}
+
+export function canPatchSigmaGlobalGraphAttributes(
+  current: GraphRendererAdapterData,
+  next: GraphRendererAdapterData,
+  currentTheme: ThemeId,
+  nextTheme: ThemeId
+): boolean {
+  if (currentTheme !== nextTheme) return false;
+  if (current.nodes.length !== next.nodes.length || current.edges.length !== next.edges.length) return false;
+  return current.nodes.every((node, index) => node.id === next.nodes[index]?.id)
+    && current.edges.every((edge, index) => {
+      const nextEdge = next.edges[index];
+      return Boolean(nextEdge)
+        && edge.id === nextEdge.id
+        && edge.sourceNodeId === nextEdge.sourceNodeId
+        && edge.targetNodeId === nextEdge.targetNodeId;
+    });
+}
+
+export function patchSigmaGlobalGraphAttributes(
+  graph: SigmaGlobalGraphologyGraph,
+  adapterData: GraphRendererAdapterData,
+  theme: ThemeId,
+  edgeStyle?: GraphEdgeStyleOptions
+): void {
+  const communityColorById = new Map(adapterData.renderable.communities.map((community) => [community.id, community.color]));
+  const aggregationRenderById = new Map(adapterData.renderable.aggregationContainers.map((aggregation) => [aggregation.id, aggregation]));
+  const selectedCommunityIds = sigmaSelectedCommunityIds(adapterData);
+  const spotlightCommunityIds = sigmaSpotlightCommunityIds(adapterData);
+
+  for (const node of adapterData.nodes) {
+    if (!graph.hasNode(node.id)) continue;
+    graph.mergeNodeAttributes(node.id, sigmaGlobalNodeAttributes(node, communityColorById, spotlightCommunityIds));
+  }
+  for (const edge of adapterData.edges) {
+    graph.mergeEdgeAttributes(edge.id, sigmaGlobalEdgeAttributes(edge, theme, edgeStyle, selectedCommunityIds));
+  }
+  graph.setAttribute("counts", adapterData.counts);
+  graph.setAttribute("selection", adapterData.selection);
+  graph.setAttribute(
+    "communities",
+    adapterData.communities.map((community) => sigmaGlobalCommunityAttributes(community, communityColorById))
+  );
+  graph.setAttribute(
+    "aggregations",
+    adapterData.aggregations.map((aggregation) => sigmaGlobalAggregationAttributes(aggregation, aggregationRenderById))
+  );
+}
+
+export function sigmaGlobalNodeAttributes(
+  node: GraphRendererAdapterNode,
+  communityColorById: Map<string, string>,
+  selectedCommunityIds: ReadonlySet<string> = new Set()
+): SigmaGlobalGraphologyNodeAttributes {
+  const spotlight = sigmaGlobalNodeSpotlightState(node, selectedCommunityIds);
+  const baseSize = sigmaGlobalNodeSize(node);
+  const baseColor = sigmaGlobalNodeColor(node, communityColorById);
+  return {
+    x: finiteNumber(node.point.x, 0),
+    y: finiteNumber(node.point.y, 0),
+    label: node.render.labelVisible ? node.label : "",
+    size: spotlight.dimmed ? roundNumber(baseSize * 0.72, 2) : baseSize,
+    color: spotlight.dimmed ? rgbaColor(baseColor, 0.2) : baseColor,
+    type: "circle",
+    graphNodeType: node.type,
+    communityId: node.communityId,
+    sourcePath: node.sourcePath,
+    selected: node.selected,
+    searchHit: node.searchHit,
+    pinned: node.pinHint.pinned,
+    communityDimmed: spotlight.dimmed,
+    communitySpotlightVisible: spotlight.forceVisible,
+    aggregationIds: [...node.aggregationIds],
+    labelVisible: node.render.labelVisible,
+    displayMode: node.render.displayMode,
+    visualRole: node.render.visualRole,
+    priority: finiteNumber(node.render.priority, 0),
+    drawerTarget: node.drawerTarget
+  };
+}
+
+export function sigmaSelectedCommunityIds(adapterData: GraphRendererAdapterData): Set<string> {
+  return new Set(adapterData.communities.filter((community) => community.selected).map((community) => community.id));
+}
+
+export function sigmaSpotlightCommunityIds(adapterData: GraphRendererAdapterData): Set<string> {
+  const communityId = sigmaSpotlightCommunityId(adapterData);
+  return communityId ? new Set([communityId]) : new Set();
+}
+
+export function sigmaSpotlightCommunityId(adapterData: GraphRendererAdapterData): string | null {
+  return adapterData.selection.input?.kind === "community" ? adapterData.selection.input.id : null;
+}
+
+export function sigmaGlobalNodeSpotlightState(
+  node: GraphRendererAdapterNode,
+  selectedCommunityIds: ReadonlySet<string>
+): { dimmed: boolean; forceVisible: boolean } {
+  const forceVisible = node.selected || node.searchHit || node.pinHint.pinned;
+  const inSelectedCommunity = Boolean(node.communityId && selectedCommunityIds.has(node.communityId));
+  return {
+    forceVisible,
+    dimmed: selectedCommunityIds.size > 0 && !inSelectedCommunity && !forceVisible
+  };
+}
+
+export function sigmaGlobalEdgeAttributes(
+  edge: GraphRendererAdapterEdge,
+  theme: ThemeId = "shan-shui",
+  style?: GraphEdgeStyleOptions,
+  selectedCommunityIds: ReadonlySet<string> = new Set()
+): SigmaGlobalGraphologyEdgeAttributes {
+  const edgeStyle = sigmaGlobalEdgeStyle(edge, theme, style, selectedCommunityIds);
+  return {
+    size: edgeStyle.size,
+    color: edgeStyle.color,
+    relationType: edge.relationType == null ? null : String(edge.relationType),
+    confidence: edge.confidence == null ? null : String(edge.confidence),
+    weight: finiteNumber(edge.weight, 0),
+    sourceCommunityId: edge.sourceCommunityId,
+    targetCommunityId: edge.targetCommunityId
+  };
+}
+
+export function sigmaGlobalEdgeStyle(
+  edge: GraphRendererAdapterEdge,
+  theme: ThemeId = "shan-shui",
+  style?: GraphEdgeStyleOptions,
+  selectedCommunityIds: ReadonlySet<string> = new Set()
+): SigmaGlobalEdgeStyle {
+  const relationClass = edgeRelationClass(edge.relationType);
+  const semantic = relationClass === "relation-contrast" || relationClass === "relation-conflict";
+  const bridge = Boolean(edge.sourceCommunityId && edge.targetCommunityId && edge.sourceCommunityId !== edge.targetCommunityId);
+  const weight = clamp(finiteNumber(edge.weight, 0), 0, 1);
+  let alpha = semantic ? (bridge ? 0.58 : 0.5) + weight * 0.08 : (bridge ? 0.34 : 0.1) + weight * (bridge ? 0.08 : 0.06);
+  let size = semantic ? (bridge ? 1.65 : 1.25) + weight * 0.6 : (bridge ? 1.1 : 0.72) + weight * (bridge ? 0.85 : 0.55);
+
+  if (style?.semanticEmphasis) {
+    if (semantic) {
+      alpha = alpha * 1.16 + 0.04;
+      size += 0.45;
+    } else {
+      alpha *= 0.6;
+      size *= 0.75;
+    }
+  }
+
+  if (style?.focusHighlight && selectedCommunityIds.size > 0) {
+    const touchesSelectedCommunity =
+      Boolean(edge.sourceCommunityId && selectedCommunityIds.has(edge.sourceCommunityId))
+      || Boolean(edge.targetCommunityId && selectedCommunityIds.has(edge.targetCommunityId));
+    if (touchesSelectedCommunity) {
+      alpha = alpha * 1.12 + 0.02;
+      size += semantic ? 0.2 : 0.12;
+    } else {
+      alpha *= 0.05;
+      size *= 0.55;
+    }
+  }
+
+  alpha = roundNumber(clamp(alpha, 0.05, 0.7), 3);
+  size = roundNumber(clamp(size, 0.6, 4), 2);
+
+  return {
+    color: rgbaColor(sigmaGlobalEdgeRelationColor(relationClass, theme), alpha),
+    size
+  };
+}
+
+export function sigmaGlobalEdgeRelationColor(relationClass: string, theme: ThemeId): string {
+  const vars = getThemeTokens(theme).vars;
+  if (relationClass === "relation-contrast") return vars["--amber"] ?? (theme === "mo-ye" ? "#e0b35e" : "#b7791f");
+  if (relationClass === "relation-conflict") return theme === "mo-ye" ? "#f472b6" : "#d94693";
+  if (theme === "mo-ye") return vars["--line"] ?? "#8e8778";
+  return vars["--night"] ?? "#315f72";
+}
+
+export function rgbaColor(hexColor: string, alpha: number): string {
+  const hex = hexColor.trim().replace(/^#/, "");
+  const normalized = hex.length === 3
+    ? hex.split("").map((part) => `${part}${part}`).join("")
+    : hex;
+  const red = Number.parseInt(normalized.slice(0, 2), 16);
+  const green = Number.parseInt(normalized.slice(2, 4), 16);
+  const blue = Number.parseInt(normalized.slice(4, 6), 16);
+  if (![red, green, blue].every(Number.isFinite)) return `rgba(49, 95, 114, ${alpha})`;
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+}
+
+export function sigmaGlobalCommunityAttributes(
+  community: GraphRendererAdapterCommunity,
+  communityColorById: Map<string, string>
+): SigmaGlobalGraphologyCommunityAttributes {
+  return {
+    id: community.id,
+    label: community.label,
+    color: communityColorById.get(community.id) ?? "#64748b",
+    nodeIds: [...community.nodeIds],
+    nodeCount: community.nodeCount,
+    selected: community.selected,
+    searchResultIds: [...community.searchResultIds],
+    pinnedNodeIds: community.pinHints.map((hint) => hint.nodeId),
+    aggregationIds: [...community.aggregationIds],
+    drawerTarget: community.drawerTarget,
+    commands: community.commands
+  };
+}
+
+export function sigmaGlobalAggregationAttributes(
+  aggregation: GraphRendererAdapterAggregation,
+  aggregationRenderById: Map<string, GraphRendererAdapterData["renderable"]["aggregationContainers"][number]>
+): SigmaGlobalGraphologyAggregationAttributes {
+  const render = aggregationRenderById.get(aggregation.id);
+  return {
+    id: aggregation.id,
+    label: aggregation.label,
+    communityId: aggregation.communityId,
+    nodeIds: [...aggregation.nodeIds],
+    selectedNodeIds: [...aggregation.selectedNodeIds],
+    searchResultIds: [...aggregation.searchResultIds],
+    pinnedNodeIds: [...aggregation.pinnedNodeIds],
+    totalCount: aggregation.totalCount,
+    selected: aggregation.selected,
+    color: render?.color ?? "#64748b",
+    point: render ? { ...render.point } : null,
+    radius: render ? finiteNumber(render.radius, 0) : null,
+    drawerTarget: aggregation.drawerTarget,
+    commands: aggregation.commands
+  };
+}
+
+export function sigmaGlobalNodeSize(node: GraphRendererAdapterNode): number {
+  if (node.pinHint.pinned || node.selected) return 10;
+  if (node.searchHit) return 9;
+  if (node.render.displayMode === "card") return 8;
+  if (node.render.displayMode === "compact-card") return 7;
+  if (node.render.displayMode === "overview") return 6;
+  return 5;
+}
+
+export function sigmaGlobalNodeColor(node: GraphRendererAdapterNode, communityColorById: Map<string, string>): string {
+  if (node.selected) return "#ef4444";
+  if (node.searchHit) return "#f59e0b";
+  if (node.pinHint.pinned) return "#0ea5e9";
+  return node.communityId ? communityColorById.get(node.communityId) ?? "#64748b" : "#64748b";
+}
+
+export function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function roundNumber(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}

--- a/packages/graph-engine/src/render/sigma-hit-projector.ts
+++ b/packages/graph-engine/src/render/sigma-hit-projector.ts
@@ -1,0 +1,125 @@
+import { createGraphSpatialIndex, type GraphSpatialIndex, type GraphSpatialIndexInput } from "../layout";
+import type { GraphRendererAdapterData } from "./adapter";
+import { screenPointToWorldPoint, type GraphScreenPoint } from "./geometry";
+import { graphSpatialHitToGestureTarget, type GraphGestureTarget } from "./gestures";
+import type { RendererViewport, RendererViewportSize } from "./viewport";
+
+export type SigmaGlobalRenderedObject =
+  | { kind: "node"; id: string }
+  | { kind: "edge"; id: string }
+  | { kind: "community-wash"; id: string }
+  | { kind: "aggregation-container"; id: string; communityId?: string | null };
+
+export interface SigmaGlobalHitInput {
+  nodeId?: string | null;
+  screenPoint?: GraphScreenPoint | null;
+  renderedObject?: SigmaGlobalRenderedObject | null;
+}
+
+export interface SigmaGlobalHitProjectorInput {
+  adapterData: GraphRendererAdapterData;
+  viewport: RendererViewport;
+  viewportSize: RendererViewportSize;
+  screenPointToWorldPoint?: (point: GraphScreenPoint) => { x: number; y: number };
+}
+
+export interface SigmaGlobalHitProjector {
+  targetFromSigmaHit(input: SigmaGlobalHitInput): GraphGestureTarget;
+  index(): GraphSpatialIndex;
+}
+
+export function createSigmaGlobalHitProjector(input: SigmaGlobalHitProjectorInput): SigmaGlobalHitProjector {
+  const knownNodeIds = new Set(input.adapterData.nodes.map((node) => node.id));
+  const spatialIndex = createGraphSpatialIndex(spatialInputFromAdapterData(input.adapterData));
+
+  return {
+    targetFromSigmaHit(hit) {
+      if (hit.nodeId && knownNodeIds.has(hit.nodeId)) {
+        return { kind: "node", id: hit.nodeId };
+      }
+
+      const renderedObjectTarget = hit.renderedObject ? gestureTargetFromSigmaRenderedObject(hit.renderedObject, input.adapterData) : null;
+      if (renderedObjectTarget) return renderedObjectTarget;
+
+      if (hit.screenPoint) {
+        const worldPoint = input.screenPointToWorldPoint
+          ? input.screenPointToWorldPoint(hit.screenPoint)
+          : screenPointToWorldPoint(
+              hit.screenPoint,
+              input.viewport,
+              input.viewportSize,
+              input.adapterData.renderable.worldBounds
+            );
+        return graphSpatialHitToGestureTarget(spatialIndex.hitTest(worldPoint));
+      }
+
+      return { kind: "graph-blank" };
+    },
+    index() {
+      return spatialIndex;
+    }
+  };
+}
+
+export function sigmaNodeIdFromPayload(payload: unknown): string | null {
+  const candidate = payload as { node?: unknown } | null;
+  return typeof candidate?.node === "string" ? candidate.node : null;
+}
+
+export function sigmaScreenPointFromPayload(payload: unknown): GraphScreenPoint | null {
+  const candidate = payload as { event?: { x?: unknown; y?: unknown }; x?: unknown; y?: unknown } | null;
+  const x = candidate?.event?.x ?? candidate?.x;
+  const y = candidate?.event?.y ?? candidate?.y;
+  return typeof x === "number" && typeof y === "number" ? { x, y } : null;
+}
+
+export function spatialInputFromAdapterData(adapterData: GraphRendererAdapterData): GraphSpatialIndexInput {
+  const renderableEdgeById = new Map(adapterData.renderable.edges.map((edge) => [edge.id, edge]));
+  return {
+    nodes: adapterData.nodes.map((node) => ({
+      id: node.id,
+      label: node.label,
+      type: node.type,
+      point: node.point,
+      displayMode: node.render.displayMode,
+      visualRole: node.render.visualRole
+    })),
+    edges: adapterData.edges.map((edge) => ({
+      id: edge.id,
+      source: edge.sourceNodeId,
+      target: edge.targetNodeId,
+      curveOffset: renderableEdgeById.get(edge.id)?.curveOffset ?? 0
+    })),
+    communities: adapterData.renderable.communities.map((community) => ({
+      id: community.id,
+      wash: community.wash
+    })),
+    aggregationContainers: adapterData.renderable.aggregationContainers.map((aggregation) => ({
+      id: aggregation.id,
+      communityId: aggregation.communityId,
+      point: aggregation.point,
+      radius: aggregation.radius
+    }))
+  };
+}
+
+export function gestureTargetFromSigmaRenderedObject(
+  object: SigmaGlobalRenderedObject,
+  adapterData: GraphRendererAdapterData
+): GraphGestureTarget | null {
+  switch (object.kind) {
+    case "node":
+      return adapterData.nodes.some((node) => node.id === object.id) ? { kind: "node", id: object.id } : null;
+    case "edge":
+      return adapterData.edges.some((edge) => edge.id === object.id) ? { kind: "edge", id: object.id } : null;
+    case "community-wash":
+      return adapterData.communities.some((community) => community.id === object.id) ? { kind: "community-wash", id: object.id } : null;
+    case "aggregation-container": {
+      const aggregation = adapterData.aggregations.find((item) => item.id === object.id);
+      if (!aggregation) return null;
+      return { kind: "aggregation-container", id: object.id, communityId: object.communityId ?? aggregation.communityId };
+    }
+    default:
+      return null;
+  }
+}

--- a/packages/graph-engine/src/render/sigma-overlay-dom.ts
+++ b/packages/graph-engine/src/render/sigma-overlay-dom.ts
@@ -1,0 +1,332 @@
+import type {
+  GraphRendererAdapterData,
+  GraphRendererAdapterNode
+} from "./adapter";
+import type { SigmaCommunityCloud } from "./community-cloud-geometry";
+import type { GraphScreenPoint } from "./geometry";
+import {
+  bindSigmaGlobalOverlayMouseDrag,
+  bindSigmaGlobalOverlayPointerDrag
+} from "./sigma-global-drag";
+import {
+  sigmaWorldPointToScreenPoint
+} from "./sigma-coordinates";
+import {
+  sigmaGlobalNodeSize,
+  sigmaGlobalNodeSpotlightState,
+  sigmaSelectedCommunityIds,
+  sigmaSpotlightCommunityIds
+} from "./sigma-graphology-model";
+import type {
+  SigmaGlobalRendererCreateOptions,
+  SigmaGlobalSigmaLike
+} from "./sigma-global-types";
+import type { SigmaGlobalRenderedObject } from "./sigma-hit-projector";
+import {
+  applyOverlayBox,
+  applySigmaCloudColor,
+  applySigmaCloudGeometry,
+  createSigmaCloudSvg,
+  sigmaOverlayButton,
+  sigmaOverlayPassiveElement,
+  type SigmaCloudKind
+} from "./sigma-overlay-svg";
+
+const SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT = 8;
+const SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT = 160;
+
+export interface SigmaOverlayDomController {
+  rebuild(): void;
+  reposition(): void;
+  clearActiveDragListeners(): void;
+  destroy(): void;
+}
+
+export interface SigmaOverlayDomControllerInput {
+  overlayRoot: HTMLElement;
+  cloudFilterId: string;
+  getAdapterData: () => GraphRendererAdapterData;
+  getSigma: () => SigmaGlobalSigmaLike;
+  getOptions: () => Pick<SigmaGlobalRendererCreateOptions, "viewport" | "viewportSize" | "adapterData">;
+  communityCloudFor: (communityId: string, wash: { cx: number; cy: number; rx: number; ry: number }) => SigmaCommunityCloud;
+  isDestroyed: () => boolean;
+  onHit: (object: SigmaGlobalRenderedObject) => void;
+  beginNodeDrag: (nodeId: string, point: GraphScreenPoint, payload?: unknown) => void;
+  moveNodeDrag: (point: GraphScreenPoint, payload?: unknown) => void;
+  commitNodeDrag: (point: GraphScreenPoint | null, payload?: unknown) => void;
+  cancelNodeDrag: () => void;
+  screenPointFromEvent: (event: MouseEvent | PointerEvent) => GraphScreenPoint;
+  consumeSuppressedNodeClick: (nodeId: string | null) => boolean;
+  activeNodeDragId: () => string | null;
+}
+
+export function createSigmaOverlayDomController(input: SigmaOverlayDomControllerInput): SigmaOverlayDomController {
+  const overlayRegionEntries = new Map<string, { element: HTMLElement; shape: SVGElement; kind: SigmaCloudKind }>();
+  const overlayNodeEntries = new Map<string, HTMLButtonElement>();
+  const overlayLabelEntries = new Map<string, HTMLElement>();
+  let overlayPointerDragCleanup: (() => void) | null = null;
+
+  return {
+    rebuild,
+    reposition,
+    clearActiveDragListeners,
+    destroy
+  };
+
+  function rebuild(): void {
+    if (input.isDestroyed()) return;
+    const adapterData = input.getAdapterData();
+    const ordered: HTMLElement[] = [];
+    const selectedCommunityIds = sigmaSelectedCommunityIds(adapterData);
+    const spotlightCommunityIds = sigmaSpotlightCommunityIds(adapterData);
+
+    const nextRegionIds = new Set<string>();
+    for (const community of adapterData.renderable.communities) {
+      if (!community.wash) continue;
+      nextRegionIds.add(community.id);
+      const cloud = input.communityCloudFor(community.id, community.wash);
+      const kind: SigmaCloudKind = cloud.localPoints ? "polygon" : "ellipse";
+      let entry = overlayRegionEntries.get(community.id);
+      if (!entry || entry.kind !== kind) {
+        const element = sigmaOverlayPassiveElement(input.overlayRoot.ownerDocument, "community-region", community.id);
+        element.className = "sigma-global-community-region";
+        element.dataset.communityId = community.id;
+        element.style.overflow = "visible";
+        const handle = createSigmaCloudSvg(input.overlayRoot.ownerDocument, cloud, input.cloudFilterId, () => {
+          input.onHit({ kind: "community-wash", id: community.id });
+        });
+        element.append(handle.svg);
+        entry = { element, shape: handle.shape, kind: handle.kind };
+        overlayRegionEntries.set(community.id, entry);
+      }
+      const selected = selectedCommunityIds.has(community.id);
+      const dim = selectedCommunityIds.size > 0 && !selected;
+      entry.element.dataset.selected = selected ? "true" : "false";
+      applySigmaCloudColor(entry.shape, community.color, dim);
+      ordered.push(entry.element);
+    }
+    pruneOverlayEntries(overlayRegionEntries, nextRegionIds);
+
+    const nextNodeIds = new Set<string>();
+    for (const node of sigmaOverlayNodes(adapterData)) {
+      nextNodeIds.add(node.id);
+      let element = overlayNodeEntries.get(node.id);
+      if (!element) {
+        element = createSigmaNodeHitTarget(node.id, node.label || node.id);
+        overlayNodeEntries.set(node.id, element);
+      }
+      element.setAttribute("aria-label", node.label || node.id);
+      element.dataset.nodeId = node.id;
+      element.dataset.searchHit = node.searchHit ? "true" : "false";
+      element.dataset.selected = node.selected ? "true" : "false";
+      element.dataset.pinned = node.pinHint.pinned ? "true" : "false";
+      element.dataset.communityDimmed = sigmaGlobalNodeSpotlightState(node, spotlightCommunityIds).dimmed ? "true" : "false";
+      ordered.push(element);
+    }
+    pruneOverlayEntries(overlayNodeEntries, nextNodeIds);
+
+    const nextLabelIds = new Set<string>();
+    for (const community of sigmaCommunityLabels(adapterData, SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT)) {
+      if (!community.wash) continue;
+      nextLabelIds.add(community.id);
+      let element = overlayLabelEntries.get(community.id);
+      if (!element) {
+        element = sigmaOverlayPassiveElement(input.overlayRoot.ownerDocument, "community-label", community.id);
+        element.className = "sigma-global-community-label";
+        element.dataset.communityId = community.id;
+        overlayLabelEntries.set(community.id, element);
+      }
+      const labelSelected = selectedCommunityIds.has(community.id);
+      element.dataset.selected = labelSelected ? "true" : "false";
+      element.dataset.dim = selectedCommunityIds.size > 0 && !labelSelected ? "true" : "false";
+      element.textContent = community.label || community.id;
+      ordered.push(element);
+    }
+    pruneOverlayEntries(overlayLabelEntries, nextLabelIds);
+
+    input.overlayRoot.replaceChildren(...ordered);
+    reposition();
+  }
+
+  function reposition(): void {
+    if (input.isDestroyed()) return;
+    const adapterData = input.getAdapterData();
+    const sigma = input.getSigma();
+    const options = input.getOptions();
+    for (const community of adapterData.renderable.communities) {
+      if (!community.wash) continue;
+      const entry = overlayRegionEntries.get(community.id);
+      if (!entry) continue;
+      const cloud = input.communityCloudFor(community.id, community.wash);
+      applyOverlayBox(entry.element, cloud.box);
+      applySigmaCloudGeometry(entry.shape, entry.kind, cloud);
+    }
+    for (const node of sigmaOverlayNodes(adapterData)) {
+      const element = overlayNodeEntries.get(node.id);
+      if (!element) continue;
+      const size = Math.max(16, sigmaGlobalNodeSize(node) * 3);
+      const center = sigmaWorldPointToScreenPoint(sigma, node.point, options);
+      applyOverlayBox(element, {
+        left: center.x - size / 2,
+        top: center.y - size / 2,
+        width: size,
+        height: size
+      });
+    }
+    for (const community of sigmaCommunityLabels(adapterData, SIGMA_GLOBAL_COMMUNITY_LABEL_LIMIT)) {
+      if (!community.wash) continue;
+      const element = overlayLabelEntries.get(community.id);
+      if (!element) continue;
+      const center = sigmaWorldPointToScreenPoint(sigma, {
+        x: community.wash.cx,
+        y: community.wash.cy - community.wash.ry * 0.16
+      }, options);
+      applyOverlayBox(element, {
+        left: center.x,
+        top: center.y,
+        width: 160,
+        height: 22
+      });
+    }
+  }
+
+  function destroy(): void {
+    clearActiveDragListeners();
+    overlayRegionEntries.clear();
+    overlayNodeEntries.clear();
+    overlayLabelEntries.clear();
+    input.overlayRoot.replaceChildren();
+  }
+
+  function createSigmaNodeHitTarget(nodeId: string, label: string): HTMLButtonElement {
+    const element = sigmaOverlayButton(input.overlayRoot.ownerDocument, "node", nodeId, label);
+    element.className = "sigma-global-node-hit-target";
+    element.addEventListener("click", (event) => {
+      event.stopPropagation();
+      if (input.consumeSuppressedNodeClick(nodeId)) return;
+      input.onHit({ kind: "node", id: nodeId });
+    });
+    element.addEventListener("pointerdown", (event) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      input.beginNodeDrag(nodeId, input.screenPointFromEvent(event), event);
+      if (input.activeNodeDragId() === nodeId) {
+        bindOverlayPointerDragListeners(element.ownerDocument, element, nodeId, event.pointerId);
+      }
+    });
+    element.addEventListener("mousedown", (event) => {
+      if (event.button !== 0) return;
+      if (element.ownerDocument.defaultView?.PointerEvent) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (input.activeNodeDragId() !== nodeId) {
+        input.beginNodeDrag(nodeId, input.screenPointFromEvent(event), event);
+      }
+      if (input.activeNodeDragId() === nodeId) {
+        bindOverlayMouseDragListeners(element.ownerDocument, nodeId);
+      }
+    });
+    element.addEventListener("dragstart", (event) => {
+      event.preventDefault();
+    });
+    return element;
+  }
+
+  function bindOverlayPointerDragListeners(ownerDocument: Document, element: HTMLElement, nodeId: string, pointerId: number): void {
+    clearActiveDragListeners();
+    const cleanup = bindSigmaGlobalOverlayPointerDrag({
+      ownerDocument,
+      element,
+      nodeId,
+      pointerId,
+      isActive: isActiveOverlayDrag,
+      screenPointFromEvent: input.screenPointFromEvent,
+      onMove: input.moveNodeDrag,
+      onEnd: (point, event) => {
+        input.commitNodeDrag(point, event);
+        clearActiveDragListeners();
+      },
+      onCancel: () => {
+        input.cancelNodeDrag();
+        clearActiveDragListeners();
+      }
+    });
+    overlayPointerDragCleanup = () => {
+      cleanup();
+      overlayPointerDragCleanup = null;
+    };
+  }
+
+  function bindOverlayMouseDragListeners(ownerDocument: Document, nodeId: string): void {
+    clearActiveDragListeners();
+    const cleanup = bindSigmaGlobalOverlayMouseDrag({
+      ownerDocument,
+      nodeId,
+      isActive: isActiveOverlayDrag,
+      screenPointFromEvent: input.screenPointFromEvent,
+      onMove: input.moveNodeDrag,
+      onEnd: (point, event) => {
+        input.commitNodeDrag(point, event);
+        clearActiveDragListeners();
+      }
+    });
+    overlayPointerDragCleanup = () => {
+      cleanup();
+      overlayPointerDragCleanup = null;
+    };
+  }
+
+  function isActiveOverlayDrag(nodeId: string): boolean {
+    return input.activeNodeDragId() === nodeId;
+  }
+
+  function clearActiveDragListeners(): void {
+    overlayPointerDragCleanup?.();
+  }
+}
+
+export function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphRendererAdapterNode[] {
+  const nodes = adapterData.nodes;
+  const seen = new Set<string>();
+  const output: GraphRendererAdapterNode[] = [];
+  const append = (candidates: GraphRendererAdapterNode[], limit: number) => {
+    let count = 0;
+    for (const node of candidates) {
+      if (output.length >= SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT || count >= limit || seen.has(node.id)) continue;
+      seen.add(node.id);
+      output.push(node);
+      count += 1;
+    }
+  };
+  if (adapterData.selection.input?.kind !== "community") {
+    append(nodes.filter((node) => node.selected), Number.POSITIVE_INFINITY);
+  }
+  append(nodes.filter((node) => node.searchHit), 80);
+  append(nodes.filter((node) => node.pinHint.pinned), 80);
+  return output;
+}
+
+export function sigmaCommunityLabels(adapterData: GraphRendererAdapterData, limit: number): GraphRendererAdapterData["renderable"]["communities"] {
+  const selectedCommunityIds = new Set(adapterData.communities.filter((community) => community.selected).map((community) => community.id));
+  return adapterData.renderable.communities
+    .filter((community) => community.wash)
+    .map((community, index) => ({
+      community,
+      index,
+      selected: selectedCommunityIds.has(community.id)
+    }))
+    .sort((left, right) => {
+      if (left.selected !== right.selected) return left.selected ? -1 : 1;
+      if (left.community.nodeCount !== right.community.nodeCount) return right.community.nodeCount - left.community.nodeCount;
+      return left.index - right.index;
+    })
+    .slice(0, limit)
+    .map((candidate) => candidate.community);
+}
+
+function pruneOverlayEntries(entries: Map<string, unknown>, keep: Set<string>): void {
+  for (const id of [...entries.keys()]) {
+    if (!keep.has(id)) entries.delete(id);
+  }
+}

--- a/packages/graph-engine/src/render/sigma-wheel-zoom.ts
+++ b/packages/graph-engine/src/render/sigma-wheel-zoom.ts
@@ -1,0 +1,106 @@
+import type { GraphScreenPoint } from "./geometry";
+import { preventSigmaDefault } from "./sigma-events";
+import type { SigmaGlobalSigmaLike } from "./sigma-global-types";
+import { sigmaWheelZoomRatio, type SigmaWheelDeltaLike } from "./sigma-zoom";
+
+interface SigmaGlobalWheelPayload {
+  x?: unknown;
+  y?: unknown;
+  delta?: unknown;
+  original?: {
+    deltaY?: unknown;
+    deltaMode?: unknown;
+    target?: unknown;
+  };
+  preventSigmaDefault?: () => void;
+}
+
+export interface SigmaWheelZoomController {
+  destroy(): void;
+}
+
+export interface SigmaWheelZoomControllerInput {
+  sigma: SigmaGlobalSigmaLike;
+  root: HTMLElement;
+  isDestroyed: () => boolean;
+  currentRatio: () => number;
+  onZoomAtPoint: (point: GraphScreenPoint, nextRatio: number) => void;
+  onFatalError?: (error: unknown) => void;
+}
+
+export function bindSigmaWheelZoomController(input: SigmaWheelZoomControllerInput): SigmaWheelZoomController {
+  const captor = input.sigma.getMouseCaptor?.();
+  if (!captor?.on) return { destroy: () => undefined };
+  const listener = (payload?: unknown): void => {
+    if (input.isDestroyed()) return;
+    try {
+      const wheel = sigmaWheelInputFromPayload(payload, sigmaViewportCenter(input.root));
+      if (!wheel) return;
+      preventSigmaDefault(payload);
+      if (sigmaWheelTargetIsZoomControl(payload)) return;
+      const nextRatio = sigmaWheelZoomRatio(input.currentRatio(), wheel.delta);
+      input.onZoomAtPoint(wheel.point, nextRatio);
+    } catch (error) {
+      input.onFatalError?.(error);
+    }
+  };
+  captor.on("wheel", listener);
+  return {
+    destroy() {
+      captor.off?.("wheel", listener);
+    }
+  };
+}
+
+export function sigmaWheelInputFromPayload(payload: unknown, fallbackPoint: GraphScreenPoint): {
+  point: GraphScreenPoint;
+  delta: SigmaWheelDeltaLike;
+} | null {
+  const wheel = payload as SigmaGlobalWheelPayload | null;
+  const originalDeltaY = wheel?.original?.deltaY;
+  const fallbackDelta = wheel?.delta;
+  const deltaY = typeof originalDeltaY === "number"
+    ? originalDeltaY
+    : typeof fallbackDelta === "number"
+      ? -fallbackDelta * 120
+      : null;
+  if (deltaY == null || !Number.isFinite(deltaY)) return null;
+
+  const x = finiteNumber(wheel?.x, Number.NaN);
+  const y = finiteNumber(wheel?.y, Number.NaN);
+  const point = Number.isFinite(x) && Number.isFinite(y) ? { x, y } : fallbackPoint;
+  const originalDeltaMode = wheel?.original?.deltaMode;
+  return {
+    point,
+    delta: {
+      deltaY,
+      deltaMode: typeof originalDeltaMode === "number" ? originalDeltaMode : 0
+    }
+  };
+}
+
+export function sigmaWheelTargetIsZoomControl(payload: unknown): boolean {
+  const wheel = payload as SigmaGlobalWheelPayload | null;
+  const target = wheel?.original?.target as {
+    closest?: (selector: string) => unknown;
+    parentElement?: { closest?: (selector: string) => unknown };
+  } | null | undefined;
+  return Boolean(
+    target?.closest?.("[data-control=\"sigma-zoom\"]") ||
+    target?.parentElement?.closest?.("[data-control=\"sigma-zoom\"]")
+  );
+}
+
+export function sigmaViewportCenter(root: HTMLElement): GraphScreenPoint {
+  const rect = typeof root.getBoundingClientRect === "function" ? root.getBoundingClientRect() : null;
+  const width = finiteNumber(rect?.width, 1000);
+  const height = finiteNumber(rect?.height, 680);
+  return {
+    x: width / 2,
+    y: height / 2
+  };
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}

--- a/packages/graph-engine/test/renderer-boundary.test.ts
+++ b/packages/graph-engine/test/renderer-boundary.test.ts
@@ -27,7 +27,8 @@ const HOST_CALLBACK_IDENTIFIERS = [
 const HOST_CALLBACK_ALLOWED_FILES = new Set(["facade.ts", "types.ts"]);
 const RAW_GRAPH_EVENT_ALLOWED_FILES = new Set([
   "render/gestures.ts",
-  "render/sigma-global-drag.ts"
+  "render/sigma-global-drag.ts",
+  "render/sigma-overlay-dom.ts"
 ]);
 const RAW_GRAPH_EVENT_PATTERNS = [
   /\baddEventListener\s*\(\s*["'](?:wheel|pointerdown|pointermove|pointerup|pointercancel|lostpointercapture)["']/,
@@ -37,10 +38,15 @@ const RAW_GRAPH_EVENT_PATTERNS = [
   /\bclassifyGraph(?:EventTarget|WheelTarget|WheelTargetFromGraphTarget|PointerDownTarget|PointerDownTargetFromGraphTarget)\s*\(/
 ];
 const SIGMA_RENDERER_FORBIDDEN_RAW_GRAPH_EVENT_PATTERNS = [
-  /\baddEventListener\s*\(\s*["'](?:wheel|pointermove|pointerup|pointercancel|lostpointercapture)["']/,
+  /\baddEventListener\s*\(\s*["'](?:wheel|pointerdown|pointermove|pointerup|pointercancel|lostpointercapture)["']/,
   /\bremoveEventListener\s*\(\s*["'](?:wheel|pointerdown|pointermove|pointerup|pointercancel|lostpointercapture)["']/,
   /\bsetPointerCapture(?:\?\.)?\s*\(/,
   /\breleasePointerCapture(?:\?\.)?\s*\(/
+];
+const SIGMA_OVERLAY_DOM_ALLOWED_RAW_GRAPH_EVENT_PATTERNS = [
+  /\baddEventListener\s*\(\s*["'](?:pointerdown)["']/,
+  /\baddEventListener\s*\(\s*["'](?:mousedown|click|dragstart)["']/,
+  /\bclassName = "sigma-global-node-hit-target"/
 ];
 const DRAWING_MODULES = [
   "render/nodes.ts",
@@ -147,20 +153,41 @@ describe("renderer and facade boundary contract", () => {
   it("keeps Sigma raw pointer exceptions limited to node overlay drag", async () => {
     const sigmaRendererText = await readFile(join(SRC, "render/sigma-global-renderer.ts"), "utf8");
     const sigmaDragText = await readFile(join(SRC, "render/sigma-global-drag.ts"), "utf8");
+    const sigmaOverlayDomText = await readFile(join(SRC, "render/sigma-overlay-dom.ts"), "utf8");
 
     assert.equal(/\baddEventListener\s*\(\s*["']wheel["']/.test(sigmaRendererText), false);
     assert.equal(/\baddEventListener\s*\(\s*["']wheel["']/.test(sigmaDragText), false);
-    assert.match(sigmaRendererText, /className = "sigma-global-node-hit-target"/);
-    assert.match(sigmaRendererText, /\baddEventListener\s*\(\s*"pointerdown"/);
+    assert.doesNotMatch(sigmaRendererText, /className = "sigma-global-node-hit-target"/);
+    assert.doesNotMatch(sigmaRendererText, /\baddEventListener\s*\(\s*"pointerdown"/);
     assert.equal(/\baddEventListener\s*\(\s*["'](?:pointermove|pointerup|pointercancel|lostpointercapture)["']/.test(sigmaRendererText), false);
     assert.equal(/\bremoveEventListener\s*\(\s*["'](?:pointermove|pointerup|pointercancel|lostpointercapture)["']/.test(sigmaRendererText), false);
     assert.equal(/\bsetPointerCapture(?:\?\.)?\s*\(/.test(sigmaRendererText), false);
     assert.equal(/\breleasePointerCapture(?:\?\.)?\s*\(/.test(sigmaRendererText), false);
+    assert.match(sigmaOverlayDomText, /className = "sigma-global-node-hit-target"/);
+    assert.match(sigmaOverlayDomText, /\baddEventListener\s*\(\s*"pointerdown"/);
+    assert.equal(/\baddEventListener\s*\(\s*["'](?:pointermove|pointerup|pointercancel|lostpointercapture)["']/.test(sigmaOverlayDomText), false);
+    assert.equal(/\bremoveEventListener\s*\(\s*["'](?:pointermove|pointerup|pointercancel|lostpointercapture)["']/.test(sigmaOverlayDomText), false);
+    for (const pattern of SIGMA_OVERLAY_DOM_ALLOWED_RAW_GRAPH_EVENT_PATTERNS) {
+      assert.match(sigmaOverlayDomText, pattern);
+    }
     assert.match(sigmaDragText, /\bbindSigmaGlobalOverlayPointerDrag\b/);
     assert.match(sigmaDragText, /\bsetPointerCapture(?:\?\.)?\s*\(/);
     assert.match(sigmaDragText, /\baddEventListener\s*\(\s*"pointermove"/);
     assert.match(sigmaDragText, /\bremoveEventListener\s*\(\s*"pointermove"/);
     assert.match(sigmaDragText, /\breleasePointerCapture(?:\?\.)?\s*\(/);
+  });
+
+  it("keeps Sigma overlay DOM out of host callbacks and graph selection ownership", async () => {
+    const sigmaOverlayDomText = await readFile(join(SRC, "render/sigma-overlay-dom.ts"), "utf8");
+
+    for (const identifier of HOST_CALLBACK_IDENTIFIERS) {
+      assert.doesNotMatch(sigmaOverlayDomText, new RegExp(`\\b${identifier}\\b`));
+    }
+    for (const pattern of RENDER_ONLY_STATE_MUTATION_PATTERNS) {
+      assert.doesNotMatch(sigmaOverlayDomText, pattern);
+    }
+    assert.doesNotMatch(sigmaOverlayDomText, /\boptions\.(?:onHitTarget|onPinsChanged|onDragActiveChange)\b/);
+    assert.doesNotMatch(sigmaOverlayDomText, /\bbuildGraphRendererAdapterData\b/);
   });
 
   it("keeps blank double-click ownership out of the graph renderer root", async () => {

--- a/packages/graph-engine/test/renderer-boundary.test.ts
+++ b/packages/graph-engine/test/renderer-boundary.test.ts
@@ -27,8 +27,7 @@ const HOST_CALLBACK_IDENTIFIERS = [
 const HOST_CALLBACK_ALLOWED_FILES = new Set(["facade.ts", "types.ts"]);
 const RAW_GRAPH_EVENT_ALLOWED_FILES = new Set([
   "render/gestures.ts",
-  "render/sigma-global-drag.ts",
-  "render/sigma-overlay-dom.ts"
+  "render/sigma-global-drag.ts"
 ]);
 const RAW_GRAPH_EVENT_PATTERNS = [
   /\baddEventListener\s*\(\s*["'](?:wheel|pointerdown|pointermove|pointerup|pointercancel|lostpointercapture)["']/,
@@ -47,6 +46,13 @@ const SIGMA_OVERLAY_DOM_ALLOWED_RAW_GRAPH_EVENT_PATTERNS = [
   /\baddEventListener\s*\(\s*["'](?:pointerdown)["']/,
   /\baddEventListener\s*\(\s*["'](?:mousedown|click|dragstart)["']/,
   /\bclassName = "sigma-global-node-hit-target"/
+];
+const SIGMA_OVERLAY_DOM_FORBIDDEN_RAW_GRAPH_EVENT_PATTERNS = [
+  /\baddEventListener\s*\(\s*["'](?:wheel|pointermove|pointerup|pointercancel|lostpointercapture)["']/,
+  /\bremoveEventListener\s*\(\s*["'](?:wheel|pointerdown|pointermove|pointerup|pointercancel|lostpointercapture)["']/,
+  /\bsetPointerCapture(?:\?\.)?\s*\(/,
+  /\breleasePointerCapture(?:\?\.)?\s*\(/,
+  /\bclassifyGraph(?:EventTarget|WheelTarget|WheelTargetFromGraphTarget|PointerDownTarget|PointerDownTargetFromGraphTarget)\s*\(/
 ];
 const DRAWING_MODULES = [
   "render/nodes.ts",
@@ -141,7 +147,9 @@ describe("renderer and facade boundary contract", () => {
       const text = await readFile(file, "utf8");
       const patterns = rel === "render/sigma-global-renderer.ts"
         ? SIGMA_RENDERER_FORBIDDEN_RAW_GRAPH_EVENT_PATTERNS
-        : RAW_GRAPH_EVENT_PATTERNS;
+        : rel === "render/sigma-overlay-dom.ts"
+          ? SIGMA_OVERLAY_DOM_FORBIDDEN_RAW_GRAPH_EVENT_PATTERNS
+          : RAW_GRAPH_EVENT_PATTERNS;
       for (const pattern of patterns) {
         if (pattern.test(text)) violations.push(`${rel}: ${pattern}`);
       }
@@ -165,8 +173,10 @@ describe("renderer and facade boundary contract", () => {
     assert.equal(/\breleasePointerCapture(?:\?\.)?\s*\(/.test(sigmaRendererText), false);
     assert.match(sigmaOverlayDomText, /className = "sigma-global-node-hit-target"/);
     assert.match(sigmaOverlayDomText, /\baddEventListener\s*\(\s*"pointerdown"/);
-    assert.equal(/\baddEventListener\s*\(\s*["'](?:pointermove|pointerup|pointercancel|lostpointercapture)["']/.test(sigmaOverlayDomText), false);
-    assert.equal(/\bremoveEventListener\s*\(\s*["'](?:pointermove|pointerup|pointercancel|lostpointercapture)["']/.test(sigmaOverlayDomText), false);
+    assert.equal(/\baddEventListener\s*\(\s*["'](?:wheel|pointermove|pointerup|pointercancel|lostpointercapture)["']/.test(sigmaOverlayDomText), false);
+    assert.equal(/\bremoveEventListener\s*\(\s*["'](?:wheel|pointerdown|pointermove|pointerup|pointercancel|lostpointercapture)["']/.test(sigmaOverlayDomText), false);
+    assert.equal(/\bsetPointerCapture(?:\?\.)?\s*\(/.test(sigmaOverlayDomText), false);
+    assert.equal(/\breleasePointerCapture(?:\?\.)?\s*\(/.test(sigmaOverlayDomText), false);
     for (const pattern of SIGMA_OVERLAY_DOM_ALLOWED_RAW_GRAPH_EVENT_PATTERNS) {
       assert.match(sigmaOverlayDomText, pattern);
     }

--- a/packages/graph-engine/test/sigma-coordinates.test.ts
+++ b/packages/graph-engine/test/sigma-coordinates.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { GRAPH_WORLD_BOUNDS } from "../src/render/geometry";
 import { sigmaScreenPointToWorldPoint, sigmaWorldPointToScreenPoint } from "../src/render/sigma-coordinates";
-import type { SigmaGlobalSigmaLike } from "../src/render/sigma-global-renderer";
+import type { SigmaGlobalSigmaLike } from "../src/render/sigma-global-types";
 
 type ProjectionOptions = Parameters<typeof sigmaWorldPointToScreenPoint>[2];
 

--- a/packages/graph-engine/test/sigma-global-camera.test.ts
+++ b/packages/graph-engine/test/sigma-global-camera.test.ts
@@ -1,0 +1,272 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type { GraphRendererAdapterData } from "../src";
+import type { SigmaGlobalCameraState, SigmaGlobalSigmaLike } from "../src/render/sigma-global-types";
+import {
+  maybeAnimateSigmaCommunitySpotlightCamera,
+  readCameraState,
+  restoreCameraState,
+  sigmaCommunitySpotlightCenter,
+  sigmaGlobalCameraState,
+  sigmaGraphPointToCameraPoint
+} from "../src/render/sigma-global-camera";
+
+describe("Sigma global camera helpers", () => {
+  it("normalizes missing and non-finite camera state", () => {
+    const sigma = sigmaLike({ x: Number.NaN, y: Infinity, angle: undefined, ratio: "bad" });
+
+    assert.deepEqual(readCameraState(sigma), { x: 0, y: 0, angle: 0, ratio: 1 });
+    assert.equal(readCameraState({}), null);
+  });
+
+  it("restores camera state only when a state exists", () => {
+    const sigma = sigmaLike({ x: 1, y: 2, angle: 0, ratio: 1 });
+
+    restoreCameraState(sigma, null);
+    assert.deepEqual(sigma.getCamera?.().getState?.(), { x: 1, y: 2, angle: 0, ratio: 1 });
+    restoreCameraState(sigma, { x: 3, y: 4, angle: 0, ratio: 0.8 });
+    assert.deepEqual(sigma.getCamera?.().getState?.(), { x: 3, y: 4, angle: 0, ratio: 0.8 });
+  });
+
+  it("uses setState instead of animate for reduced motion or missing animate", () => {
+    const reducedMotionRoot = rootWithReducedMotion(true);
+    const animatedSigma = sigmaLike({ x: 0, y: 0, angle: 0, ratio: 1 });
+
+    assert.equal(
+      maybeAnimateSigmaCommunitySpotlightCamera(animatedSigma, reducedMotionRoot, adapterDataFixture(), "community-a", null),
+      "community-a"
+    );
+    assert.equal(animatedSigma.animateCalls, 0);
+    assert.equal(animatedSigma.setStateCalls, 1);
+
+    const noAnimateSigma = sigmaLike({ x: 0, y: 0, angle: 0, ratio: 1 }, false);
+    assert.equal(
+      maybeAnimateSigmaCommunitySpotlightCamera(noAnimateSigma, rootWithReducedMotion(false), adapterDataFixture(), "community-a", null),
+      "community-a"
+    );
+    assert.equal(noAnimateSigma.setStateCalls, 1);
+  });
+
+  it("falls back to raw graph points when Sigma projection is unavailable or invalid", () => {
+    assert.deepEqual(sigmaGraphPointToCameraPoint({}, { x: 10, y: 20 }), { x: 10, y: 20 });
+    assert.deepEqual(
+      sigmaGraphPointToCameraPoint({
+        graphToViewport: () => ({ x: Number.NaN, y: 1 }),
+        viewportToFramedGraph: () => ({ x: 30, y: 40 })
+      }, { x: 10, y: 20 }),
+      { x: 10, y: 20 }
+    );
+    assert.deepEqual(
+      sigmaGraphPointToCameraPoint({
+        graphToViewport: (point) => ({ x: point.x + 1, y: point.y + 1 }),
+        viewportToFramedGraph: (point) => ({ x: point.x + 2, y: point.y + 2 })
+      }, { x: 10, y: 20 }),
+      { x: 13, y: 23 }
+    );
+  });
+
+  it("computes full graph camera state and community spotlight centers", () => {
+    const adapterData = adapterDataFixture();
+
+    assert.deepEqual(sigmaGlobalCameraState({}, adapterData), { x: 50, y: 50, angle: 0, ratio: 1 });
+    assert.deepEqual(sigmaCommunitySpotlightCenter(adapterData, "community-a"), { x: 20, y: 30 });
+    assert.deepEqual(sigmaCommunitySpotlightCenter(adapterDataWithoutWash(), "community-a"), { x: 30, y: 40 });
+  });
+
+  it("does not decide selected community internally", () => {
+    const sigma = sigmaLike({ x: 0, y: 0, angle: 0, ratio: 1 });
+
+    assert.equal(
+      maybeAnimateSigmaCommunitySpotlightCamera(sigma, rootWithReducedMotion(false), adapterDataFixture(), null, null),
+      null
+    );
+    assert.equal(sigma.setStateCalls, 0);
+    assert.equal(sigma.animateCalls, 0);
+  });
+});
+
+function sigmaLike(
+  state: Partial<SigmaGlobalCameraState> & Record<string, unknown>,
+  withAnimate = true
+): SigmaGlobalSigmaLike & { setStateCalls: number; animateCalls: number } {
+  let current = { ...state } as SigmaGlobalCameraState;
+  const output = {
+    setStateCalls: 0,
+    animateCalls: 0,
+    getCamera() {
+      return {
+        getState: () => current,
+        setState: (next: Partial<SigmaGlobalCameraState>) => {
+          output.setStateCalls += 1;
+          current = { ...current, ...next };
+        },
+        animate: withAnimate
+          ? (next: Partial<SigmaGlobalCameraState>) => {
+              output.animateCalls += 1;
+              current = { ...current, ...next };
+            }
+          : undefined
+      };
+    }
+  };
+  return output;
+}
+
+function rootWithReducedMotion(reduce: boolean): HTMLElement {
+  return {
+    ownerDocument: {
+      defaultView: {
+        matchMedia: () => ({ matches: reduce })
+      }
+    }
+  } as HTMLElement;
+}
+
+function adapterDataFixture(): GraphRendererAdapterData {
+  return {
+    counts: {
+      nodes: 2,
+      edges: 0,
+      communities: 1,
+      hidden: 0,
+      renderedNodes: 2,
+      renderedEdges: 0,
+      aggregationContainers: 0
+    },
+    selection: {
+      input: { kind: "community", id: "community-a" },
+      selectionId: "community:community-a",
+      selectedNodeIds: [],
+      selectedCommunityIds: ["community-a"],
+      containsCurrentObject: true
+    },
+    nodes: [
+      nodeFixture("alpha", { x: 10, y: 20 }),
+      nodeFixture("beta", { x: 50, y: 60 })
+    ],
+    edges: [],
+    communities: [
+      {
+        id: "community-a",
+        object: { kind: "community", communityId: "community-a" },
+        label: "Community A",
+        nodeIds: ["alpha", "beta"],
+        nodeCount: 2,
+        selected: true,
+        searchResultIds: [],
+        pinHints: [],
+        aggregationIds: [],
+        drawerTarget: {
+          summaryKind: "community-summary",
+          object: { kind: "community", communityId: "community-a" }
+        },
+        commands: []
+      }
+    ],
+    aggregations: [],
+    renderable: {
+      nodes: [],
+      edges: [],
+      communities: [
+        {
+          id: "community-a",
+          role: "community",
+          label: "Community A",
+          nodeCount: 2,
+          selected: true,
+          searchHitCount: 0,
+          pinnedCount: 0,
+          selectedCount: 0,
+          color: "#64748b",
+          x: 20,
+          y: 30,
+          radius: 20,
+          wash: { cx: 20, cy: 30, rx: 20, ry: 20 },
+          drawerTarget: {
+            summaryKind: "community-summary",
+            object: { kind: "community", communityId: "community-a" }
+          },
+          commands: []
+        }
+      ],
+      aggregationContainers: [],
+      minimap: { path: "", nodes: [] },
+      relationLegend: [],
+      selectedNodeId: null,
+      selectedCommunityId: "community-a",
+      selectedNodeIds: [],
+      hiddenNodeIds: new Set(),
+      searchResultIds: [],
+      worldBounds: { minX: 0, maxX: 100, minY: 0, maxY: 100 },
+      budgets: {
+        limits: {
+          maxNodes: 2,
+          maxEdges: 0,
+          maxLabels: 0,
+          maxCards: 0,
+          maxInteractionUpdates: 1,
+          maxVisibleCommunities: 1
+        },
+        usage: {
+          nodes: 2,
+          edges: 0,
+          labels: 0,
+          cards: 0,
+          interactionUpdate: 1,
+          activeInteraction: 1,
+          communities: 1,
+          aggregationContainers: 0
+        }
+      },
+      qualityNotice: null,
+      communityFocus: null,
+      communityQuality: {
+        boundaryCertainty: "high",
+        skeletonLabel: "stable",
+        hiddenNodeCount: 0,
+        hiddenEdgeCount: 0,
+        stableCoreNodeIds: ["alpha"],
+        stableSkeletonEdgeIds: [],
+        temporaryBoostNodeIds: []
+      }
+    }
+  };
+}
+
+function adapterDataWithoutWash(): GraphRendererAdapterData {
+  const data = adapterDataFixture();
+  data.renderable.communities = data.renderable.communities.map((community) => ({ ...community, wash: null }));
+  return data;
+}
+
+function nodeFixture(id: string, point: { x: number; y: number }): GraphRendererAdapterData["nodes"][number] {
+  return {
+    id,
+    object: { kind: "node", nodeId: id },
+    label: id,
+    type: "topic",
+    communityId: "community-a",
+    sourcePath: `${id}.md`,
+    point,
+    selected: false,
+    searchHit: false,
+    pinHint: {
+      nodeId: id,
+      wikiPath: `${id}.md`,
+      pinned: false,
+      position: null
+    },
+    aggregationIds: [],
+    drawerTarget: {
+      summaryKind: "node-summary",
+      object: { kind: "node", nodeId: id }
+    },
+    render: {
+      displayMode: "point",
+      visualRole: "landmark",
+      priority: 1,
+      labelVisible: false
+    }
+  };
+}

--- a/packages/graph-engine/test/sigma-global-renderer.test.ts
+++ b/packages/graph-engine/test/sigma-global-renderer.test.ts
@@ -338,12 +338,16 @@ describe("Sigma global renderer production boundary", () => {
   });
 
   it("keeps the production Sigma boundary on GraphRendererAdapterData instead of raw GraphData", async () => {
-    const source = await readFile(new URL("../src/render/sigma-global-renderer.ts", import.meta.url), "utf8");
-    assert.match(source, /buildSigmaGlobalGraphologyGraph\(\s*adapterData: GraphRendererAdapterData/);
-    assert.doesNotMatch(source, /GraphData/);
-    assert.doesNotMatch(source, /buildGraphRendererAdapterData/);
-    assert.doesNotMatch(source, /\bdata\.nodes\b/);
-    assert.doesNotMatch(source, /\bdata\.edges\b/);
+    const modelSource = await readFile(new URL("../src/render/sigma-graphology-model.ts", import.meta.url), "utf8");
+    const rendererSource = await readFile(new URL("../src/render/sigma-global-renderer.ts", import.meta.url), "utf8");
+
+    assert.match(modelSource, /buildSigmaGlobalGraphologyGraph\(\s*adapterData: GraphRendererAdapterData/);
+    for (const source of [modelSource, rendererSource]) {
+      assert.doesNotMatch(source, /GraphData/);
+      assert.doesNotMatch(source, /buildGraphRendererAdapterData/);
+      assert.doesNotMatch(source, /\bdata\.nodes\b/);
+      assert.doesNotMatch(source, /\bdata\.edges\b/);
+    }
   });
 
   it("keeps Sigma community overlay styles passive instead of visible circular controls", async () => {

--- a/packages/graph-engine/test/sigma-global-renderer.test.ts
+++ b/packages/graph-engine/test/sigma-global-renderer.test.ts
@@ -612,6 +612,57 @@ describe("Sigma global renderer production boundary", () => {
     renderer.destroy();
   });
 
+  it("rebuilds the Sigma graph when node and edge counts change", () => {
+    const runtime = fakeRuntime();
+    const initialData = adapterDataFixture();
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData: initialData,
+      theme: "shan-shui",
+      runtime
+    });
+    const sigma = runtime.instances[0];
+    const originalGraph = renderer.graph;
+
+    renderer.update({ adapterData: adapterDataWithAddedNodeAndEdge(initialData) });
+
+    assert.notEqual(renderer.graph, originalGraph);
+    assert.equal(sigma.setGraphCalls.length, 1);
+    assert.equal(renderer.graph.order, 3);
+    assert.equal(renderer.graph.size, 2);
+    assert.equal(sigma.graph, renderer.graph);
+
+    renderer.destroy();
+  });
+
+  it("patches edge style changes in place without swapping the Sigma graph", () => {
+    const runtime = fakeRuntime();
+    const adapterData = adapterDataFixture();
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData,
+      theme: "shan-shui",
+      runtime
+    });
+    const sigma = runtime.instances[0];
+    const originalGraph = renderer.graph;
+    const originalEdge = { ...renderer.graph.getEdgeAttributes("adapter-edge") };
+
+    renderer.update({
+      adapterData,
+      edgeStyle: { semanticEmphasis: true, focusHighlight: false }
+    });
+
+    const updatedEdge = renderer.graph.getEdgeAttributes("adapter-edge");
+    assert.equal(renderer.graph, originalGraph);
+    assert.equal(sigma.setGraphCalls.length, 0);
+    assert.notDeepEqual(updatedEdge, originalEdge);
+    assert.ok(edgeStyleAlpha(updatedEdge.color) < edgeStyleAlpha(originalEdge.color));
+    assert.ok(updatedEdge.size < originalEdge.size);
+
+    renderer.destroy();
+  });
+
   it("refreshes the Sigma canvas and overlays when the host resizes", () => {
     let resizeCallback: ResizeObserverCallback | null = null;
     let observedElement: Element | null = null;
@@ -1726,6 +1777,86 @@ function adapterDataFixture(options: {
         stableCoreNodeIds: ["render-alpha"],
         stableSkeletonEdgeIds: ["adapter-edge"],
         temporaryBoostNodeIds: []
+      }
+    }
+  };
+}
+
+function adapterDataWithAddedNodeAndEdge(data: GraphRendererAdapterData = adapterDataFixture()): GraphRendererAdapterData {
+  const seedNode = data.nodes[0];
+  const seedEdge = data.edges[0];
+  if (!seedNode || !seedEdge) throw new Error("adapterDataWithAddedNodeAndEdge requires the default adapter fixture shape");
+  const addedNode: GraphRendererAdapterData["nodes"][number] = {
+    ...seedNode,
+    id: "render-gamma",
+    object: { kind: "node", nodeId: "render-gamma" },
+    label: "Adapter Gamma",
+    sourcePath: "adapter/gamma.md",
+    point: { x: 222, y: 111 },
+    selected: false,
+    searchHit: false,
+    pinHint: {
+      nodeId: "render-gamma",
+      wikiPath: "adapter/gamma.md",
+      pinned: false,
+      position: null
+    },
+    aggregationIds: [],
+    drawerTarget: {
+      summaryKind: "node-summary",
+      object: { kind: "node", nodeId: "render-gamma" }
+    },
+    render: {
+      ...seedNode.render,
+      displayMode: "point",
+      labelVisible: false,
+      priority: 50
+    }
+  };
+  const addedEdge: GraphRendererAdapterData["edges"][number] = {
+    ...seedEdge,
+    id: "adapter-edge-added",
+    sourceNodeId: "render-beta",
+    targetNodeId: "render-gamma"
+  };
+
+  return {
+    ...data,
+    counts: {
+      ...data.counts,
+      nodes: data.counts.nodes + 1,
+      edges: data.counts.edges + 1,
+      renderedNodes: data.counts.renderedNodes + 1,
+      renderedEdges: data.counts.renderedEdges + 1
+    },
+    nodes: [...data.nodes, addedNode],
+    edges: [...data.edges, addedEdge],
+    communities: data.communities.map((community) => community.id === "adapter-community"
+      ? {
+          ...community,
+          nodeIds: [...community.nodeIds, addedNode.id],
+          nodeCount: community.nodeCount + 1
+        }
+      : community),
+    renderable: {
+      ...data.renderable,
+      budgets: {
+        ...data.renderable.budgets,
+        limits: {
+          ...data.renderable.budgets.limits,
+          maxNodes: data.renderable.budgets.limits.maxNodes + 1,
+          maxEdges: data.renderable.budgets.limits.maxEdges + 1
+        },
+        usage: {
+          ...data.renderable.budgets.usage,
+          nodes: data.renderable.budgets.usage.nodes + 1,
+          edges: data.renderable.budgets.usage.edges + 1
+        }
+      },
+      communityQuality: {
+        ...data.renderable.communityQuality,
+        stableCoreNodeIds: [...data.renderable.communityQuality.stableCoreNodeIds, addedNode.id],
+        stableSkeletonEdgeIds: [...data.renderable.communityQuality.stableSkeletonEdgeIds, addedEdge.id]
       }
     }
   };

--- a/packages/graph-engine/test/sigma-graphology-model.test.ts
+++ b/packages/graph-engine/test/sigma-graphology-model.test.ts
@@ -1,0 +1,388 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import GraphologyGraph from "graphology";
+
+import type { GraphRendererAdapterData } from "../src";
+import {
+  buildSigmaGlobalGraphologyGraph,
+  canPatchSigmaGlobalGraphAttributes,
+  patchSigmaGlobalGraphAttributes,
+  sigmaGlobalEdgeStyle
+} from "../src/render/sigma-graphology-model";
+
+describe("Sigma graphology render model", () => {
+  it("builds graphology nodes, edges, communities, and aggregations from adapter data", () => {
+    const adapterData = adapterDataFixture();
+    const graph = buildSigmaGlobalGraphologyGraph(adapterData, { GraphologyGraph });
+
+    assert.equal(graph.order, 2);
+    assert.equal(graph.size, 1);
+    assert.deepEqual(graph.getNodeAttributes("alpha"), {
+      x: 10,
+      y: 20,
+      label: "Alpha",
+      size: 10,
+      color: "#ef4444",
+      type: "circle",
+      graphNodeType: "topic",
+      communityId: "community-a",
+      sourcePath: "alpha.md",
+      selected: true,
+      searchHit: false,
+      pinned: false,
+      communityDimmed: false,
+      communitySpotlightVisible: true,
+      aggregationIds: ["aggregation-a"],
+      labelVisible: true,
+      displayMode: "card",
+      visualRole: "landmark",
+      priority: 900,
+      drawerTarget: {
+        summaryKind: "node-summary",
+        object: { kind: "node", nodeId: "alpha" }
+      }
+    });
+    assert.equal(graph.getEdgeAttribute("edge-a", "relationType"), "depends-on");
+    assert.equal(graph.source("edge-a"), "alpha");
+    assert.equal(graph.target("edge-a"), "beta");
+    assert.equal(graph.getAttribute("communities")[0].id, "community-a");
+    assert.equal(graph.getAttribute("aggregations")[0].id, "aggregation-a");
+  });
+
+  it("applies selected-community focus edge styling and semantic emphasis", () => {
+    const adapterData = adapterDataFixture({ selectedCommunityIds: ["community-b"] });
+    const graph = buildSigmaGlobalGraphologyGraph(
+      adapterData,
+      { GraphologyGraph },
+      "shan-shui",
+      { semanticEmphasis: true, focusHighlight: true }
+    );
+
+    assert.deepEqual(graph.getEdgeAttributes("edge-a"), {
+      size: 0.85,
+      color: "rgba(49, 95, 114, 0.087)",
+      relationType: "depends-on",
+      confidence: "EXTRACTED",
+      weight: 0.75,
+      sourceCommunityId: "community-a",
+      targetCommunityId: "community-a"
+    });
+    assert.deepEqual(
+      sigmaGlobalEdgeStyle({
+        relationType: "矛盾",
+        sourceCommunityId: "community-a",
+        targetCommunityId: "community-b",
+        weight: 1
+      }, "mo-ye"),
+      { color: "rgba(244, 114, 182, 0.66)", size: 2.25 }
+    );
+  });
+
+  it("dims ordinary nodes outside the selected community while keeping priority nodes visible", () => {
+    const graph = buildSigmaGlobalGraphologyGraph(spotlightAdapterData(), { GraphologyGraph });
+
+    assert.equal(graph.getNodeAttribute("alpha", "communityDimmed"), false);
+    assert.equal(graph.getNodeAttribute("beta", "communityDimmed"), true);
+    assert.equal(graph.getNodeAttribute("beta", "color"), "rgba(18, 52, 86, 0.2)");
+    assert.equal(graph.getNodeAttribute("beta", "size"), 3.6);
+    assert.equal(graph.getNodeAttribute("beta-search", "communityDimmed"), false);
+    assert.equal(graph.getNodeAttribute("beta-pinned", "communityDimmed"), false);
+  });
+
+  it("detects patch eligibility from graph structure and theme", () => {
+    const adapterData = adapterDataFixture();
+    const sameShape = adapterDataFixture({ alphaLabel: "Alpha changed" });
+    const nodeChanged = adapterDataFixture({ alphaId: "alpha-next" });
+    const edgeChanged = adapterDataFixture({ edgeId: "edge-next" });
+    const targetChanged = adapterDataFixture({ betaId: "beta-next" });
+
+    assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, sameShape, "shan-shui", "shan-shui"), true);
+    assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, sameShape, "shan-shui", "mo-ye"), false);
+    assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, nodeChanged, "shan-shui", "shan-shui"), false);
+    assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, edgeChanged, "shan-shui", "shan-shui"), false);
+    assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, targetChanged, "shan-shui", "shan-shui"), false);
+  });
+
+  it("patches graph attributes in place", () => {
+    const graph = buildSigmaGlobalGraphologyGraph(adapterDataFixture(), { GraphologyGraph });
+    const sameShape = adapterDataFixture({ alphaLabel: "Alpha changed", selectedCommunityIds: [] });
+
+    patchSigmaGlobalGraphAttributes(graph, sameShape, "shan-shui");
+
+    assert.equal(graph.getNodeAttribute("alpha", "label"), "Alpha changed");
+    assert.equal(graph.getNodeAttribute("beta", "communityDimmed"), false);
+    assert.deepEqual(graph.getAttribute("selection"), sameShape.selection);
+  });
+
+  it("keeps the Sigma production model boundary on adapter data, not raw graph data", async () => {
+    const modelSource = await readFile(new URL("../src/render/sigma-graphology-model.ts", import.meta.url), "utf8");
+    const rendererSource = await readFile(new URL("../src/render/sigma-global-renderer.ts", import.meta.url), "utf8");
+
+    assert.match(modelSource, /buildSigmaGlobalGraphologyGraph\(\s*adapterData: GraphRendererAdapterData/);
+    for (const source of [modelSource, rendererSource]) {
+      assert.doesNotMatch(source, /buildGraphRendererAdapterData/);
+      assert.doesNotMatch(source, /GraphData/);
+      assert.doesNotMatch(source, /\bdata\.nodes\b/);
+      assert.doesNotMatch(source, /\bdata\.edges\b/);
+    }
+  });
+});
+
+function adapterDataFixture(options: {
+  alphaId?: string;
+  betaId?: string;
+  edgeId?: string;
+  alphaLabel?: string;
+  selectedCommunityIds?: string[];
+} = {}): GraphRendererAdapterData {
+  const alphaId = options.alphaId ?? "alpha";
+  const betaId = options.betaId ?? "beta";
+  const edgeId = options.edgeId ?? "edge-a";
+  const selectedCommunityIds = options.selectedCommunityIds ?? ["community-a"];
+  return {
+    counts: {
+      nodes: 2,
+      edges: 1,
+      communities: 1,
+      hidden: 0,
+      renderedNodes: 2,
+      renderedEdges: 1,
+      aggregationContainers: 1
+    },
+    selection: {
+      input: { kind: "community", id: selectedCommunityIds[0] ?? "community-a" },
+      selectionId: selectedCommunityIds[0] ? `community:${selectedCommunityIds[0]}` : null,
+      selectedNodeIds: [alphaId],
+      selectedCommunityIds,
+      containsCurrentObject: selectedCommunityIds.length > 0
+    },
+    nodes: [
+      nodeFixture(alphaId, "community-a", {
+        label: options.alphaLabel ?? "Alpha",
+        point: { x: 10, y: 20 },
+        selected: true,
+        priority: 900,
+        displayMode: "card",
+        labelVisible: true
+      }),
+      nodeFixture(betaId, "community-a", {
+        label: "Beta",
+        point: { x: 30, y: 40 },
+        searchHit: true,
+        pinned: true,
+        type: "source"
+      })
+    ],
+    edges: [
+      {
+        id: edgeId,
+        sourceNodeId: alphaId,
+        targetNodeId: betaId,
+        sourceCommunityId: "community-a",
+        targetCommunityId: "community-a",
+        relationType: "depends-on",
+        confidence: "EXTRACTED",
+        weight: 0.75,
+        render: { strokeWidth: 3, opacity: 0.42 }
+      }
+    ],
+    communities: [
+      {
+        id: "community-a",
+        object: { kind: "community", communityId: "community-a" },
+        label: "Community A",
+        nodeIds: [alphaId, betaId],
+        nodeCount: 2,
+        selected: selectedCommunityIds.includes("community-a"),
+        searchResultIds: [betaId],
+        pinHints: [pinHint(betaId, true, { x: 30, y: 40 })],
+        aggregationIds: ["aggregation-a"],
+        drawerTarget: communityDrawerTarget("community-a"),
+        commands: [{ kind: "enter-community", communityId: "community-a", label: "进入社区" }]
+      }
+    ],
+    aggregations: [
+      {
+        id: "aggregation-a",
+        object: { kind: "aggregation", aggregationId: "aggregation-a", nodeIds: [alphaId, betaId], communityId: "community-a" },
+        label: "Aggregation A",
+        communityId: "community-a",
+        nodeIds: [alphaId, betaId],
+        selectedNodeIds: [alphaId],
+        searchResultIds: [betaId],
+        pinnedNodeIds: [betaId],
+        totalCount: 2,
+        selected: true,
+        pinHints: [pinHint(betaId, true, { x: 30, y: 40 })],
+        drawerTarget: communityDrawerTarget("community-a"),
+        commands: [
+          {
+            kind: "show-this-object",
+            object: { kind: "aggregation", aggregationId: "aggregation-a", nodeIds: [alphaId, betaId], communityId: "community-a" },
+            label: "显示这个对象"
+          }
+        ]
+      }
+    ],
+    renderable: {
+      nodes: [],
+      edges: [],
+      communities: [
+        renderableCommunity("community-a", "#ef4444", true),
+        renderableCommunity("community-b", "#123456", false)
+      ],
+      aggregationContainers: [
+        {
+          id: "aggregation-a",
+          role: "aggregation-container",
+          label: "Aggregation A",
+          communityId: "community-a",
+          nodeIds: [alphaId, betaId],
+          nodeCount: 2,
+          searchHitCount: 1,
+          pinnedCount: 1,
+          selectedCount: 1,
+          selected: true,
+          searchResultIds: [betaId],
+          pinnedNodeIds: [betaId],
+          selectedNodeIds: [alphaId],
+          pinHints: [pinHint(betaId, true, { x: 30, y: 40 })],
+          point: { x: 20, y: 30 },
+          x: 20,
+          y: 30,
+          radius: 12,
+          color: "#abcdef"
+        }
+      ],
+      minimap: { path: "", nodes: [] },
+      relationLegend: [],
+      selectedNodeId: alphaId,
+      selectedCommunityId: selectedCommunityIds[0] ?? null,
+      selectedNodeIds: [alphaId],
+      hiddenNodeIds: new Set(),
+      searchResultIds: [betaId],
+      worldBounds: { minX: 0, maxX: 100, minY: 0, maxY: 100 },
+      budgets: {
+        limits: {
+          maxNodes: 2,
+          maxEdges: 1,
+          maxLabels: 1,
+          maxCards: 1,
+          maxInteractionUpdates: 3,
+          maxVisibleCommunities: 2
+        },
+        usage: {
+          nodes: 2,
+          edges: 1,
+          labels: 1,
+          cards: 1,
+          interactionUpdate: 3,
+          activeInteraction: 3,
+          communities: 2,
+          aggregationContainers: 1
+        }
+      },
+      qualityNotice: null,
+      communityFocus: null,
+      communityQuality: {
+        boundaryCertainty: "high",
+        skeletonLabel: "stable",
+        hiddenNodeCount: 0,
+        hiddenEdgeCount: 0,
+        stableCoreNodeIds: [alphaId],
+        stableSkeletonEdgeIds: [edgeId],
+        temporaryBoostNodeIds: []
+      }
+    }
+  };
+}
+
+function spotlightAdapterData(): GraphRendererAdapterData {
+  const data = adapterDataFixture({ selectedCommunityIds: ["community-a"] });
+  data.nodes = [
+    nodeFixture("alpha", "community-a", { point: { x: 10, y: 20 }, selected: true }),
+    nodeFixture("beta", "community-b", { point: { x: 30, y: 40 } }),
+    nodeFixture("beta-search", "community-b", { point: { x: 35, y: 45 }, searchHit: true }),
+    nodeFixture("beta-pinned", "community-b", { point: { x: 40, y: 50 }, pinned: true })
+  ];
+  data.edges = [];
+  return data;
+}
+
+function nodeFixture(
+  id: string,
+  communityId: string,
+  options: {
+    label?: string;
+    point?: { x: number; y: number };
+    selected?: boolean;
+    searchHit?: boolean;
+    pinned?: boolean;
+    type?: "topic" | "source";
+    priority?: number;
+    displayMode?: string;
+    labelVisible?: boolean;
+  } = {}
+): GraphRendererAdapterData["nodes"][number] {
+  const point = options.point ?? { x: 0, y: 0 };
+  return {
+    id,
+    object: { kind: "node", nodeId: id },
+    label: options.label ?? id,
+    type: options.type ?? "topic",
+    communityId,
+    sourcePath: `${id}.md`,
+    point,
+    selected: options.selected ?? false,
+    searchHit: options.searchHit ?? false,
+    pinHint: pinHint(id, options.pinned ?? false, point),
+    aggregationIds: ["aggregation-a"],
+    drawerTarget: {
+      summaryKind: "node-summary",
+      object: { kind: "node", nodeId: id }
+    },
+    render: {
+      displayMode: options.displayMode ?? "point",
+      visualRole: options.pinned ? "map-pin" : "landmark",
+      priority: options.priority ?? 100,
+      labelVisible: options.labelVisible ?? false
+    }
+  };
+}
+
+function renderableCommunity(id: string, color: string, selected: boolean) {
+  return {
+    id,
+    role: "community" as const,
+    label: id,
+    nodeCount: 2,
+    selected,
+    searchHitCount: 0,
+    pinnedCount: 0,
+    selectedCount: selected ? 1 : 0,
+    color,
+    x: 0,
+    y: 0,
+    radius: 20,
+    wash: { cx: 0, cy: 0, rx: 20, ry: 20 },
+    drawerTarget: communityDrawerTarget(id),
+    commands: [{ kind: "enter-community" as const, communityId: id, label: "进入社区" }]
+  };
+}
+
+function communityDrawerTarget(id: string): GraphRendererAdapterData["communities"][number]["drawerTarget"] {
+  return {
+    summaryKind: "community-summary",
+    object: { kind: "community", communityId: id }
+  };
+}
+
+function pinHint(nodeId: string, pinned: boolean, point: { x: number; y: number }) {
+  return {
+    nodeId,
+    wikiPath: `${nodeId}.md`,
+    pinned,
+    position: pinned ? { ...point, coordinateSpace: "world" as const } : null
+  };
+}

--- a/packages/graph-engine/test/sigma-graphology-model.test.ts
+++ b/packages/graph-engine/test/sigma-graphology-model.test.ts
@@ -96,12 +96,31 @@ describe("Sigma graphology render model", () => {
     const nodeChanged = adapterDataFixture({ alphaId: "alpha-next" });
     const edgeChanged = adapterDataFixture({ edgeId: "edge-next" });
     const targetChanged = adapterDataFixture({ betaId: "beta-next" });
+    const nodeAdded = {
+      ...adapterData,
+      nodes: [
+        ...adapterData.nodes,
+        nodeFixture("gamma", "community-a", { point: { x: 50, y: 60 } })
+      ]
+    };
+    const edgeAdded = {
+      ...adapterData,
+      edges: [
+        ...adapterData.edges,
+        {
+          ...adapterData.edges[0],
+          id: "edge-added"
+        }
+      ]
+    };
 
     assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, sameShape, "shan-shui", "shan-shui"), true);
     assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, sameShape, "shan-shui", "mo-ye"), false);
     assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, nodeChanged, "shan-shui", "shan-shui"), false);
     assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, edgeChanged, "shan-shui", "shan-shui"), false);
     assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, targetChanged, "shan-shui", "shan-shui"), false);
+    assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, nodeAdded, "shan-shui", "shan-shui"), false);
+    assert.equal(canPatchSigmaGlobalGraphAttributes(adapterData, edgeAdded, "shan-shui", "shan-shui"), false);
   });
 
   it("patches graph attributes in place", () => {

--- a/packages/graph-engine/test/sigma-hit-projector.test.ts
+++ b/packages/graph-engine/test/sigma-hit-projector.test.ts
@@ -1,0 +1,271 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type { GraphRendererAdapterData } from "../src";
+import {
+  createSigmaGlobalHitProjector,
+  gestureTargetFromSigmaRenderedObject,
+  sigmaNodeIdFromPayload,
+  sigmaScreenPointFromPayload
+} from "../src/render/sigma-hit-projector";
+
+describe("Sigma hit projector", () => {
+  it("projects known Sigma node ids before spatial fallback", () => {
+    const projector = createSigmaGlobalHitProjector(projectorInput());
+
+    assert.deepEqual(
+      projector.targetFromSigmaHit({ nodeId: "alpha", screenPoint: { x: 50, y: 50 } }),
+      { kind: "node", id: "alpha" }
+    );
+  });
+
+  it("falls back from unknown Sigma node ids to rendered objects and screen points", () => {
+    const projector = createSigmaGlobalHitProjector(projectorInput());
+
+    assert.deepEqual(
+      projector.targetFromSigmaHit({ nodeId: "missing", renderedObject: { kind: "edge", id: "edge-a" } }),
+      { kind: "edge", id: "edge-a" }
+    );
+    assert.deepEqual(
+      projector.targetFromSigmaHit({ nodeId: "missing", screenPoint: { x: 50, y: 30 } }),
+      { kind: "community-wash", id: "community-a" }
+    );
+  });
+
+  it("translates rendered objects into graph gesture targets", () => {
+    const adapterData = adapterDataFixture();
+
+    assert.deepEqual(gestureTargetFromSigmaRenderedObject({ kind: "node", id: "alpha" }, adapterData), { kind: "node", id: "alpha" });
+    assert.deepEqual(gestureTargetFromSigmaRenderedObject({ kind: "edge", id: "edge-a" }, adapterData), { kind: "edge", id: "edge-a" });
+    assert.deepEqual(gestureTargetFromSigmaRenderedObject({ kind: "community-wash", id: "community-a" }, adapterData), { kind: "community-wash", id: "community-a" });
+    assert.deepEqual(
+      gestureTargetFromSigmaRenderedObject({ kind: "aggregation-container", id: "aggregation-a" }, adapterData),
+      { kind: "aggregation-container", id: "aggregation-a", communityId: "community-a" }
+    );
+  });
+
+  it("returns graph blank for invalid rendered objects through projector fallback", () => {
+    const projector = createSigmaGlobalHitProjector(projectorInput());
+
+    assert.deepEqual(
+      projector.targetFromSigmaHit({ renderedObject: { kind: "edge", id: "missing" } }),
+      { kind: "graph-blank" }
+    );
+  });
+
+  it("parses Sigma node and screen point payloads defensively", () => {
+    assert.equal(sigmaNodeIdFromPayload({ node: "alpha" }), "alpha");
+    assert.equal(sigmaNodeIdFromPayload({ node: 42 }), null);
+    assert.deepEqual(sigmaScreenPointFromPayload({ x: 10, y: 20 }), { x: 10, y: 20 });
+    assert.deepEqual(sigmaScreenPointFromPayload({ event: { x: 30, y: 40 } }), { x: 30, y: 40 });
+    assert.equal(sigmaScreenPointFromPayload({ event: { x: "30", y: 40 } }), null);
+  });
+
+  it("returns graph blank when no hit input can be projected", () => {
+    const projector = createSigmaGlobalHitProjector(projectorInput());
+
+    assert.deepEqual(projector.targetFromSigmaHit({}), { kind: "graph-blank" });
+  });
+});
+
+function projectorInput() {
+  return {
+    adapterData: adapterDataFixture(),
+    viewport: { x: 0, y: 0, scale: 1 },
+    viewportSize: { width: 100, height: 100 },
+    screenPointToWorldPoint: (point: { x: number; y: number }) => point
+  };
+}
+
+function adapterDataFixture(): GraphRendererAdapterData {
+  return {
+    counts: {
+      nodes: 2,
+      edges: 1,
+      communities: 1,
+      hidden: 0,
+      renderedNodes: 2,
+      renderedEdges: 1,
+      aggregationContainers: 1
+    },
+    selection: {
+      input: null,
+      selectionId: null,
+      selectedNodeIds: [],
+      selectedCommunityIds: [],
+      containsCurrentObject: false
+    },
+    nodes: [
+      nodeFixture("alpha", { x: 10, y: 10 }),
+      nodeFixture("beta", { x: 90, y: 10 })
+    ],
+    edges: [
+      {
+        id: "edge-a",
+        sourceNodeId: "alpha",
+        targetNodeId: "beta",
+        sourceCommunityId: "community-a",
+        targetCommunityId: "community-a",
+        relationType: "depends-on",
+        confidence: "EXTRACTED",
+        weight: 1,
+        render: { strokeWidth: 1, opacity: 1 }
+      }
+    ],
+    communities: [
+      {
+        id: "community-a",
+        object: { kind: "community", communityId: "community-a" },
+        label: "Community A",
+        nodeIds: ["alpha", "beta"],
+        nodeCount: 2,
+        selected: false,
+        searchResultIds: [],
+        pinHints: [],
+        aggregationIds: ["aggregation-a"],
+        drawerTarget: communityDrawerTarget("community-a"),
+        commands: [{ kind: "enter-community", communityId: "community-a", label: "进入社区" }]
+      }
+    ],
+    aggregations: [
+      {
+        id: "aggregation-a",
+        object: { kind: "aggregation", aggregationId: "aggregation-a", nodeIds: ["alpha", "beta"], communityId: "community-a" },
+        label: "Aggregation A",
+        communityId: "community-a",
+        nodeIds: ["alpha", "beta"],
+        selectedNodeIds: [],
+        searchResultIds: [],
+        pinnedNodeIds: [],
+        totalCount: 2,
+        selected: false,
+        pinHints: [],
+        drawerTarget: communityDrawerTarget("community-a"),
+        commands: []
+      }
+    ],
+    renderable: {
+      nodes: [],
+      edges: [{ id: "edge-a", sourceNodeId: "alpha", targetNodeId: "beta", curveOffset: 0 }],
+      communities: [
+        {
+          id: "community-a",
+          role: "community",
+          label: "Community A",
+          nodeCount: 2,
+          selected: false,
+          searchHitCount: 0,
+          pinnedCount: 0,
+          selectedCount: 0,
+          color: "#64748b",
+          x: 50,
+          y: 50,
+          radius: 30,
+          wash: { cx: 50, cy: 50, rx: 30, ry: 30 },
+          drawerTarget: communityDrawerTarget("community-a"),
+          commands: [{ kind: "enter-community", communityId: "community-a", label: "进入社区" }]
+        }
+      ],
+      aggregationContainers: [
+        {
+          id: "aggregation-a",
+          role: "aggregation-container",
+          label: "Aggregation A",
+          communityId: "community-a",
+          nodeIds: ["alpha", "beta"],
+          nodeCount: 2,
+          searchHitCount: 0,
+          pinnedCount: 0,
+          selectedCount: 0,
+          selected: false,
+          searchResultIds: [],
+          pinnedNodeIds: [],
+          selectedNodeIds: [],
+          pinHints: [],
+          point: { x: 80, y: 80 },
+          x: 80,
+          y: 80,
+          radius: 8,
+          color: "#64748b"
+        }
+      ],
+      minimap: { path: "", nodes: [] },
+      relationLegend: [],
+      selectedNodeId: null,
+      selectedCommunityId: null,
+      selectedNodeIds: [],
+      hiddenNodeIds: new Set(),
+      searchResultIds: [],
+      worldBounds: { minX: 0, maxX: 100, minY: 0, maxY: 100 },
+      budgets: {
+        limits: {
+          maxNodes: 2,
+          maxEdges: 1,
+          maxLabels: 1,
+          maxCards: 1,
+          maxInteractionUpdates: 1,
+          maxVisibleCommunities: 1
+        },
+        usage: {
+          nodes: 2,
+          edges: 1,
+          labels: 1,
+          cards: 1,
+          interactionUpdate: 1,
+          activeInteraction: 1,
+          communities: 1,
+          aggregationContainers: 1
+        }
+      },
+      qualityNotice: null,
+      communityFocus: null,
+      communityQuality: {
+        boundaryCertainty: "high",
+        skeletonLabel: "stable",
+        hiddenNodeCount: 0,
+        hiddenEdgeCount: 0,
+        stableCoreNodeIds: ["alpha"],
+        stableSkeletonEdgeIds: ["edge-a"],
+        temporaryBoostNodeIds: []
+      }
+    }
+  };
+}
+
+function nodeFixture(id: string, point: { x: number; y: number }): GraphRendererAdapterData["nodes"][number] {
+  return {
+    id,
+    object: { kind: "node", nodeId: id },
+    label: id,
+    type: "topic",
+    communityId: "community-a",
+    sourcePath: `${id}.md`,
+    point,
+    selected: false,
+    searchHit: false,
+    pinHint: {
+      nodeId: id,
+      wikiPath: `${id}.md`,
+      pinned: false,
+      position: null
+    },
+    aggregationIds: ["aggregation-a"],
+    drawerTarget: {
+      summaryKind: "node-summary",
+      object: { kind: "node", nodeId: id }
+    },
+    render: {
+      displayMode: "point",
+      visualRole: "landmark",
+      priority: 1,
+      labelVisible: false
+    }
+  };
+}
+
+function communityDrawerTarget(id: string): GraphRendererAdapterData["communities"][number]["drawerTarget"] {
+  return {
+    summaryKind: "community-summary",
+    object: { kind: "community", communityId: id }
+  };
+}

--- a/packages/graph-engine/test/sigma-overlay-dom.test.ts
+++ b/packages/graph-engine/test/sigma-overlay-dom.test.ts
@@ -1,0 +1,573 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type { GraphRendererAdapterData } from "../src/render/adapter";
+import type { SigmaGlobalSigmaLike } from "../src/render/sigma-global-types";
+import {
+  createSigmaOverlayDomController,
+  sigmaCommunityLabels,
+  sigmaOverlayNodes
+} from "../src/render/sigma-overlay-dom";
+
+describe("Sigma overlay DOM controller", () => {
+  it("routes node hit-target clicks through the rendered object callback", () => {
+    const fixture = controllerFixture();
+    fixture.controller.rebuild();
+
+    nodeTarget(fixture.overlayRoot, "alpha")?.dispatch("click");
+
+    assert.deepEqual(fixture.hits, [{ kind: "node", id: "alpha" }]);
+  });
+
+  it("routes community cloud shape clicks through the rendered object callback", () => {
+    const fixture = controllerFixture();
+    fixture.controller.rebuild();
+
+    communityShape(fixture.overlayRoot, "community-a")?.dispatch("click");
+
+    assert.deepEqual(fixture.hits, [{ kind: "community-wash", id: "community-a" }]);
+  });
+
+  it("binds pointer overlay drag and clears document listeners on pointerup", () => {
+    const fixture = controllerFixture();
+    fixture.controller.rebuild();
+
+    nodeTarget(fixture.overlayRoot, "alpha")?.dispatch("pointerdown", {
+      button: 0,
+      pointerId: 7,
+      clientX: 10,
+      clientY: 20
+    });
+    assert.deepEqual(fixture.dragCalls, ["begin:alpha:10,20"]);
+    assert.equal(fixture.document.listenerCount("pointermove"), 1);
+    assert.equal(fixture.document.listenerCount("pointerup"), 1);
+
+    fixture.document.dispatch("pointermove", { pointerId: 7, clientX: 14, clientY: 24 });
+    fixture.document.dispatch("pointerup", { pointerId: 7, clientX: 18, clientY: 28 });
+
+    assert.deepEqual(fixture.dragCalls, [
+      "begin:alpha:10,20",
+      "move:14,24",
+      "commit:18,28"
+    ]);
+    assert.equal(fixture.document.listenerCount("pointermove"), 0);
+    assert.equal(fixture.document.listenerCount("pointerup"), 0);
+    assert.equal(fixture.document.listenerCount("pointercancel"), 0);
+  });
+
+  it("clears pointer listeners and cancels the drag on pointercancel", () => {
+    const fixture = controllerFixture();
+    fixture.controller.rebuild();
+
+    nodeTarget(fixture.overlayRoot, "alpha")?.dispatch("pointerdown", {
+      button: 0,
+      pointerId: 7,
+      clientX: 10,
+      clientY: 20
+    });
+    fixture.document.dispatch("pointercancel", { pointerId: 7, clientX: 18, clientY: 28 });
+
+    assert.deepEqual(fixture.dragCalls, ["begin:alpha:10,20", "cancel"]);
+    assert.equal(fixture.document.listenerCount("pointermove"), 0);
+    assert.equal(fixture.document.listenerCount("pointerup"), 0);
+    assert.equal(fixture.document.listenerCount("pointercancel"), 0);
+  });
+
+  it("uses mouse drag fallback when PointerEvent is unavailable", () => {
+    const fixture = controllerFixture({ pointerEvents: false });
+    fixture.controller.rebuild();
+
+    nodeTarget(fixture.overlayRoot, "alpha")?.dispatch("mousedown", {
+      button: 0,
+      clientX: 10,
+      clientY: 20
+    });
+    fixture.document.dispatch("mousemove", { clientX: 12, clientY: 22 });
+    fixture.document.dispatch("mouseup", { clientX: 13, clientY: 23 });
+
+    assert.deepEqual(fixture.dragCalls, [
+      "begin:alpha:10,20",
+      "move:12,22",
+      "commit:13,23"
+    ]);
+    assert.equal(fixture.document.listenerCount("mousemove"), 0);
+    assert.equal(fixture.document.listenerCount("mouseup"), 0);
+  });
+
+  it("destroy clears overlay elements and active drag listeners", () => {
+    const fixture = controllerFixture();
+    fixture.controller.rebuild();
+    nodeTarget(fixture.overlayRoot, "alpha")?.dispatch("pointerdown", {
+      button: 0,
+      pointerId: 7,
+      clientX: 10,
+      clientY: 20
+    });
+
+    fixture.controller.destroy();
+
+    assert.equal(fixture.overlayRoot.children.length, 0);
+    assert.equal(fixture.document.listenerCount("pointermove"), 0);
+    assert.equal(fixture.document.listenerCount("pointerup"), 0);
+    assert.equal(fixture.document.listenerCount("pointercancel"), 0);
+  });
+
+  it("rebuild prunes stale elements and refreshes reused node data attributes", () => {
+    const initialData = adapterDataFixture({
+      nodes: [
+        nodeFixture("alpha", { selected: true }),
+        nodeFixture("beta", { searchHit: true, pinned: true })
+      ],
+      communities: [communityFixture("community-a"), communityFixture("community-b")]
+    });
+    const fixture = controllerFixture({ adapterData: initialData });
+    fixture.controller.rebuild();
+    const alphaBefore = nodeTarget(fixture.overlayRoot, "alpha");
+
+    fixture.setAdapterData(adapterDataFixture({
+      nodes: [
+        nodeFixture("alpha", { selected: false, searchHit: true, pinned: true })
+      ],
+      communities: [communityFixture("community-a")]
+    }));
+    fixture.controller.rebuild();
+
+    const alphaAfter = nodeTarget(fixture.overlayRoot, "alpha");
+    assert.equal(alphaAfter, alphaBefore);
+    assert.equal(alphaAfter?.dataset.selected, "false");
+    assert.equal(alphaAfter?.dataset.searchHit, "true");
+    assert.equal(alphaAfter?.dataset.pinned, "true");
+    assert.equal(nodeTarget(fixture.overlayRoot, "beta"), undefined);
+    assert.equal(communityRegion(fixture.overlayRoot, "community-b"), undefined);
+  });
+
+  it("reposition updates boxes without creating elements, replacing children, or rebinding listeners", () => {
+    const fixture = controllerFixture();
+    fixture.controller.rebuild();
+    const childrenBefore = [...fixture.overlayRoot.children];
+    fixture.document.created = 0;
+    fixture.overlayRoot.replaceCount = 0;
+    const alphaBefore = nodeTarget(fixture.overlayRoot, "alpha");
+    const clickListenersBefore = alphaBefore?.listenerCount("click") ?? 0;
+
+    fixture.controller.reposition();
+    fixture.controller.reposition();
+
+    assert.equal(fixture.document.created, 0);
+    assert.equal(fixture.overlayRoot.replaceCount, 0);
+    assert.deepEqual(fixture.overlayRoot.children, childrenBefore);
+    assert.equal(alphaBefore?.listenerCount("click"), clickListenersBefore);
+    assert.match(alphaBefore?.style.left ?? "", /px$/);
+  });
+
+  it("keeps community label cap at eight and prioritizes selected communities", () => {
+    const communities = Array.from({ length: 10 }, (_, index) => communityFixture(`community-${index + 1}`, {
+      selected: index === 1,
+      nodeCount: index + 1
+    }));
+    const fixture = controllerFixture({
+      adapterData: adapterDataFixture({ communities, nodes: [nodeFixture("alpha")] })
+    });
+    fixture.controller.rebuild();
+
+    const labels = fixture.overlayRoot.children.filter((child) => child.className === "sigma-global-community-label");
+
+    assert.equal(labels.length, 8);
+    assert.equal(labels[0]?.dataset.communityId, "community-2");
+    assert.deepEqual(
+      sigmaCommunityLabels(fixture.adapterData(), 8).map((community) => community.id),
+      labels.map((label) => label.dataset.communityId)
+    );
+  });
+
+  it("keeps node hit-target cap at 160 while preserving selected search and pinned anchors", () => {
+    const nodes = Array.from({ length: 250 }, (_, index) => nodeFixture(`node-${index}`, {
+      selected: index === 249,
+      searchHit: index < 100,
+      pinned: index >= 150
+    }));
+    const data = adapterDataFixture({ nodes, communities: [communityFixture("community-a")] });
+    const fixture = controllerFixture({ adapterData: data });
+    fixture.controller.rebuild();
+
+    const targets = fixture.overlayRoot.children.filter((child) => child.className === "sigma-global-node-hit-target");
+
+    assert.equal(targets.length, 160);
+    assert.ok(targets.some((target) => target.dataset.nodeId === "node-249"));
+    assert.ok(targets.some((target) => target.dataset.searchHit === "true"));
+    assert.ok(targets.some((target) => target.dataset.pinned === "true"));
+    assert.deepEqual(
+      sigmaOverlayNodes(data).map((node) => node.id),
+      targets.map((target) => target.dataset.nodeId)
+    );
+  });
+});
+
+function controllerFixture(options: {
+  adapterData?: GraphRendererAdapterData;
+  pointerEvents?: boolean;
+} = {}) {
+  const document = new FakeDocument(options.pointerEvents ?? true);
+  const overlayRoot = document.createElement("div");
+  let adapterData = options.adapterData ?? adapterDataFixture();
+  let activeNodeId: string | null = null;
+  const hits: unknown[] = [];
+  const dragCalls: string[] = [];
+  const controller = createSigmaOverlayDomController({
+    overlayRoot: overlayRoot as unknown as HTMLElement,
+    cloudFilterId: "test-cloud-filter",
+    getAdapterData: () => adapterData,
+    getSigma: () => sigmaIdentity(),
+    getOptions: () => ({
+      adapterData,
+      viewportSize: { width: 500, height: 500 },
+      viewport: { x: 0, y: 0, scale: 1 }
+    }),
+    communityCloudFor: (_communityId, wash) => ({
+      box: {
+        left: wash.cx - wash.rx,
+        top: wash.cy - wash.ry,
+        width: wash.rx * 2,
+        height: wash.ry * 2
+      },
+      localPoints: null
+    }),
+    isDestroyed: () => false,
+    onHit: (object) => hits.push(object),
+    beginNodeDrag: (nodeId, point) => {
+      activeNodeId = nodeId;
+      dragCalls.push(`begin:${nodeId}:${point.x},${point.y}`);
+    },
+    moveNodeDrag: (point) => {
+      dragCalls.push(`move:${point.x},${point.y}`);
+    },
+    commitNodeDrag: (point) => {
+      activeNodeId = null;
+      dragCalls.push(`commit:${point?.x ?? "null"},${point?.y ?? "null"}`);
+    },
+    cancelNodeDrag: () => {
+      activeNodeId = null;
+      dragCalls.push("cancel");
+    },
+    screenPointFromEvent: (event) => ({ x: event.clientX, y: event.clientY }),
+    consumeSuppressedNodeClick: () => false,
+    activeNodeDragId: () => activeNodeId
+  });
+  return {
+    controller,
+    document,
+    overlayRoot,
+    hits,
+    dragCalls,
+    adapterData: () => adapterData,
+    setAdapterData: (next: GraphRendererAdapterData) => {
+      adapterData = next;
+    }
+  };
+}
+
+function adapterDataFixture(options: {
+  nodes?: ReturnType<typeof nodeFixture>[];
+  communities?: ReturnType<typeof communityFixture>[];
+  selectionInput?: GraphRendererAdapterData["selection"]["input"];
+} = {}): GraphRendererAdapterData {
+  const nodes = options.nodes ?? [
+    nodeFixture("alpha", { selected: true }),
+    nodeFixture("beta", { searchHit: true, pinned: true })
+  ];
+  const communities = options.communities ?? [communityFixture("community-a", { selected: true })];
+  const selectedNodeIds = nodes.filter((node) => node.selected).map((node) => node.id);
+  return {
+    counts: {
+      nodes: nodes.length,
+      edges: 0,
+      communities: communities.length,
+      hidden: 0,
+      renderedNodes: nodes.length,
+      renderedEdges: 0,
+      aggregationContainers: 0
+    },
+    selection: {
+      input: options.selectionInput ?? { kind: "node", id: selectedNodeIds[0] ?? nodes[0]?.id ?? "none" },
+      selectionId: "test-selection",
+      selectedNodeIds,
+      selectedCommunityIds: communities.filter((community) => community.selected).map((community) => community.id),
+      containsCurrentObject: selectedNodeIds.length > 0
+    },
+    nodes,
+    edges: [],
+    communities: communities.map((community) => ({
+      id: community.id,
+      object: { kind: "community", communityId: community.id },
+      label: community.label,
+      nodeIds: nodes.filter((node) => node.communityId === community.id).map((node) => node.id),
+      nodeCount: community.nodeCount,
+      selected: community.selected,
+      searchResultIds: nodes.filter((node) => node.searchHit).map((node) => node.id),
+      pinHints: [],
+      aggregationIds: [],
+      drawerTarget: {
+        summaryKind: "community-summary",
+        object: { kind: "community", communityId: community.id }
+      },
+      commands: []
+    })),
+    aggregations: [],
+    renderable: {
+      nodes: [],
+      edges: [],
+      communities,
+      aggregationContainers: [],
+      minimap: { path: "", nodes: [] },
+      relationLegend: [],
+      selectedNodeId: selectedNodeIds[0] ?? null,
+      selectedCommunityId: communities.find((community) => community.selected)?.id ?? null,
+      selectedNodeIds,
+      hiddenNodeIds: new Set(),
+      searchResultIds: nodes.filter((node) => node.searchHit).map((node) => node.id),
+      worldBounds: { minX: 0, maxX: 500, minY: 0, maxY: 500 },
+      budgets: {
+        limits: {
+          maxNodes: nodes.length,
+          maxEdges: 0,
+          maxLabels: 8,
+          maxCards: 0,
+          maxInteractionUpdates: nodes.length,
+          maxVisibleCommunities: communities.length
+        },
+        usage: {
+          nodes: nodes.length,
+          edges: 0,
+          labels: Math.min(communities.length, 8),
+          cards: 0,
+          interactionUpdate: nodes.length,
+          activeInteraction: nodes.length,
+          communities: communities.length,
+          aggregationContainers: 0
+        }
+      },
+      qualityNotice: null,
+      communityFocus: null,
+      communityQuality: {
+        boundaryCertainty: "high",
+        skeletonLabel: "stable",
+        hiddenNodeCount: 0,
+        hiddenEdgeCount: 0,
+        stableCoreNodeIds: [],
+        stableSkeletonEdgeIds: [],
+        temporaryBoostNodeIds: []
+      }
+    }
+  } as GraphRendererAdapterData;
+}
+
+function nodeFixture(id: string, options: {
+  selected?: boolean;
+  searchHit?: boolean;
+  pinned?: boolean;
+  communityId?: string;
+} = {}) {
+  const index = Number(id.match(/\d+$/)?.[0] ?? 1);
+  return {
+    id,
+    object: { kind: "node" as const, nodeId: id },
+    label: `Node ${id}`,
+    type: "topic",
+    communityId: options.communityId ?? "community-a",
+    sourcePath: `${id}.md`,
+    point: { x: 40 + index, y: 80 + index },
+    selected: options.selected ?? false,
+    searchHit: options.searchHit ?? false,
+    pinHint: {
+      nodeId: id,
+      wikiPath: `${id}.md`,
+      pinned: options.pinned ?? false,
+      position: options.pinned ? { x: 40 + index, y: 80 + index, coordinateSpace: "world" as const } : null
+    },
+    aggregationIds: [],
+    drawerTarget: {
+      summaryKind: "node-summary" as const,
+      object: { kind: "node" as const, nodeId: id }
+    },
+    render: {
+      displayMode: "point",
+      visualRole: "landmark",
+      priority: options.selected ? 1000 : 100,
+      labelVisible: Boolean(options.selected)
+    }
+  };
+}
+
+function communityFixture(id: string, options: { selected?: boolean; nodeCount?: number } = {}) {
+  const index = Number(id.match(/\d+$/)?.[0] ?? 1);
+  return {
+    id,
+    role: "community-wash" as const,
+    label: `Community ${id}`,
+    nodeIds: [],
+    nodeCount: options.nodeCount ?? index,
+    selected: options.selected ?? false,
+    searchResultIds: [],
+    pinnedNodeIds: [],
+    aggregationIds: [],
+    x: 100 + index,
+    y: 120 + index,
+    radius: 40,
+    color: "#123456",
+    wash: { cx: 100 + index, cy: 120 + index, rx: 32, ry: 24 }
+  };
+}
+
+function sigmaIdentity(): SigmaGlobalSigmaLike {
+  return {
+    graphToViewport: (point) => ({ x: point.x, y: point.y })
+  };
+}
+
+function nodeTarget(root: FakeElement, nodeId: string): FakeElement | undefined {
+  return root.children.find((child) => child.dataset.nodeId === nodeId);
+}
+
+function communityRegion(root: FakeElement, communityId: string): FakeElement | undefined {
+  return root.children.find((child) => child.className === "sigma-global-community-region" && child.dataset.communityId === communityId);
+}
+
+function communityShape(root: FakeElement, communityId: string): FakeElement | undefined {
+  return communityRegion(root, communityId)?.children[0]?.children[0];
+}
+
+class FakeDocument {
+  readonly listeners = new Map<string, Array<(event: FakeEvent) => void>>();
+  readonly defaultView: { PointerEvent?: unknown };
+  created = 0;
+
+  constructor(pointerEvents: boolean) {
+    this.defaultView = pointerEvents ? { PointerEvent: class PointerEvent {} } : {};
+  }
+
+  createElement(tagName: string): FakeElement {
+    this.created += 1;
+    return new FakeElement(tagName, this);
+  }
+
+  createElementNS(_namespace: string, tagName: string): FakeElement {
+    this.created += 1;
+    return new FakeElement(tagName, this);
+  }
+
+  addEventListener(type: string, listener: (event: FakeEvent) => void): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: FakeEvent) => void): void {
+    this.listeners.set(type, (this.listeners.get(type) ?? []).filter((candidate) => candidate !== listener));
+  }
+
+  dispatch(type: string, init: Partial<FakeEvent> = {}): FakeEvent {
+    const event = new FakeEvent(type, init);
+    for (const listener of [...(this.listeners.get(type) ?? [])]) {
+      listener(event);
+    }
+    return event;
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.length ?? 0;
+  }
+}
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly listeners = new Map<string, Array<(event: FakeEvent) => void>>();
+  readonly style: Record<string, string> = {};
+  readonly dataset: Record<string, string> = {};
+  readonly attributes = new Map<string, string>();
+  className = "";
+  textContent = "";
+  tabIndex = 0;
+  type = "";
+  replaceCount = 0;
+  parentElement: FakeElement | null = null;
+
+  constructor(readonly tagName: string, readonly ownerDocument: FakeDocument) {}
+
+  append(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parentElement = this;
+      this.children.push(child);
+    }
+  }
+
+  replaceChildren(...children: FakeElement[]): void {
+    this.replaceCount += 1;
+    this.children.splice(0, this.children.length);
+    this.append(...children);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  addEventListener(type: string, listener: (event: FakeEvent) => void): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: FakeEvent) => void): void {
+    this.listeners.set(type, (this.listeners.get(type) ?? []).filter((candidate) => candidate !== listener));
+  }
+
+  dispatch(type: string, init: Partial<FakeEvent> = {}): FakeEvent {
+    const event = new FakeEvent(type, { ...init, target: this });
+    for (const listener of [...(this.listeners.get(type) ?? [])]) {
+      listener(event);
+    }
+    return event;
+  }
+
+  dispatchEvent(event: FakeEvent): boolean {
+    for (const listener of [...(this.listeners.get(event.type) ?? [])]) {
+      listener(event);
+    }
+    return !event.defaultPrevented;
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.length ?? 0;
+  }
+
+  setPointerCapture(): void {}
+
+  releasePointerCapture(): void {}
+}
+
+class FakeEvent {
+  readonly type: string;
+  button = 0;
+  pointerId = 1;
+  clientX = 0;
+  clientY = 0;
+  target: unknown = null;
+  defaultPrevented = false;
+  propagationStopped = false;
+
+  constructor(type: string, init: Partial<FakeEvent> = {}) {
+    this.type = type;
+    Object.assign(this, init);
+  }
+
+  preventDefault(): void {
+    this.defaultPrevented = true;
+  }
+
+  stopPropagation(): void {
+    this.propagationStopped = true;
+  }
+}

--- a/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+++ b/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
@@ -6,7 +6,8 @@ const helperFiles = [
   "sigma-global-types.ts",
   "sigma-events.ts",
   "sigma-graphology-model.ts",
-  "sigma-hit-projector.ts"
+  "sigma-hit-projector.ts",
+  "sigma-global-camera.ts"
 ];
 
 const existingTypeOnlyFiles = [

--- a/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+++ b/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
@@ -8,7 +8,8 @@ const helperFiles = [
   "sigma-graphology-model.ts",
   "sigma-hit-projector.ts",
   "sigma-global-camera.ts",
-  "sigma-wheel-zoom.ts"
+  "sigma-wheel-zoom.ts",
+  "sigma-overlay-dom.ts"
 ];
 
 const existingTypeOnlyFiles = [

--- a/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+++ b/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
@@ -4,7 +4,8 @@ import { readFile } from "node:fs/promises";
 
 const helperFiles = [
   "sigma-global-types.ts",
-  "sigma-events.ts"
+  "sigma-events.ts",
+  "sigma-graphology-model.ts"
 ];
 
 const existingTypeOnlyFiles = [

--- a/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+++ b/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
@@ -1,25 +1,15 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 
-const helperFiles = [
-  "sigma-global-types.ts",
-  "sigma-events.ts",
-  "sigma-graphology-model.ts",
-  "sigma-hit-projector.ts",
-  "sigma-global-camera.ts",
-  "sigma-wheel-zoom.ts",
-  "sigma-overlay-dom.ts"
-];
+const renderDir = new URL("../src/render/", import.meta.url);
 
-const existingTypeOnlyFiles = [
-  "sigma-coordinates.ts",
-  "community-cloud-geometry.ts"
-];
+const rendererBoundaryExcludedFiles = new Set(["sigma-global-renderer.ts"]);
+const existingTypeOnlyFiles = ["community-cloud-geometry.ts"];
 
 describe("Sigma global renderer refactor boundaries", () => {
   it("keeps shared helper modules from importing the renderer", async () => {
-    for (const file of [...helperFiles, ...existingTypeOnlyFiles]) {
+    for (const file of [...await sigmaHelperFiles(), ...existingTypeOnlyFiles]) {
       const source = await readFile(new URL(`../src/render/${file}`, import.meta.url), "utf8");
       assert.doesNotMatch(source, /from\s+["']\.\/sigma-global-renderer(?:\.[jt]s)?["']/);
     }
@@ -27,7 +17,7 @@ describe("Sigma global renderer refactor boundaries", () => {
 
   it("keeps new Sigma internal helpers out of the render package barrel", async () => {
     const source = await readFile(new URL("../src/render/index.ts", import.meta.url), "utf8");
-    for (const file of helperFiles) {
+    for (const file of await sigmaHelperFiles()) {
       const moduleName = file.replace(/\.ts$/, "");
       assert.doesNotMatch(source, new RegExp(`from\\s+["']\\./${moduleName}(?:\\.js)?["']`));
     }
@@ -38,3 +28,11 @@ describe("Sigma global renderer refactor boundaries", () => {
     assert.doesNotMatch(source, /^\s*export\s+(?!type\b|interface\b)/m);
   });
 });
+
+async function sigmaHelperFiles(): Promise<string[]> {
+  const entries = await readdir(renderDir);
+  return entries
+    .filter((file) => file.startsWith("sigma-") && file.endsWith(".ts"))
+    .filter((file) => !rendererBoundaryExcludedFiles.has(file))
+    .sort();
+}

--- a/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+++ b/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
@@ -7,7 +7,8 @@ const helperFiles = [
   "sigma-events.ts",
   "sigma-graphology-model.ts",
   "sigma-hit-projector.ts",
-  "sigma-global-camera.ts"
+  "sigma-global-camera.ts",
+  "sigma-wheel-zoom.ts"
 ];
 
 const existingTypeOnlyFiles = [

--- a/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+++ b/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
@@ -5,7 +5,8 @@ import { readFile } from "node:fs/promises";
 const helperFiles = [
   "sigma-global-types.ts",
   "sigma-events.ts",
-  "sigma-graphology-model.ts"
+  "sigma-graphology-model.ts",
+  "sigma-hit-projector.ts"
 ];
 
 const existingTypeOnlyFiles = [

--- a/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
+++ b/packages/graph-engine/test/sigma-refactor-boundaries.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const helperFiles = [
+  "sigma-global-types.ts",
+  "sigma-events.ts"
+];
+
+const existingTypeOnlyFiles = [
+  "sigma-coordinates.ts",
+  "community-cloud-geometry.ts"
+];
+
+describe("Sigma global renderer refactor boundaries", () => {
+  it("keeps shared helper modules from importing the renderer", async () => {
+    for (const file of [...helperFiles, ...existingTypeOnlyFiles]) {
+      const source = await readFile(new URL(`../src/render/${file}`, import.meta.url), "utf8");
+      assert.doesNotMatch(source, /from\s+["']\.\/sigma-global-renderer(?:\.[jt]s)?["']/);
+    }
+  });
+
+  it("keeps new Sigma internal helpers out of the render package barrel", async () => {
+    const source = await readFile(new URL("../src/render/index.ts", import.meta.url), "utf8");
+    for (const file of helperFiles) {
+      const moduleName = file.replace(/\.ts$/, "");
+      assert.doesNotMatch(source, new RegExp(`from\\s+["']\\./${moduleName}(?:\\.js)?["']`));
+    }
+  });
+
+  it("keeps the shared type file type-only", async () => {
+    const source = await readFile(new URL("../src/render/sigma-global-types.ts", import.meta.url), "utf8");
+    assert.doesNotMatch(source, /^\s*export\s+(?!type\b|interface\b)/m);
+  });
+});

--- a/packages/graph-engine/test/sigma-wheel-zoom.test.ts
+++ b/packages/graph-engine/test/sigma-wheel-zoom.test.ts
@@ -1,0 +1,181 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  bindSigmaWheelZoomController,
+  sigmaViewportCenter,
+  sigmaWheelInputFromPayload,
+  sigmaWheelTargetIsZoomControl
+} from "../src/render/sigma-wheel-zoom";
+import { sigmaWheelZoomRatio } from "../src/render/sigma-zoom";
+import type { SigmaGlobalSigmaLike } from "../src/render/sigma-global-types";
+
+describe("Sigma wheel zoom controller", () => {
+  it("binds one wheel listener and unregisters the same listener on destroy", () => {
+    const captor = fakeCaptor();
+
+    const controller = bindSigmaWheelZoomController({
+      sigma: sigmaWithCaptor(captor),
+      root: rootWithRect(200, 100),
+      isDestroyed: () => false,
+      currentRatio: () => 1,
+      onZoomAtPoint: () => undefined
+    });
+
+    assert.equal(captor.onCalls.length, 1);
+    controller.destroy();
+    assert.equal(captor.offCalls.length, 1);
+    assert.equal(captor.offCalls[0]?.listener, captor.onCalls[0]?.listener);
+  });
+
+  it("makes late wheel events no-op after destroy even when captor still invokes the listener", () => {
+    const captor = fakeCaptor();
+    let zoomCalls = 0;
+    let destroyed = false;
+    bindSigmaWheelZoomController({
+      sigma: sigmaWithCaptor(captor),
+      root: rootWithRect(200, 100),
+      isDestroyed: () => destroyed,
+      currentRatio: () => 1,
+      onZoomAtPoint: () => {
+        zoomCalls += 1;
+      }
+    });
+
+    destroyed = true;
+    captor.emit({ original: { deltaY: 120 } });
+
+    assert.equal(zoomCalls, 0);
+  });
+
+  it("ignores invalid payloads", () => {
+    const captor = fakeCaptor();
+    let zoomCalls = 0;
+    bindSigmaWheelZoomController({
+      sigma: sigmaWithCaptor(captor),
+      root: rootWithRect(200, 100),
+      isDestroyed: () => false,
+      currentRatio: () => 1,
+      onZoomAtPoint: () => {
+        zoomCalls += 1;
+      }
+    });
+
+    captor.emit({});
+
+    assert.equal(zoomCalls, 0);
+  });
+
+  it("parses delta and pointer fallbacks consistently", () => {
+    assert.deepEqual(
+      sigmaWheelInputFromPayload({ x: 5, y: 6, delta: -10, original: { deltaY: 120, deltaMode: 1 } }, { x: 50, y: 60 }),
+      { point: { x: 5, y: 6 }, delta: { deltaY: 120, deltaMode: 1 } }
+    );
+    assert.deepEqual(
+      sigmaWheelInputFromPayload({ delta: -2 }, { x: 50, y: 60 }),
+      { point: { x: 50, y: 60 }, delta: { deltaY: 240, deltaMode: 0 } }
+    );
+    assert.equal(sigmaWheelInputFromPayload({ original: { deltaY: Number.NaN } }, { x: 0, y: 0 }), null);
+  });
+
+  it("prevents zoom-control wheel events without zooming", () => {
+    const captor = fakeCaptor();
+    let zoomCalls = 0;
+    let prevented = 0;
+    bindSigmaWheelZoomController({
+      sigma: sigmaWithCaptor(captor),
+      root: rootWithRect(200, 100),
+      isDestroyed: () => false,
+      currentRatio: () => 1,
+      onZoomAtPoint: () => {
+        zoomCalls += 1;
+      }
+    });
+
+    captor.emit({
+      original: {
+        deltaY: 120,
+        target: { closest: (selector: string) => selector === "[data-control=\"sigma-zoom\"]" }
+      },
+      preventSigmaDefault: () => {
+        prevented += 1;
+      }
+    });
+
+    assert.equal(sigmaWheelTargetIsZoomControl(captor.lastPayload), true);
+    assert.equal(prevented, 1);
+    assert.equal(zoomCalls, 0);
+  });
+
+  it("uses viewport center and reports thrown zoom errors", () => {
+    const captor = fakeCaptor();
+    const errors: unknown[] = [];
+    const points: Array<{ x: number; y: number }> = [];
+    bindSigmaWheelZoomController({
+      sigma: sigmaWithCaptor(captor),
+      root: rootWithRect(200, 100),
+      isDestroyed: () => false,
+      currentRatio: () => 1,
+      onZoomAtPoint: (point) => {
+        points.push(point);
+        throw new Error("zoom failed");
+      },
+      onFatalError: (error) => errors.push(error)
+    });
+
+    captor.emit({ original: { deltaY: 120 } });
+
+    assert.deepEqual(sigmaViewportCenter(rootWithRect(200, 100)), { x: 100, y: 50 });
+    assert.deepEqual(points, [{ x: 100, y: 50 }]);
+    assert.equal((errors[0] as Error).message, "zoom failed");
+  });
+
+  it("passes the next wheel ratio to the zoom callback", () => {
+    const captor = fakeCaptor();
+    let nextRatio = 0;
+    bindSigmaWheelZoomController({
+      sigma: sigmaWithCaptor(captor),
+      root: rootWithRect(200, 100),
+      isDestroyed: () => false,
+      currentRatio: () => 1.2,
+      onZoomAtPoint: (_point, ratio) => {
+        nextRatio = ratio;
+      }
+    });
+
+    captor.emit({ original: { deltaY: 120 } });
+
+    assert.equal(nextRatio, sigmaWheelZoomRatio(1.2, { deltaY: 120, deltaMode: 0 }));
+  });
+});
+
+function fakeCaptor() {
+  const state = {
+    onCalls: [] as Array<{ event: "wheel"; listener: (payload?: unknown) => void }>,
+    offCalls: [] as Array<{ event: "wheel"; listener: (payload?: unknown) => void }>,
+    lastPayload: undefined as unknown,
+    on(event: "wheel", listener: (payload?: unknown) => void) {
+      state.onCalls.push({ event, listener });
+    },
+    off(event: "wheel", listener: (payload?: unknown) => void) {
+      state.offCalls.push({ event, listener });
+    },
+    emit(payload: unknown) {
+      state.lastPayload = payload;
+      state.onCalls[0]?.listener(payload);
+    }
+  };
+  return state;
+}
+
+function sigmaWithCaptor(captor: ReturnType<typeof fakeCaptor>): SigmaGlobalSigmaLike {
+  return {
+    getMouseCaptor: () => captor
+  };
+}
+
+function rootWithRect(width: number, height: number): HTMLElement {
+  return {
+    getBoundingClientRect: () => ({ width, height })
+  } as HTMLElement;
+}


### PR DESCRIPTION
## Summary
- Split the large Sigma global renderer into focused internal modules for shared types/events, graph model updates, hit projection, camera control, wheel zoom, and overlay DOM control.
- Kept the public graph-engine rendering surface unchanged while shrinking the renderer orchestration file.
- Added focused tests and boundary guards for the extracted modules, including graph rebuild/patch paths, overlay event ownership, late wheel events, camera behavior, hit projection, and helper export boundaries.

## Test Coverage
All new code paths have test coverage through graph-engine unit tests and the Sigma production browser regression.

## Pre-Landing Review
No blocking issues found in the resumed branch review. Follow-up test guard suggestions were applied before push.

## Design Review
No user-facing UI design changes.

## Eval Results
No prompt-related files changed.

## Plan Completion
The planned Sigma renderer split was completed: camera, wheel zoom, overlay DOM, Graphology model, hit projector, shared events/types, direct tests, and boundary tests are all present.

## Linked Issue
Closes #77

## Verification Results
- [x] `npm run test -w @llm-wiki/graph-engine` — 501 tests passed
- [x] `npm run typecheck` — passed
- [x] `bash tests/graph-sigma-global-production.regression-1.sh` — passed on final standalone run, 33 records across 3 graph shapes
- [x] `bash install.sh --dry-run --platform codex` — passed
- [x] privacy path grep — no matches
- [x] `git diff --check` — passed

## TODOS
No TODO items completed in this PR.
