### PR TITLE
fix: harden community reading layout refresh

### DIFF
--- a/packages/graph-engine/src/facade.ts
+++ b/packages/graph-engine/src/facade.ts
@@ -314,13 +314,29 @@ export function createGraphFacadeRouteManager(
       state.data = data;
       if (pins) state.pins = pins;
       let clearedSourceCommunity = false;
+      let clearedFocusedCommunity = false;
+      let clearedTemporaryObject = false;
       // Drop a stale source highlight when refreshed data no longer contains it.
       if (state.sourceCommunityId && !dataHasCommunity(state.data, state.sourceCommunityId)) {
         state.sourceCommunityId = null;
         clearedSourceCommunity = true;
       }
+      if (state.focus?.kind === "community" && !dataHasCommunity(state.data, state.focus.id)) {
+        state.focus = null;
+        state.selection = null;
+        state.searchQuery = "";
+        state.searchResultIds = [];
+        state.temporaryObject = null;
+        clearedFocusedCommunity = true;
+      } else if (state.temporaryObject && !dataHasSummaryObject(state.data, state.temporaryObject)) {
+        state.temporaryObject = null;
+        clearedTemporaryObject = true;
+      }
       if (clearedSourceCommunity) {
         currentRenderer().setSourceCommunityContext?.(null);
+      }
+      if (clearedTemporaryObject) {
+        currentRenderer().clearTemporaryObjectDisplay();
       }
       clearStaleCommunityReadingSelectionForData(data);
       if (graphExceedsGlobalNodeLimit(state.data)) {
@@ -342,6 +358,10 @@ export function createGraphFacadeRouteManager(
           switchToFallbackRoute();
         }
         return;
+      }
+      if (clearedFocusedCommunity) {
+        switchToGlobalRoute();
+        if (routeId === "sigma-global") currentRenderer().resetView();
       }
       currentRenderer().setData(data, pins);
     },
@@ -741,6 +761,16 @@ export function graphExceedsGlobalNodeLimit(data: GraphData): boolean {
 function dataHasCommunity(data: GraphData, communityId: string): boolean {
   if (data.nodes.some((node) => node.community === communityId)) return true;
   return (data.learning?.communities ?? []).some((community) => community.id === communityId);
+}
+
+function dataHasSummaryObject(data: GraphData, object: GraphSummaryObjectRef): boolean {
+  if (object.kind === "node") return data.nodes.some((node) => node.id === object.nodeId);
+  if (object.kind === "community") return dataHasCommunity(data, object.communityId);
+  if (object.kind === "aggregation") {
+    const nodeIds = new Set(data.nodes.map((node) => node.id));
+    return object.nodeIds.some((nodeId) => nodeIds.has(nodeId));
+  }
+  return false;
 }
 
 function clearFacadeInteractionState(state: GraphFacadeState): { preservedCommunityFocus: boolean; clearedSourceCommunity: boolean } {

--- a/packages/graph-engine/src/facade.ts
+++ b/packages/graph-engine/src/facade.ts
@@ -316,28 +316,36 @@ export function createGraphFacadeRouteManager(
       let clearedSourceCommunity = false;
       let clearedFocusedCommunity = false;
       let clearedTemporaryObject = false;
+      let downgradedTemporaryObject: GraphSummaryObjectRef | null = null;
       // Drop a stale source highlight when refreshed data no longer contains it.
       if (state.sourceCommunityId && !dataHasCommunity(state.data, state.sourceCommunityId)) {
         state.sourceCommunityId = null;
         clearedSourceCommunity = true;
       }
       if (state.focus?.kind === "community" && !dataHasCommunity(state.data, state.focus.id)) {
+        clearedTemporaryObject = state.temporaryObject != null;
         state.focus = null;
         state.selection = null;
         state.searchQuery = "";
         state.searchResultIds = [];
         state.temporaryObject = null;
         clearedFocusedCommunity = true;
-      } else if (state.temporaryObject && !dataHasSummaryObject(state.data, state.temporaryObject)) {
-        state.temporaryObject = null;
-        clearedTemporaryObject = true;
+      } else if (state.temporaryObject) {
+        const nextTemporaryObject = summaryObjectForData(state.data, state.temporaryObject);
+        if (nextTemporaryObject !== state.temporaryObject) {
+          state.temporaryObject = nextTemporaryObject;
+          if (nextTemporaryObject) {
+            downgradedTemporaryObject = nextTemporaryObject;
+          } else {
+            clearedTemporaryObject = true;
+          }
+        }
       }
       if (clearedSourceCommunity) {
         currentRenderer().setSourceCommunityContext?.(null);
       }
-      if (clearedTemporaryObject) {
-        currentRenderer().clearTemporaryObjectDisplay();
-      }
+      if (clearedTemporaryObject) currentRenderer().clearTemporaryObjectDisplay();
+      if (downgradedTemporaryObject) currentRenderer().showTemporaryObject(downgradedTemporaryObject);
       clearStaleCommunityReadingSelectionForData(data);
       if (graphExceedsGlobalNodeLimit(state.data)) {
         if (routeId === "over-limit-notice" && active) {
@@ -763,14 +771,17 @@ function dataHasCommunity(data: GraphData, communityId: string): boolean {
   return (data.learning?.communities ?? []).some((community) => community.id === communityId);
 }
 
-function dataHasSummaryObject(data: GraphData, object: GraphSummaryObjectRef): boolean {
-  if (object.kind === "node") return data.nodes.some((node) => node.id === object.nodeId);
-  if (object.kind === "community") return dataHasCommunity(data, object.communityId);
+function summaryObjectForData(data: GraphData, object: GraphSummaryObjectRef): GraphSummaryObjectRef | null {
+  if (object.kind === "node") return data.nodes.some((node) => node.id === object.nodeId) ? object : null;
+  if (object.kind === "community") return dataHasCommunity(data, object.communityId) ? object : null;
   if (object.kind === "aggregation") {
     const nodeIds = new Set(data.nodes.map((node) => node.id));
-    return object.nodeIds.some((nodeId) => nodeIds.has(nodeId));
+    const survivingNodeIds = object.nodeIds.filter((nodeId) => nodeIds.has(nodeId));
+    if (survivingNodeIds.length === 0) return null;
+    if (survivingNodeIds.length === object.nodeIds.length) return object;
+    return { ...object, nodeIds: survivingNodeIds };
   }
-  return false;
+  return null;
 }
 
 function clearFacadeInteractionState(state: GraphFacadeState): { preservedCommunityFocus: boolean; clearedSourceCommunity: boolean } {

--- a/packages/graph-engine/test/route-continuity.test.ts
+++ b/packages/graph-engine/test/route-continuity.test.ts
@@ -240,11 +240,61 @@ describe("graph route state continuity", () => {
     assert.deepEqual(state.searchResultIds, []);
     assert.deepEqual(state.temporaryObject, null);
     assert.deepEqual(state.pins, { "wiki/a.md": { x: 10, y: 20, coordinateSpace: "world" } });
-    assert.deepEqual(sigmaRenderers[0].calls.slice(-3), [
+    assert.deepEqual(
+      sigmaRenderers[0].calls.filter((call) => call[0] === "clearTemporaryObjectDisplay"),
+      [["clearTemporaryObjectDisplay"]]
+    );
+    assert.deepEqual(sigmaRenderers[0].calls.slice(-4), [
       ["setSourceCommunityContext", null],
+      ["clearTemporaryObjectDisplay"],
       ["resetView"],
       ["setData", state.data, undefined]
     ]);
+  });
+
+  it("keeps dragged pins when returning global and re-entering the same community", () => {
+    const container = { dataset: {} as Record<string, string | undefined> };
+    const state: GraphFacadeState = {
+      data: DATA,
+      pins: {},
+      theme: "shan-shui",
+      focus: null,
+      typeFilters: {},
+      aggregationMarkers: [],
+      selection: null,
+      searchQuery: "",
+      searchResultIds: [],
+      temporaryObject: null
+    };
+    const sigmaInputs: GraphFacadeRouteRendererFactoryInput[] = [];
+    const sigmaRenderers: Array<GraphFacadeRenderer & { calls: unknown[][] }> = [];
+    const manager = createGraphFacadeRouteManager(container as unknown as HTMLElement, {
+      state,
+      factories: {
+        createSigmaGlobal: (input) => {
+          sigmaInputs.push(input);
+          return trackRenderer(sigmaRenderers, "sigma-global");
+        },
+        createDomSvgCommunity: () => createFakeRenderer(),
+        createDomSvgSmallFallback: () => createFakeRenderer(),
+        createOverLimitNotice: () => createFakeRenderer()
+      }
+    });
+    const draggedPins: PinMap = {
+      "wiki/a.md": { x: 88, y: 99, coordinateSpace: "world" },
+      "wiki/b.md": { x: 188, y: 199, coordinateSpace: "world" }
+    };
+
+    manager.focusCommunity("c1");
+    sigmaInputs[0].options.callbacks.onPinsChanged?.(draggedPins);
+    sigmaInputs[0].options.callbacks.onGlobalResetRequested?.();
+    manager.focusCommunity("c1");
+
+    assert.deepEqual(state.pins, draggedPins);
+    assert.deepEqual(
+      sigmaRenderers[0].calls.filter((call) => call[0] === "focusCommunity"),
+      [["focusCommunity", "c1"], ["focusCommunity", "c1"]]
+    );
   });
 
   it("clears stale temporary display state when refreshed data removes the object", () => {
@@ -286,6 +336,45 @@ describe("graph route state continuity", () => {
       ["clearTemporaryObjectDisplay"],
       ["setData", state.data, undefined]
     ]);
+  });
+
+  it("downgrades temporary aggregation state when refreshed data removes only some referenced nodes", () => {
+    const container = { dataset: {} as Record<string, string | undefined> };
+    const state: GraphFacadeState = {
+      data: DATA,
+      pins: {},
+      theme: "shan-shui",
+      focus: null,
+      typeFilters: {},
+      aggregationMarkers: [],
+      selection: null,
+      searchQuery: "",
+      searchResultIds: [],
+      temporaryObject: null
+    };
+    const sigmaRenderers: Array<GraphFacadeRenderer & { calls: unknown[][] }> = [];
+    const manager = createGraphFacadeRouteManager(container as unknown as HTMLElement, {
+      state,
+      factories: {
+        createSigmaGlobal: () => trackRenderer(sigmaRenderers, "sigma-global"),
+        createDomSvgCommunity: () => createFakeRenderer(),
+        createDomSvgSmallFallback: () => createFakeRenderer(),
+        createOverLimitNotice: () => createFakeRenderer()
+      }
+    });
+
+    manager.showTemporaryObject({ kind: "aggregation", aggregationId: "agg", nodeIds: ["a", "b"], communityId: "c1" });
+    manager.setData({
+      ...DATA,
+      nodes: DATA.nodes.filter((node) => node.id !== "b"),
+      edges: []
+    });
+
+    assert.deepEqual(state.temporaryObject, { kind: "aggregation", aggregationId: "agg", nodeIds: ["a"], communityId: "c1" });
+    assert.deepEqual(
+      sigmaRenderers[0].calls.filter((call) => call[0] === "showTemporaryObject").slice(-1),
+      [["showTemporaryObject", { kind: "aggregation", aggregationId: "agg", nodeIds: ["a"], communityId: "c1" }]]
+    );
   });
 
   it("resets all persisted pins while staying in Sigma community reading", () => {

--- a/packages/graph-engine/test/route-continuity.test.ts
+++ b/packages/graph-engine/test/route-continuity.test.ts
@@ -198,6 +198,138 @@ describe("graph route state continuity", () => {
     assert.equal(state.selection, null);
   });
 
+  it("returns to global and clears community-local state when refreshed data removes the focused community", () => {
+    const container = { dataset: {} as Record<string, string | undefined> };
+    const state: GraphFacadeState = {
+      data: DATA,
+      pins: { "wiki/a.md": { x: 10, y: 20, coordinateSpace: "world" } },
+      theme: "shan-shui",
+      focus: null,
+      typeFilters: { topic: true, source: true },
+      aggregationMarkers: [],
+      selection: null,
+      searchQuery: "Alpha",
+      searchResultIds: ["a"],
+      temporaryObject: { kind: "node", nodeId: "a" }
+    };
+    const sigmaRenderers: Array<GraphFacadeRenderer & { calls: unknown[][] }> = [];
+    const manager = createGraphFacadeRouteManager(container as unknown as HTMLElement, {
+      state,
+      factories: {
+        createSigmaGlobal: () => trackRenderer(sigmaRenderers, "sigma-global"),
+        createDomSvgCommunity: () => createFakeRenderer(),
+        createDomSvgSmallFallback: () => createFakeRenderer(),
+        createOverLimitNotice: () => createFakeRenderer()
+      }
+    });
+
+    manager.focusCommunity("c1");
+    manager.select({ kind: "node", id: "a" });
+    assert.equal(manager.sourceCommunityId, "c1");
+    manager.setData({
+      ...DATA,
+      nodes: DATA.nodes.map((node) => ({ ...node, community: "c2" })),
+      edges: []
+    });
+
+    assert.equal(manager.routeId, "sigma-global");
+    assert.equal(state.focus, null);
+    assert.equal(state.sourceCommunityId, null);
+    assert.equal(state.selection, null);
+    assert.equal(state.searchQuery, "");
+    assert.deepEqual(state.searchResultIds, []);
+    assert.deepEqual(state.temporaryObject, null);
+    assert.deepEqual(state.pins, { "wiki/a.md": { x: 10, y: 20, coordinateSpace: "world" } });
+    assert.deepEqual(sigmaRenderers[0].calls.slice(-3), [
+      ["setSourceCommunityContext", null],
+      ["resetView"],
+      ["setData", state.data, undefined]
+    ]);
+  });
+
+  it("clears stale temporary display state when refreshed data removes the object", () => {
+    const container = { dataset: {} as Record<string, string | undefined> };
+    const state: GraphFacadeState = {
+      data: DATA,
+      pins: {},
+      theme: "shan-shui",
+      focus: null,
+      typeFilters: {},
+      aggregationMarkers: [],
+      selection: null,
+      searchQuery: "",
+      searchResultIds: [],
+      temporaryObject: null
+    };
+    const sigmaRenderers: Array<GraphFacadeRenderer & { calls: unknown[][] }> = [];
+    const manager = createGraphFacadeRouteManager(container as unknown as HTMLElement, {
+      state,
+      factories: {
+        createSigmaGlobal: () => trackRenderer(sigmaRenderers, "sigma-global"),
+        createDomSvgCommunity: () => createFakeRenderer(),
+        createDomSvgSmallFallback: () => createFakeRenderer(),
+        createOverLimitNotice: () => createFakeRenderer()
+      }
+    });
+
+    manager.focusCommunity("c1");
+    manager.showTemporaryObject({ kind: "node", nodeId: "b" });
+    manager.setData({
+      ...DATA,
+      nodes: DATA.nodes.filter((node) => node.id !== "b"),
+      edges: []
+    });
+
+    assert.deepEqual(state.focus, { kind: "community", id: "c1" });
+    assert.equal(state.temporaryObject, null);
+    assert.deepEqual(sigmaRenderers[0].calls.slice(-2), [
+      ["clearTemporaryObjectDisplay"],
+      ["setData", state.data, undefined]
+    ]);
+  });
+
+  it("resets all persisted pins while staying in Sigma community reading", () => {
+    const container = { dataset: {} as Record<string, string | undefined> };
+    const state: GraphFacadeState = {
+      data: DATA,
+      pins: {
+        "wiki/a.md": { x: 10, y: 20, coordinateSpace: "world" },
+        "wiki/b.md": { x: 30, y: 40, coordinateSpace: "world" }
+      },
+      theme: "shan-shui",
+      focus: null,
+      typeFilters: {},
+      aggregationMarkers: [],
+      selection: null,
+      searchQuery: "",
+      searchResultIds: [],
+      temporaryObject: null
+    };
+    const pinsChanged: unknown[] = [];
+    const sigmaRenderers: Array<GraphFacadeRenderer & { calls: unknown[][] }> = [];
+    const manager = createGraphFacadeRouteManager(container as unknown as HTMLElement, {
+      state,
+      callbacks: {
+        onPinsChanged: (pins) => pinsChanged.push(pins)
+      },
+      factories: {
+        createSigmaGlobal: () => trackRenderer(sigmaRenderers, "sigma-global"),
+        createDomSvgCommunity: () => createFakeRenderer(),
+        createDomSvgSmallFallback: () => createFakeRenderer(),
+        createOverLimitNotice: () => createFakeRenderer()
+      }
+    });
+
+    manager.focusCommunity("c1");
+    manager.resetLayout();
+
+    assert.equal(manager.routeId, "sigma-global");
+    assert.deepEqual(state.focus, { kind: "community", id: "c1" });
+    assert.deepEqual(state.pins, {});
+    assert.deepEqual(pinsChanged, [{}]);
+    assert.deepEqual(sigmaRenderers[0].calls.slice(-2), [["focusCommunity", "c1"], ["resetLayout"]]);
+  });
+
   it("passes shared interaction state into DOM/SVG small fallback and keeps return-global rules consistent", () => {
     const container = { dataset: {} as Record<string, string | undefined> };
     const state: GraphFacadeState = {
@@ -282,6 +414,9 @@ function createFakeRenderer(): GraphFacadeRenderer & { calls: unknown[][] } {
     },
     focusCommunity(id: string) {
       calls.push(["focusCommunity", id]);
+    },
+    setSourceCommunityContext(id: string | null) {
+      calls.push(["setSourceCommunityContext", id]);
     },
     previewNode(id: string | null) {
       calls.push(["previewNode", id]);

--- a/packages/graph-engine/test/sigma-global-renderer.test.ts
+++ b/packages/graph-engine/test/sigma-global-renderer.test.ts
@@ -1735,6 +1735,62 @@ describe("Sigma global renderer production boundary", () => {
     renderer.destroy();
   });
 
+  it("drags a Sigma community reading node without losing reading interactions", () => {
+    const runtime = fakeRuntime();
+    const pins: unknown[] = [];
+    const hovers: unknown[] = [];
+    const hits: unknown[] = [];
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData: communityReadingAdapterDataFixture({
+        selectedNodeId: "render-alpha",
+        searchResultIds: ["render-alpha"],
+        betaPinned: true
+      }),
+      theme: "shan-shui",
+      runtime,
+      pins: {
+        "adapter/beta.md": { x: 333, y: 444, coordinateSpace: "world" }
+      },
+      onPinsChanged: (nextPins) => pins.push(nextPins),
+      onNodeHover: (nodeId) => hovers.push(nodeId),
+      onHitTarget: (target) => hits.push(target)
+    });
+    const sigma = runtime.instances[0];
+
+    assert.equal(renderer.root.dataset.communityFocusId, "adapter-community");
+
+    sigma.emit("downNode", sigmaEventPayload("render-alpha", 116, 228));
+    sigma.emit("moveBody", sigmaEventPayload(null, 156, 268));
+    sigma.emit("upStage", sigmaEventPayload(null, 176, 288));
+
+    assert.deepEqual(pins, [
+      {
+        "adapter/beta.md": { x: 333, y: 444, coordinateSpace: "world" },
+        "adapter/alpha.md": {
+          x: 171,
+          y: 282,
+          coordinateSpace: "world"
+        }
+      }
+    ]);
+    assert.equal(renderer.graph.getNodeAttribute("render-alpha", "x"), 171);
+    assert.equal(renderer.graph.getNodeAttribute("render-alpha", "y"), 282);
+    assert.equal(renderer.graph.getNodeAttribute("render-alpha", "selected"), true);
+    assert.equal(renderer.graph.getNodeAttribute("render-alpha", "searchHit"), true);
+    assert.equal(renderer.graph.getNodeAttribute("render-alpha", "relationFocusDepth"), "first");
+    assert.equal(renderer.overlayRoot.children.find((child) => child.dataset.nodeId === "render-alpha")?.dataset.pinned, "true");
+
+    sigma.emit("enterNode", sigmaEventPayload("render-alpha", 171, 282));
+    assert.equal(hovers.at(-1), "render-alpha");
+
+    sigma.emit("clickNode", sigmaEventPayload("render-alpha", 171, 282));
+    sigma.emit("clickNode", sigmaEventPayload("render-alpha", 171, 282));
+    assert.deepEqual(hits, [{ kind: "node", id: "render-alpha" }]);
+
+    renderer.destroy();
+  });
+
   it("keeps selected search and pinned metadata intact while dragging a Sigma global node", () => {
     const runtime = fakeRuntime();
     const renderer = createSigmaGlobalRenderer({
@@ -2289,6 +2345,78 @@ function adapterDataFixture(options: {
         stableCoreNodeIds: ["render-alpha"],
         stableSkeletonEdgeIds: ["adapter-edge"],
         temporaryBoostNodeIds: []
+      }
+    }
+  };
+}
+
+function communityReadingAdapterDataFixture(options: {
+  selectedNodeId?: string;
+  searchResultIds?: string[];
+  alphaPinned?: boolean;
+  betaPinned?: boolean;
+} = {}): GraphRendererAdapterData {
+  const data = adapterDataFixture(options);
+  const focusedCommunityId = "adapter-community";
+  const nodes = data.nodes.map((node) => (
+    node.id === "render-alpha"
+      ? { ...node, relationFocusDepth: "first" as const }
+      : node
+  ));
+  const edges = data.edges.map((edge) => ({
+    ...edge,
+    render: {
+      ...edge.render,
+      relationFocusDepth: "first" as const
+    }
+  }));
+  const current = {
+    communityId: focusedCommunityId,
+    source: "focus" as const,
+    nodeRulesById: Object.fromEntries(nodes.map((node) => [
+      node.id,
+      {
+        nodeId: node.id,
+        tier: node.render.communityMapTier,
+        basePoint: node.point,
+        labelVisible: node.render.labelVisible,
+        labelSide: node.render.communityMapLabelSide,
+        relationLabel: node.render.communityMapRelationLabel,
+        importance: node.render.communityMapImportance,
+        dotSize: node.render.communityMapDotSize
+      }
+    ])),
+    edgeRulesById: Object.fromEntries(edges.map((edge) => [
+      edge.id,
+      {
+        edgeId: edge.id,
+        layer: edge.render.communityMapLayer,
+        skeleton: edge.render.skeleton,
+        traceable: edge.render.traceable
+      }
+    ])),
+    layout: {
+      coordinateSpace: "world" as const,
+      bounds: { minX: 111, minY: 222, maxX: 333, maxY: 444, width: 222, height: 222 },
+      viewportAspectRatio: null
+    },
+    labelBudget: { limit: 1, visible: 1, hidden: 1 },
+    edgeLayers: { skeleton: 1, related: 0, background: 0 }
+  };
+  return {
+    ...data,
+    sourceCommunityId: focusedCommunityId,
+    nodes,
+    edges,
+    renderable: {
+      ...data.renderable,
+      communityMap: {
+        active: true,
+        sourceCommunityId: focusedCommunityId,
+        motionMode: "frozen",
+        maxNodeDriftRatio: 0,
+        current,
+        rulesByCommunityId: { [focusedCommunityId]: current }
       }
     }
   };

--- a/workbench/web/src/App.tsx
+++ b/workbench/web/src/App.tsx
@@ -62,6 +62,7 @@ import {
 	graphReaderFilteredHidden,
 	graphReaderStaleAfterRefresh,
 	sameGraphDrawerTarget,
+	temporaryObjectAfterGraphDataRefresh,
 	visibilityWithTemporaryObject,
 } from "@/lib/graph-data-refresh";
 import {
@@ -431,7 +432,10 @@ function App() {
 
 	const handleGraphVisibilityChange = useCallback((state: GraphVisibilityState | null) => {
 		setGraphVisibilityState(state);
-		const effectiveState = visibilityWithTemporaryObject(state, graphTemporaryObjectRef.current ?? state?.temporaryObject ?? null);
+		const nextTemporaryObject = temporaryObjectAfterGraphDataRefresh(graphData, state?.temporaryObject ?? null);
+		graphTemporaryObjectRef.current = nextTemporaryObject;
+		setGraphTemporaryObject(nextTemporaryObject);
+		const effectiveState = visibilityWithTemporaryObject(state, nextTemporaryObject);
 		setDrawer((current) => {
 			if (current.mode === "graph-node-summary") {
 				if (
@@ -472,13 +476,16 @@ function App() {
 
 	const handleGraphDataChange = useCallback((nextData: GraphData | null) => {
 		setGraphData(nextData);
-		const effectiveState = visibilityWithTemporaryObject(graphVisibilityState, graphTemporaryObjectRef.current);
+		const nextTemporaryObject = temporaryObjectAfterGraphDataRefresh(nextData, graphTemporaryObjectRef.current);
+		graphTemporaryObjectRef.current = nextTemporaryObject;
+		setGraphTemporaryObject(nextTemporaryObject);
+		const effectiveState = visibilityWithTemporaryObject(graphVisibilityState, nextTemporaryObject);
 		setDrawer((current) => {
 			if (graphReaderStaleAfterRefresh(current, nextData, effectiveState)) clearStaleGraphReaderFocus();
 			const next = drawerAfterGraphDataRefresh(current, nextData, {
 				pins: graphPins,
 				visibility: graphVisibilityState,
-				temporaryObject: graphTemporaryObjectRef.current,
+				temporaryObject: nextTemporaryObject,
 			});
 			return sameGraphDrawerTarget(current, next) ? current : next;
 		});
@@ -708,14 +715,17 @@ function App() {
 	}, [graphData, graphPins, graphVisibilityState, handleOpenGraphPage]);
 
 	useEffect(() => {
-		const effectiveState = visibilityWithTemporaryObject(graphVisibilityState, graphTemporaryObjectRef.current);
+		const nextTemporaryObject = temporaryObjectAfterGraphDataRefresh(graphData, graphTemporaryObjectRef.current);
+		graphTemporaryObjectRef.current = nextTemporaryObject;
+		setGraphTemporaryObject(nextTemporaryObject);
+		const effectiveState = visibilityWithTemporaryObject(graphVisibilityState, nextTemporaryObject);
 		setDrawer((current) => {
 			if (!isGraphInteractionDrawer(current)) return current;
 			if (graphReaderStaleAfterRefresh(current, graphData, effectiveState)) clearStaleGraphReaderFocus();
 			return drawerAfterGraphDataRefresh(current, graphData, {
 				pins: graphPins,
 				visibility: graphVisibilityState,
-				temporaryObject: graphTemporaryObjectRef.current,
+				temporaryObject: nextTemporaryObject,
 			});
 		});
 	}, [clearStaleGraphReaderFocus, graphData, graphPins, graphVisibilityState]);

--- a/workbench/web/src/components/GraphPanel.tsx
+++ b/workbench/web/src/components/GraphPanel.tsx
@@ -103,7 +103,11 @@ export function GraphPanel({
 	const lastSelectionCommandRef = useRef<GraphSelectionCommand | undefined>(selectionCommand);
 	const [data, setData] = useState<GraphData | null>(null);
 	const [edgeStyle, setEdgeStyle] = useState<GraphEdgeStyleOptions>(() => readGraphEdgeStylePreference());
-	const edgeStyleRef = useRef<GraphEdgeStyleOptions>(edgeStyle);
+	const [communityEdgeStyle, setCommunityEdgeStyle] = useState<GraphEdgeStyleOptions>({ ...DEFAULT_GRAPH_EDGE_STYLE });
+	const [communityFocusId, setCommunityFocusId] = useState<string | null>(null);
+	const communityFocusIdRef = useRef<string | null>(null);
+	const activeEdgeStyle = communityFocusId ? communityEdgeStyle : edgeStyle;
+	const activeEdgeStyleRef = useRef<GraphEdgeStyleOptions>(activeEdgeStyle);
 	const edgeTuningRef = useRef<HTMLDivElement | null>(null);
 	const edgeTuningButtonRef = useRef<HTMLButtonElement | null>(null);
 	const edgeTuningFirstToggleRef = useRef<HTMLInputElement | null>(null);
@@ -130,6 +134,9 @@ export function GraphPanel({
 		activeKbPathRef.current = currentKnowledgeBasePath;
 		layoutPinsRef.current = {};
 		lastDragStateRef.current = false;
+		communityFocusIdRef.current = null;
+		setCommunityFocusId(null);
+		setCommunityEdgeStyle({ ...DEFAULT_GRAPH_EDGE_STYLE });
 		setData(null);
 		setDataKnowledgeBasePath(currentKnowledgeBasePath);
 	}, [currentKnowledgeBasePath]);
@@ -153,10 +160,13 @@ export function GraphPanel({
 	}, [currentKnowledgeBasePath, graphBuildError]);
 
 	useEffect(() => {
-		edgeStyleRef.current = edgeStyle;
 		writeGraphEdgeStylePreference(edgeStyle);
-		engineRef.current?.setEdgeStyle(edgeStyle);
 	}, [edgeStyle]);
+
+	useEffect(() => {
+		activeEdgeStyleRef.current = activeEdgeStyle;
+		engineRef.current?.setEdgeStyle(activeEdgeStyle);
+	}, [activeEdgeStyle]);
 
 	useEffect(() => {
 		if (!edgeTuningOpen) return;
@@ -183,6 +193,28 @@ export function GraphPanel({
 	useEffect(() => {
 		if (!edgeTuningAvailable) setEdgeTuningOpen(false);
 	}, [edgeTuningAvailable]);
+
+	const clearCommunityEdgeScope = useCallback((): void => {
+		communityFocusIdRef.current = null;
+		setCommunityFocusId(null);
+		setCommunityEdgeStyle({ ...DEFAULT_GRAPH_EDGE_STYLE });
+	}, []);
+
+	const enterCommunityEdgeScope = useCallback((communityId: string): void => {
+		if (communityFocusIdRef.current !== communityId) {
+			setCommunityEdgeStyle({ ...DEFAULT_GRAPH_EDGE_STYLE });
+		}
+		communityFocusIdRef.current = communityId;
+		setCommunityFocusId(communityId);
+	}, []);
+
+	const updateActiveEdgeStyle = useCallback((patch: Partial<GraphEdgeStyleOptions>): void => {
+		if (communityFocusIdRef.current) {
+			setCommunityEdgeStyle((current) => ({ ...current, ...patch }));
+			return;
+		}
+		setEdgeStyle((current) => ({ ...current, ...patch }));
+	}, []);
 
 	useLayoutEffect(() => {
 		graphThemeRef.current = graphTheme;
@@ -427,13 +459,16 @@ export function GraphPanel({
 			data,
 			pins: layoutPinsRef.current,
 			theme: graphThemeRef.current,
-			edgeStyle: edgeStyleRef.current,
+			edgeStyle: activeEdgeStyleRef.current,
 			aggregationMarkers,
 			capabilities: createGraphWorkbenchCapabilities({
 				onOpenPage: (payload) => onOpenPageRef.current?.(payload),
 				onSelectionChange: (nextSelection) => onSelectionChangeRef.current?.(nextSelection),
 				onSelectionClear: () => onSelectionChangeRef.current?.(null),
-				onViewReset: () => onViewResetRef.current?.(),
+				onViewReset: () => {
+					clearCommunityEdgeScope();
+					onViewResetRef.current?.();
+				},
 				onAsk: (nextSelection) => onSelectionChangeRef.current?.(nextSelection),
 				persistPins,
 				onDragStateChange: (dragging) => {
@@ -443,13 +478,20 @@ export function GraphPanel({
 						void playDiff(decision.diff);
 					}
 				},
-				onVisibilityStateChange: (state) => onGraphVisibilityChangeRef.current?.(state),
+				onVisibilityStateChange: (state) => {
+					if ("focusCommunityId" in state) {
+						const nextCommunityFocusId = state.focusCommunityId ?? null;
+						if (nextCommunityFocusId) enterCommunityEdgeScope(nextCommunityFocusId);
+						else clearCommunityEdgeScope();
+					}
+					onGraphVisibilityChangeRef.current?.(state);
+				},
 			}).capabilities,
 		});
 		engineRef.current = engine;
 		engineKbPathRef.current = currentKnowledgeBasePath;
 		engineDataRef.current = data;
-	}, [aggregationMarkers, currentKnowledgeBasePath, data, dataKnowledgeBasePath, persistPins, playDiff, selectionCommand]);
+	}, [aggregationMarkers, clearCommunityEdgeScope, currentKnowledgeBasePath, data, dataKnowledgeBasePath, enterCommunityEdgeScope, persistPins, playDiff, selectionCommand]);
 
 	useEffect(() => {
 		engineRef.current?.setTheme(graphTheme);
@@ -472,10 +514,12 @@ export function GraphPanel({
 			if (selected) onSelectionChangeRef.current?.(selected);
 		}
 		if (selectionCommand.type === "enter-community") {
+			enterCommunityEdgeScope(selectionCommand.id);
 			const selected = engineRef.current ? applyCommunityEnter(engineRef.current, selectionCommand.id) : null;
 			onSelectionChangeRef.current?.(selected);
 		}
 		if (selectionCommand.type === "enter-community-node") {
+			enterCommunityEdgeScope(selectionCommand.id);
 			const selected = engineRef.current?.select({ kind: "node", id: selectionCommand.nodeId });
 			engineRef.current?.focusCommunity(selectionCommand.id);
 			if (selected) onSelectionChangeRef.current?.(selected);
@@ -492,7 +536,7 @@ export function GraphPanel({
 		if (selectionCommand.type === "clear-temporary-object-display") {
 			engineRef.current?.clearTemporaryObjectDisplay();
 		}
-	}, [selectionCommand, status]);
+	}, [enterCommunityEdgeScope, selectionCommand, status]);
 
 	useEffect(() => {
 		if (
@@ -616,13 +660,10 @@ export function GraphPanel({
 										<input
 											type="checkbox"
 											ref={edgeTuningFirstToggleRef}
-											checked={edgeStyle.semanticEmphasis}
+											checked={activeEdgeStyle.semanticEmphasis}
 											onChange={(event) => {
 												const checked = event.currentTarget.checked;
-												setEdgeStyle((current) => ({
-													...current,
-													semanticEmphasis: checked,
-												}));
+												updateActiveEdgeStyle({ semanticEmphasis: checked });
 											}}
 										/>
 										<span>语义强调</span>
@@ -630,13 +671,10 @@ export function GraphPanel({
 									<label className="graph-edge-tuning-toggle">
 										<input
 											type="checkbox"
-											checked={edgeStyle.focusHighlight}
+											checked={activeEdgeStyle.focusHighlight}
 											onChange={(event) => {
 												const checked = event.currentTarget.checked;
-												setEdgeStyle((current) => ({
-													...current,
-													focusHighlight: checked,
-												}));
+												updateActiveEdgeStyle({ focusHighlight: checked });
 											}}
 										/>
 										<span>聚焦点亮</span>
@@ -725,6 +763,13 @@ function readGraphEdgeStylePreference(): GraphEdgeStyleOptions {
 
 function writeGraphEdgeStylePreference(style: GraphEdgeStyleOptions): void {
 	try {
+		if (
+			style.semanticEmphasis === DEFAULT_GRAPH_EDGE_STYLE.semanticEmphasis
+			&& style.focusHighlight === DEFAULT_GRAPH_EDGE_STYLE.focusHighlight
+		) {
+			localStorage.removeItem(GRAPH_EDGE_STYLE_STORAGE_KEY);
+			return;
+		}
 		localStorage.setItem(GRAPH_EDGE_STYLE_STORAGE_KEY, JSON.stringify(style));
 	} catch {
 		// localStorage can be unavailable in restricted browser contexts.

--- a/workbench/web/src/lib/graph-data-refresh.ts
+++ b/workbench/web/src/lib/graph-data-refresh.ts
@@ -79,6 +79,24 @@ export function visibilityWithTemporaryObject(
 	};
 }
 
+export function temporaryObjectAfterGraphDataRefresh(
+	data: GraphData | null,
+	object: GraphSummaryObjectRef | null,
+): GraphSummaryObjectRef | null {
+	if (!data || !object) return null;
+	if (object.kind === "node") {
+		return data.nodes.some((node) => node.id === object.nodeId) ? object : null;
+	}
+	if (object.kind === "community") {
+		return graphDataHasCommunity(data, object.communityId) ? object : null;
+	}
+	const nodeIds = new Set(data.nodes.map((node) => node.id));
+	const survivingNodeIds = object.nodeIds.filter((nodeId) => nodeIds.has(nodeId));
+	if (survivingNodeIds.length === 0) return null;
+	if (survivingNodeIds.length === object.nodeIds.length) return object;
+	return { ...object, nodeIds: survivingNodeIds };
+}
+
 export function graphReaderFilteredHidden(nodeId: string, state: GraphVisibilityState | null): boolean {
 	return state?.hiddenReadingNodeId === nodeId;
 }
@@ -103,7 +121,17 @@ export function drawerAfterGraphDataRefresh(
 		temporaryObject: GraphSummaryObjectRef | null;
 	},
 ): DrawerState {
-	const visibility = visibilityWithTemporaryObject(options.visibility, options.temporaryObject);
+	const temporaryObject = temporaryObjectAfterGraphDataRefresh(data, options.temporaryObject);
+	const visibility = visibilityWithTemporaryObject(options.visibility, temporaryObject);
+	const missingFocusedCommunityId = focusedCommunityMissingAfterRefresh(data, options.visibility);
+	if (missingFocusedCommunityId) {
+		return drawerForUnavailableGraphObject(data, { kind: "community", communityId: missingFocusedCommunityId }, "missing-community", current, {
+			pins: options.pins,
+			selection: { kind: "community", id: missingFocusedCommunityId },
+			searchResultIds: visibility?.searchResultIds ?? [],
+			temporaryObject: visibility?.temporaryObject ?? null,
+		});
+	}
 	if (current.mode === "graph-reader") {
 		if (graphReaderStaleAfterRefresh(current, data, visibility)) return closedDrawer();
 		return {
@@ -146,6 +174,17 @@ export function drawerAfterGraphDataRefresh(
 		});
 	}
 	return current;
+}
+
+function focusedCommunityMissingAfterRefresh(data: GraphData | null, visibility: GraphVisibilityState | null): string | null {
+	const communityId = visibility?.focusCommunityId ?? null;
+	if (!data || !communityId) return null;
+	return graphDataHasCommunity(data, communityId) ? null : communityId;
+}
+
+function graphDataHasCommunity(data: GraphData, communityId: string): boolean {
+	if (data.nodes.some((node) => node.community === communityId)) return true;
+	return (data.learning?.communities ?? []).some((community) => community.id === communityId);
 }
 
 function graphSummaryCommandSignature(commands: readonly GraphSummaryCommand[]): string {

--- a/workbench/web/test/graph-data-refresh.test.ts
+++ b/workbench/web/test/graph-data-refresh.test.ts
@@ -1,11 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import type { GraphData, GraphOpenPagePayload, GraphVisibilityState } from "@llm-wiki/graph-engine";
-import { graphReaderDrawer } from "../src/lib/drawer-state";
+import type { GraphData, GraphOpenPagePayload, GraphSummaryObjectRef, GraphVisibilityState } from "@llm-wiki/graph-engine";
+import { closedDrawer, graphReaderDrawer } from "../src/lib/drawer-state";
 import {
 	drawerAfterGraphDataRefresh,
 	graphReaderStaleAfterRefresh,
+	temporaryObjectAfterGraphDataRefresh,
 } from "../src/lib/graph-data-refresh";
 
 describe("graph data refresh drawer state", () => {
@@ -44,15 +45,40 @@ describe("graph data refresh drawer state", () => {
 		};
 
 		assert.equal(graphReaderStaleAfterRefresh(current, graphData("c1"), visibility), false);
-		assert.equal(graphReaderStaleAfterRefresh(current, { ...graphData("c1"), nodes: [] }, visibility), true);
-		assert.equal(graphReaderStaleAfterRefresh(current, graphData("c2"), visibility), true);
+		const missingNodeInFocusedCommunity = {
+			...graphData("c1"),
+			nodes: [
+				{
+					id: "community-anchor",
+					label: "Anchor",
+					type: "topic",
+					community: "c1",
+					source_path: "wiki/community-anchor.md",
+				},
+			],
+		};
+		assert.equal(graphReaderStaleAfterRefresh(current, missingNodeInFocusedCommunity, visibility), true);
+		const movedOutsideFocusedCommunity = {
+			...graphData("c2"),
+			nodes: [
+				...graphData("c2").nodes,
+				{
+					id: "community-anchor",
+					label: "Anchor",
+					type: "topic",
+					community: "c1",
+					source_path: "wiki/community-anchor.md",
+				},
+			],
+		};
+		assert.equal(graphReaderStaleAfterRefresh(current, movedOutsideFocusedCommunity, visibility), true);
 
-		const missing = drawerAfterGraphDataRefresh(current, { ...graphData("c1"), nodes: [] }, {
+		const missing = drawerAfterGraphDataRefresh(current, missingNodeInFocusedCommunity, {
 			pins: {},
 			visibility,
 			temporaryObject: null,
 		});
-		const moved = drawerAfterGraphDataRefresh(current, graphData("c2"), {
+		const moved = drawerAfterGraphDataRefresh(current, movedOutsideFocusedCommunity, {
 			pins: {},
 			visibility,
 			temporaryObject: null,
@@ -60,6 +86,40 @@ describe("graph data refresh drawer state", () => {
 
 		assert.deepEqual(missing, { mode: "closed" });
 		assert.deepEqual(moved, { mode: "closed" });
+	});
+
+	it("shows an unavailable message when the focused community disappears while the drawer is closed", () => {
+		const next = drawerAfterGraphDataRefresh(closedDrawer(), graphData("c2"), {
+			pins: {},
+			visibility: {
+				searchQuery: "",
+				searchResultIds: [],
+				typeFilters: {},
+				temporaryObject: null,
+				focusCommunityId: "c1",
+				hiddenReadingNodeId: null,
+			},
+			temporaryObject: null,
+		});
+
+		assert.equal(next.mode, "graph-unavailable-object");
+		assert.equal(next.mode === "graph-unavailable-object" ? next.payload.reason : null, "missing-community");
+		assert.deepEqual(next.mode === "graph-unavailable-object" ? next.payload.object : null, {
+			kind: "community",
+			communityId: "c1",
+		});
+	});
+
+	it("drops or downgrades temporary display objects when refreshed data no longer contains them", () => {
+		const helper: (data: GraphData | null, object: GraphSummaryObjectRef | null) => GraphSummaryObjectRef | null =
+			temporaryObjectAfterGraphDataRefresh;
+
+		assert.deepEqual(helper(graphData("c1"), { kind: "node", nodeId: "a" }), { kind: "node", nodeId: "a" });
+		assert.equal(helper({ ...graphData("c1"), nodes: [] }, { kind: "node", nodeId: "a" }), null);
+		assert.deepEqual(
+			helper(graphData("c1"), { kind: "aggregation", aggregationId: "agg", nodeIds: ["a", "missing"], communityId: "c1" }),
+			{ kind: "aggregation", aggregationId: "agg", nodeIds: ["a"], communityId: "c1" },
+		);
 	});
 
 	it("turns a stale community drawer into an unavailable message after refresh", () => {

--- a/workbench/web/test/graph-data-refresh.test.ts
+++ b/workbench/web/test/graph-data-refresh.test.ts
@@ -61,6 +61,57 @@ describe("graph data refresh drawer state", () => {
 		assert.deepEqual(missing, { mode: "closed" });
 		assert.deepEqual(moved, { mode: "closed" });
 	});
+
+	it("turns a stale community drawer into an unavailable message after refresh", () => {
+		const current = {
+			mode: "graph-community-summary" as const,
+			payload: {
+				communityId: "c1",
+				label: "Community 1",
+				nodeCount: 1,
+				description: "Old summary",
+				facts: { pageCount: 1, internalLinkCount: 0, communityCount: 1, isolatedCount: 1 },
+				structureState: "loose" as const,
+				canEnterCommunity: true,
+				coreNodeIds: ["a"],
+				coreNodes: [],
+				searchResultIds: [],
+				pinHints: [],
+				selection: {
+					input: { kind: "community" as const, id: "c1" },
+					selectionId: "community:c1",
+					selectedNodeIds: ["a"],
+					selectedCommunityIds: ["c1"],
+					containsCurrentObject: true,
+				},
+				strongestRelations: [],
+				bridgeRelations: [],
+				aggregationMarkers: [],
+				commands: [],
+			},
+			freeText: "",
+		};
+
+		const next = drawerAfterGraphDataRefresh(current, graphData("c2"), {
+			pins: {},
+			visibility: {
+				searchQuery: "",
+				searchResultIds: [],
+				typeFilters: {},
+				temporaryObject: null,
+				focusCommunityId: null,
+				hiddenReadingNodeId: null,
+			},
+			temporaryObject: null,
+		});
+
+		assert.equal(next.mode, "graph-unavailable-object");
+		assert.equal(next.mode === "graph-unavailable-object" ? next.payload.reason : null, "missing-community");
+		assert.deepEqual(next.mode === "graph-unavailable-object" ? next.payload.object : null, {
+			kind: "community",
+			communityId: "c1",
+		});
+	});
 });
 
 function openPagePayload(id: string, community: string): GraphOpenPagePayload {

--- a/workbench/web/test/graph-panel-paper.test.tsx
+++ b/workbench/web/test/graph-panel-paper.test.tsx
@@ -94,6 +94,57 @@ describe("GraphPanel Paper shell", () => {
 		assert.equal(document.activeElement, tuningButton);
 	});
 
+	it("keeps edge tuning changes local to community reading and clears them on return", async () => {
+		mockGraphFetch();
+		const selectionChanges: unknown[] = [];
+		const { rerender } = render(
+			<GraphPanel
+				currentKnowledgeBaseName="AI 学习库"
+				currentKnowledgeBasePath="/kb"
+				theme="light"
+				onSelectionChange={(selection) => selectionChanges.push(selection)}
+			/>,
+		);
+
+		await waitFor(() => {
+			assert.match(document.body.textContent ?? "", /1 节点 · 0 关联/);
+		});
+
+		rerender(
+			<GraphPanel
+				currentKnowledgeBaseName="AI 学习库"
+				currentKnowledgeBasePath="/kb"
+				theme="light"
+				onSelectionChange={(selection) => selectionChanges.push(selection)}
+				selectionCommand={{ id: "paper", type: "enter-community" }}
+			/>,
+		);
+
+		await waitFor(() => {
+			assert.deepEqual(selectionChanges, [null]);
+			assert.notEqual(screen.queryByRole("button", { name: "回全图" }), null);
+		});
+
+		const tuningButton = screen.getByRole("button", { name: /调参/ }) as HTMLButtonElement;
+		await click(tuningButton);
+		const semanticToggle = screen.getByRole("checkbox", { name: "语义强调" }) as HTMLInputElement;
+		await click(semanticToggle);
+
+		await waitFor(() => {
+			assert.equal(semanticToggle.checked, true);
+			assert.equal(localStorage.getItem("llm-wiki.graph.edge-style"), null);
+		});
+
+		await click(screen.getByRole("button", { name: "回全图" }));
+
+		await waitFor(() => {
+			assert.equal(localStorage.getItem("llm-wiki.graph.edge-style"), null);
+		});
+		await click(tuningButton);
+		const returnedSemanticToggle = screen.getByRole("checkbox", { name: "语义强调" }) as HTMLInputElement;
+		assert.equal(returnedSemanticToggle.checked, false);
+	});
+
 	it("surfaces graph build errors in the graph panel", async () => {
 		mockGraphFetch({ needsBuild: true });
 

--- a/workbench/web/test/setup-dom.ts
+++ b/workbench/web/test/setup-dom.ts
@@ -48,6 +48,21 @@ Object.defineProperty(globalThis, "ResizeObserver", {
 	value: TestResizeObserver,
 });
 
+Object.defineProperties(window.HTMLElement.prototype, {
+	hasPointerCapture: {
+		configurable: true,
+		value: () => false,
+	},
+	releasePointerCapture: {
+		configurable: true,
+		value: () => undefined,
+	},
+	setPointerCapture: {
+		configurable: true,
+		value: () => undefined,
+	},
+});
+
 const { cleanup } = await import("@testing-library/react");
 
 beforeEach(() => {


### PR DESCRIPTION
Closes #100

## Summary
- keep Sigma community reading node drag positions across return/global mode changes
- reset the full graph layout from community reading instead of only the focused community
- preserve or clear community/node reading state correctly when refreshed data changes
- clean up stale temporary display state after refresh

## Verification
- npm run typecheck
- node --import tsx --test packages/graph-engine/test/route-continuity.test.ts
- npm run test -w @llm-wiki-agent/web -- graph-data-refresh.test.ts
- npm run lint -w @llm-wiki-agent/web
- bash install.sh --dry-run --platform codex
- grep -r '本机用户路径\|真实姓名\|私有素材路径' scripts/ templates/ tests/ SKILL.md