### PR TITLE
修复 Sigma 社区阅读真实体验验收

### DIFF
--- a/packages/graph-engine/src/graph-routes/sigma-global-route.ts
+++ b/packages/graph-engine/src/graph-routes/sigma-global-route.ts
@@ -7,7 +7,8 @@ import {
   readToolbarPanelState,
   writeToolbarPanelState,
   type GraphRendererAdapterData,
-  type GraphGestureTarget
+  type GraphGestureTarget,
+  type RendererViewportSize
 } from "../render";
 import type { SigmaGlobalHitContext } from "../render/sigma-global-types";
 import {
@@ -61,13 +62,13 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
   let toolbarPanelState = readToolbarPanelState(input.container.ownerDocument.defaultView?.localStorage);
   let searchStatus: HTMLElement | null = null;
   let searchResultsList: HTMLElement | null = null;
-  let currentSigmaAdapterData = adapterDataForSigmaRoute(options, hoverNodeId, typeFiltersForCurrentRoute());
   const shell = input.container.ownerDocument.createElement("div");
   shell.className = "sigma-global-route llm-wiki-graph-engine";
   shell.dataset.route = "sigma-global";
   applyGraphThemeToElement(shell, options.theme);
   input.container.append(shell);
   ensureGraphRendererStyles(input.container.ownerDocument);
+  let currentSigmaAdapterData = adapterDataForSigmaRoute(options, hoverNodeId, typeFiltersForCurrentRoute(), sigmaRouteViewportSize());
   const hiddenReadingNodeHint = input.container.ownerDocument.createElement("div");
   hiddenReadingNodeHint.className = "sigma-community-hidden-node-hint";
   hiddenReadingNodeHint.textContent = "当前节点被筛选隐藏";
@@ -81,12 +82,14 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
     .then((runtime) => {
       if (destroyed) return;
       try {
+        currentSigmaAdapterData = adapterDataForSigmaRoute(options, hoverNodeId, typeFiltersForCurrentRoute(), sigmaRouteViewportSize());
         renderer = createSigmaGlobalRenderer({
           container: shell,
           adapterData: currentSigmaAdapterData,
           theme: options.theme,
           edgeStyle: options.edgeStyle,
           runtime: runtime as unknown as SigmaGlobalRendererRuntime,
+          viewportSize: sigmaRouteViewportSize(),
           pins: options.pins,
           onPinsChanged: handleSigmaPinsChanged,
           onDragActiveChange: input.options.callbacks.onDragActiveChange,
@@ -187,7 +190,7 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
       const path = wikiPathForGraphNode(node);
       const nextPins: PinMap = { ...options.pins };
       if (mode === "fix") {
-        const adapterNode = adapterDataForSigmaRoute(options, null, typeFiltersForCurrentRoute()).nodes.find((item) => item.id === id);
+        const adapterNode = adapterDataForSigmaRoute(options, null, typeFiltersForCurrentRoute(), sigmaRouteViewportSize()).nodes.find((item) => item.id === id);
         nextPins[path] = {
           x: adapterNode?.point.x ?? numericNodeCoordinate(node.x),
           y: adapterNode?.point.y ?? numericNodeCoordinate(node.y),
@@ -225,15 +228,20 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
   };
 
   function updateSigmaRenderer(): void {
-    currentSigmaAdapterData = adapterDataForSigmaRoute(options, hoverNodeId, typeFiltersForCurrentRoute());
+    currentSigmaAdapterData = adapterDataForSigmaRoute(options, hoverNodeId, typeFiltersForCurrentRoute(), sigmaRouteViewportSize());
     syncHiddenReadingNodeHint();
     if (!renderer || destroyed) return;
     renderer.update({
       adapterData: currentSigmaAdapterData,
       theme: options.theme,
       edgeStyle: options.edgeStyle,
-      pins: options.pins
+      pins: options.pins,
+      viewportSize: sigmaRouteViewportSize()
     });
+  }
+
+  function sigmaRouteViewportSize(): RendererViewportSize | undefined {
+    return measuredViewportSize(shell) ?? measuredViewportSize(input.container);
   }
 
   function updateSigmaSelection(selection: SelectionInput | null): void {
@@ -274,7 +282,7 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
       case "edge":
         break;
       case "graph-blank":
-        const shouldResetCamera = options.selection?.kind === "community";
+        const shouldResetCamera = options.selection?.kind === "community" || options.sourceCommunityId != null;
         options = { ...options, temporaryObject: null, sourceCommunityId: null };
         input.options.callbacks.onSelectionClearRequested?.();
         updateSigmaSelection(null);
@@ -613,7 +621,8 @@ function typeFiltersForRouteControls(
 function adapterDataForSigmaRoute(
   options: GraphFacadeRouteRendererOptions,
   hoverNodeId: string | null = null,
-  typeFilters = options.typeFilters
+  typeFilters = options.typeFilters,
+  viewportSize?: RendererViewportSize
 ): GraphRendererAdapterData {
   return buildGraphRendererAdapterData(options.data, {
     theme: options.theme,
@@ -623,9 +632,18 @@ function adapterDataForSigmaRoute(
     aggregationMarkers: options.aggregationMarkers,
     focus: options.focus,
     typeFilters,
+    viewportSize,
     sourceCommunityId: options.sourceCommunityId,
     relationFocusNodeId: hoverNodeId
   });
+}
+
+function measuredViewportSize(element: HTMLElement): RendererViewportSize | undefined {
+  const rect = element.getBoundingClientRect();
+  const width = Math.floor(Number(rect.width));
+  const height = Math.floor(Number(rect.height));
+  if (width > 0 && height > 0) return { width, height };
+  return undefined;
 }
 
 function applyGraphThemeToElement(element: HTMLElement, theme: ThemeId): void {

--- a/packages/graph-engine/src/graph-routes/sigma-global-route.ts
+++ b/packages/graph-engine/src/graph-routes/sigma-global-route.ts
@@ -68,6 +68,7 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
   applyGraphThemeToElement(shell, options.theme);
   input.container.append(shell);
   ensureGraphRendererStyles(input.container.ownerDocument);
+  let observedViewportSize = measuredViewportSize(shell) ?? measuredViewportSize(input.container);
   let currentSigmaAdapterData = adapterDataForSigmaRoute(options, hoverNodeId, typeFiltersForCurrentRoute(), sigmaRouteViewportSize());
   const hiddenReadingNodeHint = input.container.ownerDocument.createElement("div");
   hiddenReadingNodeHint.className = "sigma-community-hidden-node-hint";
@@ -95,6 +96,7 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
           onDragActiveChange: input.options.callbacks.onDragActiveChange,
           onHitTarget: handleSigmaHitTarget,
           onNodeHover: handleSigmaNodeHover,
+          onViewportSizeChange: handleSigmaViewportSizeChange,
           onFatalError: (error) => input.onSigmaUnavailable?.(error)
         });
       } catch (error) {
@@ -228,7 +230,8 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
   };
 
   function updateSigmaRenderer(): void {
-    currentSigmaAdapterData = adapterDataForSigmaRoute(options, hoverNodeId, typeFiltersForCurrentRoute(), sigmaRouteViewportSize());
+    const viewportSize = sigmaRouteViewportSize();
+    currentSigmaAdapterData = adapterDataForSigmaRoute(options, hoverNodeId, typeFiltersForCurrentRoute(), viewportSize);
     syncHiddenReadingNodeHint();
     if (!renderer || destroyed) return;
     renderer.update({
@@ -236,12 +239,17 @@ export function createSigmaGlobalFacadeRenderer(input: GraphFacadeRouteRendererF
       theme: options.theme,
       edgeStyle: options.edgeStyle,
       pins: options.pins,
-      viewportSize: sigmaRouteViewportSize()
+      viewportSize
     });
   }
 
   function sigmaRouteViewportSize(): RendererViewportSize | undefined {
-    return measuredViewportSize(shell) ?? measuredViewportSize(input.container);
+    return observedViewportSize ?? measuredViewportSize(shell) ?? measuredViewportSize(input.container);
+  }
+
+  function handleSigmaViewportSizeChange(size: RendererViewportSize): void {
+    observedViewportSize = size;
+    updateSigmaRenderer();
   }
 
   function updateSigmaSelection(selection: SelectionInput | null): void {

--- a/packages/graph-engine/src/model/legacy-helpers.ts
+++ b/packages/graph-engine/src/model/legacy-helpers.ts
@@ -1102,10 +1102,45 @@
       });
       var center = centers[(communityIndex[communityId] || 0) % centers.length];
       var count = grouped[communityId].length;
+      var explicitNodes = grouped[communityId].filter(function (node) {
+        return node.x != null && node.y != null && Number.isFinite(Number(node.x)) && Number.isFinite(Number(node.y));
+      });
+      var rawBounds = explicitNodes.reduce(function (bounds, node) {
+        var x = Number(node.x);
+        var y = Number(node.y);
+        return {
+          minX: Math.min(bounds.minX, x),
+          minY: Math.min(bounds.minY, y),
+          maxX: Math.max(bounds.maxX, x),
+          maxY: Math.max(bounds.maxY, y)
+        };
+      }, { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity });
+      var rawWidth = Math.max(0, rawBounds.maxX - rawBounds.minX);
+      var rawHeight = Math.max(0, rawBounds.maxY - rawBounds.minY);
+      var shouldNormalizeExplicitShape = explicitNodes.length === grouped[communityId].length
+        && explicitNodes.length > 1
+        && (rawWidth > 0 || rawHeight > 0)
+        && explicitNodes.some(function (node) {
+          return Number(node.x) < 5 || Number(node.x) > 95 || Number(node.y) < 8 || Number(node.y) > 92;
+        });
+      var rawCenterX = (rawBounds.minX + rawBounds.maxX) / 2;
+      var rawCenterY = (rawBounds.minY + rawBounds.maxY) / 2;
+      var relativeScale = shouldNormalizeExplicitShape
+        ? Math.min(
+          1,
+          rawWidth > 0 ? 62 / rawWidth : 1,
+          rawHeight > 0 ? 54 / rawHeight : 1
+        )
+        : 1;
       grouped[communityId].forEach(function (node, index) {
         if (node.x != null && node.y != null && Number.isFinite(Number(node.x)) && Number.isFinite(Number(node.y))) {
-          node.x = clampAtlasNumber(node.x, center.x, 5, 95);
-          node.y = clampAtlasNumber(node.y, center.y, 8, 92);
+          if (shouldNormalizeExplicitShape) {
+            node.x = clampAtlasNumber(center.x + (Number(node.x) - rawCenterX) * relativeScale, center.x, 5, 95);
+            node.y = clampAtlasNumber(center.y + (Number(node.y) - rawCenterY) * relativeScale, center.y, 8, 92);
+          } else {
+            node.x = clampAtlasNumber(node.x, center.x, 5, 95);
+            node.y = clampAtlasNumber(node.y, center.y, 8, 92);
+          }
           return;
         }
         var ring = Math.floor(index / 8);

--- a/packages/graph-engine/src/render/adapter.ts
+++ b/packages/graph-engine/src/render/adapter.ts
@@ -24,6 +24,7 @@ import type {
   WikiPath
 } from "../types";
 import { buildRenderableGraph, type CommunityMapEdgeLayer, type CommunityMapLabelSide, type CommunityMapNodeTier, type RenderPosition, type RenderPositionMap, type RenderableGraph } from "./model";
+import type { RendererViewportSize } from "./viewport";
 import type { GraphRelationFocusDepth } from "./relation-focus";
 
 export const GRAPH_RENDERER_ADAPTER_ROUTES = ["dom-svg", "candidate-global", "aggregation-fallback"] as const;
@@ -39,6 +40,7 @@ export interface GraphRendererAdapterOptions {
   focus?: GraphFocusInput;
   typeFilters?: GraphTypeFilters;
   positions?: RenderPositionMap;
+  viewportSize?: RendererViewportSize;
   sourceCommunityId?: string | null;
   relationFocusNodeId?: NodeId | null;
 }
@@ -203,6 +205,7 @@ export function buildGraphRendererAdapterData(
     focus: options.focus,
     typeFilters: options.typeFilters,
     positions: options.positions,
+    viewportSize: options.viewportSize,
     searchResultIds: options.searchResultIds,
     sourceCommunityId: options.sourceCommunityId,
     relationFocusNodeId: options.relationFocusNodeId

--- a/packages/graph-engine/src/render/community-cloud-geometry.ts
+++ b/packages/graph-engine/src/render/community-cloud-geometry.ts
@@ -8,6 +8,14 @@ export interface SigmaCommunityCloud {
   localPoints: Array<{ x: number; y: number }> | null;
 }
 
+export interface SigmaCommunityCloudOptions {
+  minBoxWidth?: number;
+  minBoxHeight?: number;
+}
+
+export const SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH = 96;
+export const SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT = 72;
+
 export interface SigmaCommunityCloudBasis {
   hullPoints: Array<{ x: number; y: number }>;
   signature: string;
@@ -112,7 +120,8 @@ export function clampPointToWorldEllipse(
 
 export function sigmaCommunityCloud(
   screenHullPoints: GraphScreenPoint[],
-  fallbackBox: { left: number; top: number; width: number; height: number }
+  fallbackBox: { left: number; top: number; width: number; height: number },
+  options: SigmaCommunityCloudOptions = {}
 ): SigmaCommunityCloud {
   const hull = screenHullPoints;
   if (hull.length >= 3) {
@@ -132,10 +141,51 @@ export function sigmaCommunityCloud(
       maxX = Math.max(maxX, p.x);
       maxY = Math.max(maxY, p.y);
     }
-    const box = { left: minX, top: minY, width: Math.max(8, maxX - minX), height: Math.max(8, maxY - minY) };
+    const box = expandScreenBox({
+      left: minX,
+      top: minY,
+      width: Math.max(8, maxX - minX),
+      height: Math.max(8, maxY - minY)
+    }, options);
     return { box, localPoints: expanded.map((p) => ({ x: p.x - box.left, y: p.y - box.top })) };
   }
-  return { box: fallbackBox, localPoints: null };
+  if (hull.length > 0) {
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const p of hull) {
+      minX = Math.min(minX, p.x);
+      minY = Math.min(minY, p.y);
+      maxX = Math.max(maxX, p.x);
+      maxY = Math.max(maxY, p.y);
+    }
+    return {
+      box: expandScreenBox({
+        left: minX,
+        top: minY,
+        width: Math.max(8, maxX - minX),
+        height: Math.max(8, maxY - minY)
+      }, options),
+      localPoints: null
+    };
+  }
+  return { box: expandScreenBox(fallbackBox, options), localPoints: null };
+}
+
+export function expandScreenBox(
+  box: { left: number; top: number; width: number; height: number },
+  options: SigmaCommunityCloudOptions = {}
+): { left: number; top: number; width: number; height: number } {
+  const width = Math.max(box.width, finitePositiveNumber(options.minBoxWidth, box.width));
+  const height = Math.max(box.height, finitePositiveNumber(options.minBoxHeight, box.height));
+  if (width === box.width && height === box.height) return box;
+  return {
+    left: box.left + box.width / 2 - width / 2,
+    top: box.top + box.height / 2 - height / 2,
+    width,
+    height
+  };
 }
 
 export function clampPointToScreenEllipse(
@@ -175,4 +225,8 @@ export function convexHull2d(points: GraphScreenPoint[]): GraphScreenPoint[] {
   lower.pop();
   upper.pop();
   return lower.concat(upper);
+}
+
+function finitePositiveNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
 }

--- a/packages/graph-engine/src/render/model.ts
+++ b/packages/graph-engine/src/render/model.ts
@@ -451,7 +451,7 @@ export function buildRenderableGraph(data: GraphData, options: BuildRenderableGr
   const focusedCommunityNodeCount = focus?.kind === "community" ? model.nodes.filter((node) => node.community === focus.id).length : 0;
   const communityFocus = resolveCommunityFocusScale(focus, focusedCommunityNodeCount);
   const communityQuality = evaluateCommunityQuality(data);
-  const budgetLimits = resolveGraphRenderBudget(focus, focusedCommunityNodeCount);
+  const budgetLimits = resolveGraphRenderBudget(focus, focusedCommunityNodeCount, options.viewportSize);
   const budgetView: GraphRenderBudgetView = focus?.kind === "community" ? "community" : "global";
   const typeFilters = normalizeGraphTypeFilters(options.typeFilters, model.nodes);
   const visible = resolveAtlasVisibleSnapshot(model, layout, {
@@ -1056,9 +1056,17 @@ function aggregationContainerRadius(nodeCount: number): number {
   return round(Math.max(34, Math.min(88, 28 + Math.sqrt(Math.max(1, nodeCount)) * 7)));
 }
 
-export function resolveGraphRenderBudget(focus: GraphFocusInput, focusedCommunityNodeCount = 0): GraphRenderBudgetLimits {
+export function resolveGraphRenderBudget(
+  focus: GraphFocusInput,
+  focusedCommunityNodeCount = 0,
+  viewportSize?: { width: number; height: number }
+): GraphRenderBudgetLimits {
   if (focus?.kind !== "community") return { ...GRAPH_RENDER_BUDGETS.global };
-  return { ...GRAPH_COMMUNITY_FOCUS_BUDGETS[communityFocusSizeBand(focusedCommunityNodeCount)] };
+  const budget = { ...GRAPH_COMMUNITY_FOCUS_BUDGETS[communityFocusSizeBand(focusedCommunityNodeCount)] };
+  if (!viewportSize || viewportSize.width <= 0 || viewportSize.height <= 0) return budget;
+  if (viewportSize.width <= 430) return { ...budget, maxLabels: Math.min(budget.maxLabels, 2) };
+  if (viewportSize.width <= 640) return { ...budget, maxLabels: Math.min(budget.maxLabels, 4) };
+  return budget;
 }
 
 export function resolveCommunityFocusScale(focus: GraphFocusInput, focusedCommunityNodeCount: number): GraphCommunityFocusScale | null {

--- a/packages/graph-engine/src/render/sigma-global-camera.ts
+++ b/packages/graph-engine/src/render/sigma-global-camera.ts
@@ -1,4 +1,5 @@
 import type { GraphRendererAdapterData } from "./adapter";
+import type { RendererViewportSize } from "./viewport";
 import type {
   SigmaGlobalCameraState,
   SigmaGlobalSigmaLike
@@ -47,6 +48,7 @@ export function maybeAnimateSigmaCommunitySpotlightCamera(
   adapterData: GraphRendererAdapterData,
   communityId: string | null,
   previousCommunityId: string | null,
+  viewportSize?: RendererViewportSize,
   onAnimationError?: (error: unknown) => void
 ): SigmaCommunitySpotlightCameraResult {
   if (!communityId) {
@@ -55,7 +57,7 @@ export function maybeAnimateSigmaCommunitySpotlightCamera(
   if (communityId === previousCommunityId) {
     return { communityId, movement: "skipped", skipReason: "already-settled" };
   }
-  const target = sigmaCommunitySpotlightCameraState(sigma, adapterData, communityId);
+  const target = sigmaCommunitySpotlightCameraState(sigma, adapterData, communityId, viewportSize);
   if (!target) {
     return { communityId, movement: "skipped", skipReason: "no-target" };
   }
@@ -96,14 +98,16 @@ export function moveSigmaCamera(
 export function sigmaCommunitySpotlightCameraState(
   sigma: SigmaGlobalSigmaLike,
   adapterData: GraphRendererAdapterData,
-  communityId: string
+  communityId: string,
+  viewportSize?: RendererViewportSize
 ): Partial<SigmaGlobalCameraState> | null {
   const current = readCameraState(sigma) ?? { x: 0, y: 0, angle: 0, ratio: 1 };
   const center = sigmaCommunitySpotlightCenter(adapterData, communityId);
   if (!center) return null;
+  const communityReading = adapterData.renderable.communityMap?.active === true;
   const bounds = adapterData.renderable.worldBounds;
   const worldWidth = Math.max(0, finiteNumber(bounds.maxX, center.x) - finiteNumber(bounds.minX, center.x));
-  const drawerOffset = worldWidth * 0.08;
+  const drawerOffset = communityReading ? 0 : worldWidth * 0.08;
   const graphTargetPoint = { x: center.x + drawerOffset, y: center.y };
   const targetPoint = sigmaGraphPointToCameraPoint(sigma, graphTargetPoint);
   const targetX = roundNumber(targetPoint.x, 3);
@@ -115,13 +119,72 @@ export function sigmaCommunitySpotlightCameraState(
     x: targetX,
     y: targetY,
     angle: current.angle,
-    ratio: positionSettled || current.ratio <= 0.9
+    ratio: communityReading
+      ? roundNumber(sigmaCommunityReadingCameraRatio(
+          sigma,
+          adapterData,
+          communityId,
+          { x: targetX, y: targetY, angle: current.angle, ratio: Math.max(current.ratio, 1) },
+          viewportSize
+        ), 3)
+      : positionSettled || current.ratio <= 0.9
       ? current.ratio
       : roundNumber(clamp(current.ratio * 0.92, 0.72, current.ratio), 3)
   };
   const settled = positionSettled
     && Math.abs(current.ratio - target.ratio) <= 0.025;
   return settled ? null : target;
+}
+
+function sigmaCommunityReadingCameraRatio(
+  sigma: SigmaGlobalSigmaLike,
+  adapterData: GraphRendererAdapterData,
+  communityId: string,
+  baseState: SigmaGlobalCameraState,
+  viewportSize?: RendererViewportSize
+): number {
+  const baseRatio = Math.max(baseState.ratio, 1);
+  const size = viewportSize && viewportSize.width > 0 && viewportSize.height > 0 ? viewportSize : null;
+  if (!size || !sigma.graphToViewport) return baseRatio;
+  const points: Array<{ x: number; y: number }> = [];
+  for (const node of adapterData.nodes) {
+    if (node.communityId !== communityId) continue;
+    const point = sigma.graphToViewport(node.point, { cameraState: baseState });
+    if (Number.isFinite(point.x) && Number.isFinite(point.y)) points.push(point);
+  }
+  if (points.length < 2) return baseRatio;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const point of points) {
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+  }
+  const projectedWidth = Math.max(0, maxX - minX);
+  const projectedHeight = Math.max(0, maxY - minY);
+  const maxReadableWidth = size.width * 0.72;
+  const maxReadableHeight = size.height * 0.68;
+  const minReadableWidth = Math.min(maxReadableWidth, Math.max(180, size.width * 0.28));
+  const minReadableHeight = Math.min(maxReadableHeight, Math.max(140, size.height * 0.22));
+  const minRatio = 0.3;
+  const maxRatio = 3;
+  const lowerBound = Math.max(
+    minRatio,
+    maxReadableWidth > 0 ? baseRatio * projectedWidth / maxReadableWidth : minRatio,
+    maxReadableHeight > 0 ? baseRatio * projectedHeight / maxReadableHeight : minRatio
+  );
+  let upperBound = maxRatio;
+  if (projectedWidth > 0 && projectedWidth < minReadableWidth) {
+    upperBound = Math.min(upperBound, baseRatio * projectedWidth / minReadableWidth);
+  }
+  if (projectedHeight > 0 && projectedHeight < minReadableHeight) {
+    upperBound = Math.min(upperBound, baseRatio * projectedHeight / minReadableHeight);
+  }
+  if (upperBound < lowerBound) return roundNumber(lowerBound, 3);
+  return clamp(baseRatio, roundNumber(lowerBound, 3), roundNumber(upperBound, 3));
 }
 
 export function sigmaGlobalCameraState(
@@ -172,6 +235,11 @@ export function sigmaCommunitySpotlightCenter(
   adapterData: GraphRendererAdapterData,
   communityId: string
 ): { x: number; y: number } | null {
+  const communityReadingCenter = adapterData.renderable.communityMap?.active
+    ? sigmaCommunityNodeCenter(adapterData, communityId)
+    : null;
+  if (communityReadingCenter) return communityReadingCenter;
+
   const renderableCommunity = adapterData.renderable.communities.find((community) => community.id === communityId);
   if (renderableCommunity?.wash) {
     return {
@@ -179,6 +247,13 @@ export function sigmaCommunitySpotlightCenter(
       y: finiteNumber(renderableCommunity.wash.cy, 0)
     };
   }
+  return sigmaCommunityNodeCenter(adapterData, communityId);
+}
+
+function sigmaCommunityNodeCenter(
+  adapterData: GraphRendererAdapterData,
+  communityId: string
+): { x: number; y: number } | null {
   const nodes = adapterData.nodes.filter((node) => node.communityId === communityId);
   if (nodes.length === 0) return null;
   const sum = nodes.reduce((acc, node) => ({

--- a/packages/graph-engine/src/render/sigma-global-camera.ts
+++ b/packages/graph-engine/src/render/sigma-global-camera.ts
@@ -1,5 +1,6 @@
 import type { GraphRendererAdapterData } from "./adapter";
 import type { RendererViewportSize } from "./viewport";
+import { SIGMA_CAMERA_MAX_RATIO } from "./sigma-zoom";
 import type {
   SigmaGlobalCameraState,
   SigmaGlobalSigmaLike
@@ -144,7 +145,7 @@ function sigmaCommunityReadingCameraRatio(
   viewportSize?: RendererViewportSize
 ): number {
   const baseRatio = Math.max(baseState.ratio, 1);
-  const size = viewportSize && viewportSize.width > 0 && viewportSize.height > 0 ? viewportSize : null;
+  const size = viewportSize && viewportSize.width >= 32 && viewportSize.height >= 32 ? viewportSize : null;
   if (!size || !sigma.graphToViewport) return baseRatio;
   const points: Array<{ x: number; y: number }> = [];
   for (const node of adapterData.nodes) {
@@ -189,18 +190,137 @@ function sigmaCommunityReadingCameraRatio(
 
 export function sigmaGlobalCameraState(
   sigma: SigmaGlobalSigmaLike,
-  adapterData: GraphRendererAdapterData
+  adapterData: GraphRendererAdapterData,
+  viewportSize?: RendererViewportSize
 ): Partial<SigmaGlobalCameraState> {
-  const bounds = adapterData.renderable.worldBounds;
-  const center = sigmaGraphPointToCameraPoint(sigma, {
-    x: (finiteNumber(bounds.minX, 0) + finiteNumber(bounds.maxX, 0)) / 2,
-    y: (finiteNumber(bounds.minY, 0) + finiteNumber(bounds.maxY, 0)) / 2
-  });
-  return {
+  const graphCenter = sigmaGraphExtentCenterPoint(adapterData);
+  const center = sigma.graphToViewport
+    ? sigmaGraphPointToNormalizedCameraPoint(adapterData, graphCenter)
+    : sigmaGraphPointToCameraPoint(sigma, graphCenter);
+  const baseState = {
     x: roundNumber(center.x, 3),
     y: roundNumber(center.y, 3),
     angle: 0,
     ratio: 1
+  };
+  return {
+    ...baseState,
+    ratio: roundNumber(sigmaGlobalCameraRatio(sigma, adapterData, baseState, viewportSize), 3)
+  };
+}
+
+function sigmaGraphExtentCenterPoint(adapterData: GraphRendererAdapterData): { x: number; y: number } {
+  const points = adapterData.nodes.length > 0
+    ? adapterData.nodes.map((node) => node.point)
+    : sigmaWorldBoundsCornerPoints(adapterData);
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const point of points) {
+    const x = finiteNumber(point.x, 0);
+    const y = finiteNumber(point.y, 0);
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+    const bounds = adapterData.renderable.worldBounds;
+    return {
+      x: (finiteNumber(bounds.minX, 0) + finiteNumber(bounds.maxX, 0)) / 2,
+      y: (finiteNumber(bounds.minY, 0) + finiteNumber(bounds.maxY, 0)) / 2
+    };
+  }
+  return {
+    x: (minX + maxX) / 2,
+    y: (minY + maxY) / 2
+  };
+}
+
+function sigmaGlobalCameraRatio(
+  sigma: SigmaGlobalSigmaLike,
+  adapterData: GraphRendererAdapterData,
+  baseState: SigmaGlobalCameraState,
+  viewportSize?: RendererViewportSize
+): number {
+  const size = viewportSize && viewportSize.width > 0 && viewportSize.height > 0 ? viewportSize : null;
+  if (!size || !sigma.graphToViewport) return baseState.ratio;
+  const points = adapterData.nodes.length > 0
+    ? adapterData.nodes.map((node) => node.point)
+    : sigmaWorldBoundsCornerPoints(adapterData);
+  const projected = points
+    .map((point) => sigma.graphToViewport?.(point, { cameraState: baseState }))
+    .filter((point): point is { x: number; y: number } => Boolean(point && Number.isFinite(point.x) && Number.isFinite(point.y)));
+  if (projected.length < 2) return baseState.ratio;
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const point of projected) {
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+  }
+  const projectedWidth = Math.max(0, maxX - minX);
+  const projectedHeight = Math.max(0, maxY - minY);
+  const usableWidth = Math.max(1, size.width * 0.78);
+  const usableHeight = Math.max(1, size.height * 0.76);
+  return clamp(
+    Math.max(
+      baseState.ratio,
+      projectedWidth / usableWidth,
+      projectedHeight / usableHeight
+    ),
+    baseState.ratio,
+    SIGMA_CAMERA_MAX_RATIO
+  );
+}
+
+function sigmaWorldBoundsCornerPoints(adapterData: GraphRendererAdapterData): Array<{ x: number; y: number }> {
+  const bounds = adapterData.renderable.worldBounds;
+  const minX = finiteNumber(bounds.minX, 0);
+  const maxX = finiteNumber(bounds.maxX, minX);
+  const minY = finiteNumber(bounds.minY, 0);
+  const maxY = finiteNumber(bounds.maxY, minY);
+  return [
+    { x: minX, y: minY },
+    { x: maxX, y: minY },
+    { x: maxX, y: maxY },
+    { x: minX, y: maxY }
+  ];
+}
+
+function sigmaGraphPointToNormalizedCameraPoint(
+  adapterData: GraphRendererAdapterData,
+  point: { x: number; y: number }
+): { x: number; y: number } {
+  const points = adapterData.nodes.length > 0
+    ? adapterData.nodes.map((node) => node.point)
+    : sigmaWorldBoundsCornerPoints(adapterData);
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const item of points) {
+    const x = finiteNumber(item.x, 0);
+    const y = finiteNumber(item.y, 0);
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+    return point;
+  }
+  const ratio = Math.max(maxX - minX, maxY - minY, 1);
+  const centerX = (maxX + minX) / 2;
+  const centerY = (maxY + minY) / 2;
+  return {
+    x: 0.5 + (finiteNumber(point.x, centerX) - centerX) / ratio,
+    y: 0.5 + (finiteNumber(point.y, centerY) - centerY) / ratio
   };
 }
 

--- a/packages/graph-engine/src/render/sigma-global-renderer.ts
+++ b/packages/graph-engine/src/render/sigma-global-renderer.ts
@@ -8,6 +8,7 @@ import {
 } from "./sigma-global-drag";
 import type { GraphScreenPoint } from "./geometry";
 import type { GraphGestureTarget } from "./gestures";
+import type { GraphRendererAdapterData } from "./adapter";
 import { DEFAULT_RENDERER_VIEWPORT, type RendererViewport, type RendererViewportSize } from "./viewport";
 import { overlayPointerScreenPoint, sigmaScreenPointToWorldPoint, sigmaWorldPointToScreenPoint } from "./sigma-coordinates";
 import {
@@ -94,6 +95,12 @@ export const SIGMA_GLOBAL_RENDERER_ID = "sigma-global" as const;
 export const SIGMA_GLOBAL_RENDERER_ROUTE_MANAGER_OWNER = "facade" as const;
 const SIGMA_CAMERA_MINIMUM_FAST_PATH_FRAMES = 1;
 const SIGMA_NODE_LABEL_EDGE_GUTTER = 8;
+const SIGMA_ROOT_CLICK_FALLBACK_IGNORE_SELECTORS = [
+  ".sigma-global-node-hit-target",
+  ".sigma-global-community-region",
+  ".sigma-global-aggregation-container",
+  "[data-control=\"sigma-zoom\"]"
+] as const;
 
 interface SigmaNodeLabelData {
   x: number;
@@ -178,6 +185,9 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
   let sigmaWheelZoomController: SigmaWheelZoomController | null = null;
   let eventBindings: Array<{ event: string; listener: (payload?: unknown) => void }> = [];
   let cameraEventBindings: Array<{ event: "updated"; listener: (state?: SigmaGlobalCameraState) => void }> = [];
+  let sigmaRootClickFallbackListener: ((event: MouseEvent) => void) | null = null;
+  let suppressSigmaRootClickFallback = false;
+  let suppressSigmaRootClickFallbackToken = 0;
   let resizeObserver: ResizeObserver | null = null;
   let resizeAnimationFrame: number | null = null;
   let lastObservedRootSize: RendererViewportSize | null = null;
@@ -221,6 +231,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       onFatalError: options.onFatalError
     });
     bindSigmaEvents();
+    bindSigmaRootClickFallback();
     bindSigmaResizeObserver();
     overlayDomController.rebuild();
   } catch (error) {
@@ -246,7 +257,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     resetView() {
       assertActive();
       cameraSpotlightKey = null;
-      sigma.getCamera?.().setState?.(sigmaGlobalCameraState(sigma, adapterData));
+      sigma.getCamera?.().setState?.(sigmaGlobalCameraState(sigma, adapterData, currentViewportSize));
       suppressOverlayAnimationFastPathUntilSettled();
     },
     zoomIn() {
@@ -261,6 +272,8 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       assertActive();
       const cameraState = readCameraState(sigma);
       const previousCameraSpotlightKey = cameraSpotlightKey;
+      let spotlightCameraPreviousKey = previousCameraSpotlightKey;
+      const previousViewportSize = currentViewportSize;
       cancelNodeDrag();
       generation += 1;
       const finalizeUpdate = (): void => {
@@ -268,7 +281,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
           restoreCameraState(sigma, cameraState);
           sigma.refresh?.();
           overlayDomController?.rebuild();
-          scheduleSpotlightCameraUpdate(previousCameraSpotlightKey, generation);
+          scheduleSpotlightCameraUpdate(spotlightCameraPreviousKey, generation);
         } catch (error) {
           options.onFatalError?.(error);
         }
@@ -278,6 +291,9 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       const nextEdgeStyle = updateOptions.edgeStyle ?? currentEdgeStyle;
       const nextPins = { ...(updateOptions.pins ?? currentPins) };
       if (updateOptions.viewportSize) currentViewportSize = updateOptions.viewportSize;
+      if (shouldRefitSpotlightCameraAfterViewportChange(previousViewportSize, currentViewportSize, nextAdapterData)) {
+        spotlightCameraPreviousKey = null;
+      }
       if (canPatchSigmaGlobalGraphAttributes(adapterData, nextAdapterData, currentTheme, nextTheme)) {
         adapterData = nextAdapterData;
         currentEdgeStyle = nextEdgeStyle;
@@ -328,6 +344,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       overlayDomController?.destroy();
       overlayDomController = null;
       unbindSigmaEvents();
+      unbindSigmaRootClickFallback();
       cancelScheduledResizeRefresh();
       cancelOverlayAnimationSettleCheck();
       cancelDeferredSpotlightCameraUpdate();
@@ -354,14 +371,18 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
 
   function bindSigmaEvents(): void {
     const nodeClick = (payload?: unknown): void => {
+      if (shouldSuppressRootClickFallbackForSigmaNodeClick()) suppressRootClickFallbackForSigmaPointerEvent();
       const nodeId = sigmaNodeIdFromPayload(payload);
       if (consumeSuppressedNodeClick(nodeId)) return;
       handleSigmaHit({ nodeId, additive: sigmaAdditiveFromPayload(payload) });
     };
-    const stageClick = (payload?: unknown): void => handleSigmaHit({
-      screenPoint: sigmaScreenPointFromPayload(payload),
-      additive: sigmaAdditiveFromPayload(payload)
-    });
+    const stageClick = (payload?: unknown): void => {
+      suppressRootClickFallbackForSigmaPointerEvent();
+      handleSigmaHit({
+        screenPoint: sigmaScreenPointFromPayload(payload),
+        additive: sigmaAdditiveFromPayload(payload)
+      });
+    };
     const requestCameraFrame = (): void => requestOverlayAnimationFrame(overlayAnimationFrameOwner);
     const nodeDown = (payload?: unknown): void => beginNodeDrag(sigmaNodeIdFromPayload(payload), sigmaScreenPointFromPayload(payload), payload);
     const nodeMove = (payload?: unknown): void => moveNodeDrag(sigmaScreenPointFromPayload(payload), payload);
@@ -388,6 +409,54 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       camera.on("updated", listener);
       cameraEventBindings = [{ event: "updated", listener }];
     }
+  }
+
+  function bindSigmaRootClickFallback(): void {
+    const listener = (event: MouseEvent): void => {
+      if (destroyed || suppressSigmaRootClickFallback || event.defaultPrevented) return;
+      if (typeof event.button === "number" && event.button !== 0) return;
+      if (sigmaRootClickTargetIsExplicitControl(event.target)) return;
+      const screenPoint = overlayPointerScreenPoint(event, sigmaRoot);
+      const additive = event.shiftKey;
+      queueMicrotask(() => {
+        if (destroyed || suppressSigmaRootClickFallback) return;
+        handleSigmaHit({ screenPoint, additive });
+      });
+    };
+    sigmaRootClickFallbackListener = listener;
+    sigmaRoot.addEventListener("click", listener, true);
+  }
+
+  function unbindSigmaRootClickFallback(): void {
+    if (!sigmaRootClickFallbackListener) return;
+    sigmaRoot.removeEventListener?.("click", sigmaRootClickFallbackListener, true);
+    sigmaRootClickFallbackListener = null;
+  }
+
+  function suppressRootClickFallbackForSigmaPointerEvent(): void {
+    const token = suppressSigmaRootClickFallbackToken + 1;
+    suppressSigmaRootClickFallbackToken = token;
+    suppressSigmaRootClickFallback = true;
+    setTimeout(() => {
+      if (suppressSigmaRootClickFallbackToken !== token) return;
+      suppressSigmaRootClickFallback = false;
+    }, 0);
+  }
+
+  function shouldSuppressRootClickFallbackForSigmaNodeClick(): boolean {
+    return adapterData.renderable.communityMap?.active === true || !adapterData.sourceCommunityId;
+  }
+
+  function sigmaRootClickTargetIsExplicitControl(target: EventTarget | null): boolean {
+    return SIGMA_ROOT_CLICK_FALLBACK_IGNORE_SELECTORS.some((selector) => Boolean(closestSigmaRootClickTarget(target, selector)));
+  }
+
+  function closestSigmaRootClickTarget(target: EventTarget | null, selector: string): unknown {
+    const candidate = target as {
+      closest?: (query: string) => unknown;
+      parentElement?: { closest?: (query: string) => unknown } | null;
+    } | null;
+    return candidate?.closest?.(selector) ?? candidate?.parentElement?.closest?.(selector) ?? null;
   }
 
   function unbindSigmaEvents(): void {
@@ -521,7 +590,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       deferredSpotlightCameraFrame = null;
       if (destroyed || updateGeneration !== generation) return;
       try {
-        const currentCommunityId = sigmaSpotlightCommunityId(adapterData);
+        const currentCommunityId = sigmaSpotlightCameraCommunityId(adapterData);
         const currentSpotlightKey = sigmaSpotlightCameraKey(adapterData);
         const spotlightCamera = maybeAnimateSigmaCommunitySpotlightCamera(
           sigma,
@@ -595,6 +664,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       if (nextSize) {
         lastObservedRootSize = nextSize;
         currentViewportSize = nextSize;
+        options.onViewportSizeChange?.(nextSize);
       }
       scheduleResizeRefresh();
     });
@@ -657,6 +727,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     const target = projector.targetFromSigmaHit(input);
     if (destroyed || eventGeneration !== generation) return;
     lastHitTarget = target;
+    syncSigmaRootLastHitMetadata(target);
     options.onHitTarget?.(target, { additive: Boolean(input.additive) });
   }
 
@@ -831,12 +902,30 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     sigmaRoot.dataset.communityMapVisibleLabels = String(communityMap?.current?.labelBudget.visible ?? 0);
   }
 
+  function syncSigmaRootLastHitMetadata(target: GraphGestureTarget): void {
+    sigmaRoot.dataset.lastHitKind = target.kind;
+    sigmaRoot.dataset.lastHitId = "id" in target && typeof target.id === "string" ? target.id : "";
+  }
+
 }
 
-function sigmaSpotlightCameraKey(adapterData: Parameters<typeof sigmaSpotlightCommunityId>[0]): string | null {
-  const communityId = sigmaSpotlightCommunityId(adapterData);
+function sigmaSpotlightCameraCommunityId(adapterData: GraphRendererAdapterData): string | null {
+  if (adapterData.renderable.communityMap?.active) return sigmaSpotlightCommunityId(adapterData);
+  return adapterData.selection.input?.kind === "community" ? adapterData.selection.input.id : null;
+}
+
+function sigmaSpotlightCameraKey(adapterData: GraphRendererAdapterData): string | null {
+  const communityId = sigmaSpotlightCameraCommunityId(adapterData);
   if (!communityId) return null;
   return `${adapterData.renderable.communityMap?.active ? "reading" : "global"}:${communityId}`;
+}
+
+function shouldRefitSpotlightCameraAfterViewportChange(
+  previousSize: RendererViewportSize,
+  nextSize: RendererViewportSize,
+  adapterData: GraphRendererAdapterData
+): boolean {
+  return adapterData.renderable.communityMap?.active === true && !sameRendererViewportSize(previousSize, nextSize);
 }
 
 function createSigmaRoot(container: HTMLElement, theme: ThemeId): HTMLElement {

--- a/packages/graph-engine/src/render/sigma-global-renderer.ts
+++ b/packages/graph-engine/src/render/sigma-global-renderer.ts
@@ -11,6 +11,8 @@ import type { GraphGestureTarget } from "./gestures";
 import { DEFAULT_RENDERER_VIEWPORT, type RendererViewport, type RendererViewportSize } from "./viewport";
 import { overlayPointerScreenPoint, sigmaScreenPointToWorldPoint, sigmaWorldPointToScreenPoint } from "./sigma-coordinates";
 import {
+  SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT,
+  SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH,
   sigmaCommunityCloud,
   sigmaCommunityCloudBasisById,
   sigmaCommunityCloudBasisByIdWithNodePoint,
@@ -91,6 +93,26 @@ export const SIGMA_GLOBAL_RENDERER_ID = "sigma-global" as const;
 
 export const SIGMA_GLOBAL_RENDERER_ROUTE_MANAGER_OWNER = "facade" as const;
 const SIGMA_CAMERA_MINIMUM_FAST_PATH_FRAMES = 1;
+const SIGMA_NODE_LABEL_EDGE_GUTTER = 8;
+
+interface SigmaNodeLabelData {
+  x: number;
+  y: number;
+  size: number;
+  label?: string | null;
+  color?: string;
+  [key: string]: unknown;
+}
+
+interface SigmaNodeLabelSettings {
+  labelSize: number;
+  labelFont: string;
+  labelWeight: string;
+  labelColor: {
+    attribute?: string;
+    color?: string;
+  };
+}
 
 export const SIGMA_GLOBAL_RENDERER_BUNDLE_BOUNDARY = {
   sigma: "runtime-loaded-by-sigma-global-renderer",
@@ -138,18 +160,19 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
   filterHost.append(sigmaSharedCloudFilterDef(sigmaRoot.ownerDocument, cloudFilterId));
   sigmaRoot.append(filterHost);
   let cloudBasisByCommunityId = sigmaCommunityCloudBasisById(adapterData);
+  let currentViewportSize: RendererViewportSize = options.viewportSize ?? { width: 1, height: 1 };
   let projector = createSigmaGlobalHitProjector({
     adapterData,
     viewport: options.viewport ?? DEFAULT_RENDERER_VIEWPORT,
-    viewportSize: options.viewportSize ?? { width: 1, height: 1 },
-    screenPointToWorldPoint: (point) => sigmaScreenPointToWorldPoint(sigma, point, options)
+    viewportSize: currentViewportSize,
+    screenPointToWorldPoint: (point) => sigmaScreenPointToWorldPoint(sigma, point, rendererCoordinateOptions())
   });
   let sigma: SigmaGlobalSigmaLike;
   let generation = 0;
   let lastHitTarget: GraphGestureTarget | null = null;
   let activeNodeDrag: SigmaGlobalNodeDragSession | null = null;
   let currentPins: PinMap = { ...(options.pins ?? {}) };
-  let cameraSpotlightCommunityId: string | null = sigmaSpotlightCommunityId(adapterData);
+  let cameraSpotlightKey: string | null = sigmaSpotlightCameraKey(adapterData);
   let suppressNextNodeClickId: string | null = null;
   let overlayDomController: SigmaOverlayDomController | null = null;
   let sigmaWheelZoomController: SigmaWheelZoomController | null = null;
@@ -176,7 +199,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       cloudFilterId,
       getAdapterData: () => adapterData,
       getSigma: () => sigma,
-      getOptions: () => ({ ...options, adapterData }),
+      getOptions: () => rendererCoordinateOptions(),
       communityCloudFor: sigmaCommunityCloudFor,
       isDestroyed: () => destroyed,
       onHit: (renderedObject) => handleSigmaHit({ renderedObject }),
@@ -222,7 +245,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     },
     resetView() {
       assertActive();
-      cameraSpotlightCommunityId = null;
+      cameraSpotlightKey = null;
       sigma.getCamera?.().setState?.(sigmaGlobalCameraState(sigma, adapterData));
       suppressOverlayAnimationFastPathUntilSettled();
     },
@@ -237,7 +260,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     update(updateOptions) {
       assertActive();
       const cameraState = readCameraState(sigma);
-      const previousCameraSpotlightCommunityId = cameraSpotlightCommunityId;
+      const previousCameraSpotlightKey = cameraSpotlightKey;
       cancelNodeDrag();
       generation += 1;
       const finalizeUpdate = (): void => {
@@ -245,7 +268,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
           restoreCameraState(sigma, cameraState);
           sigma.refresh?.();
           overlayDomController?.rebuild();
-          scheduleSpotlightCameraUpdate(previousCameraSpotlightCommunityId, generation);
+          scheduleSpotlightCameraUpdate(previousCameraSpotlightKey, generation);
         } catch (error) {
           options.onFatalError?.(error);
         }
@@ -254,6 +277,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       const nextTheme = updateOptions.theme ?? currentTheme;
       const nextEdgeStyle = updateOptions.edgeStyle ?? currentEdgeStyle;
       const nextPins = { ...(updateOptions.pins ?? currentPins) };
+      if (updateOptions.viewportSize) currentViewportSize = updateOptions.viewportSize;
       if (canPatchSigmaGlobalGraphAttributes(adapterData, nextAdapterData, currentTheme, nextTheme)) {
         adapterData = nextAdapterData;
         currentEdgeStyle = nextEdgeStyle;
@@ -264,8 +288,8 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
         projector = createSigmaGlobalHitProjector({
           adapterData,
           viewport: options.viewport ?? DEFAULT_RENDERER_VIEWPORT,
-          viewportSize: options.viewportSize ?? { width: 1, height: 1 },
-          screenPointToWorldPoint: (point) => sigmaScreenPointToWorldPoint(sigma, point, options)
+          viewportSize: currentViewportSize,
+          screenPointToWorldPoint: (point) => sigmaScreenPointToWorldPoint(sigma, point, rendererCoordinateOptions())
         });
         finalizeUpdate();
         return;
@@ -280,8 +304,8 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       projector = createSigmaGlobalHitProjector({
         adapterData,
         viewport: options.viewport ?? DEFAULT_RENDERER_VIEWPORT,
-        viewportSize: options.viewportSize ?? { width: 1, height: 1 },
-        screenPointToWorldPoint: (point) => sigmaScreenPointToWorldPoint(sigma, point, options)
+        viewportSize: currentViewportSize,
+        screenPointToWorldPoint: (point) => sigmaScreenPointToWorldPoint(sigma, point, rendererCoordinateOptions())
       });
       try {
         sigma.setGraph?.(graph);
@@ -319,6 +343,14 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
   };
 
   return renderer;
+
+  function rendererCoordinateOptions(): Pick<SigmaGlobalRendererCreateOptions, "viewport" | "viewportSize" | "adapterData"> {
+    return {
+      ...options,
+      adapterData,
+      viewportSize: currentViewportSize
+    };
+  }
 
   function bindSigmaEvents(): void {
     const nodeClick = (payload?: unknown): void => {
@@ -471,7 +503,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
   }
 
   function applySpotlightCameraResult(result: SigmaCommunitySpotlightCameraResult): void {
-    cameraSpotlightCommunityId = result.communityId;
+    cameraSpotlightKey = result.communityId ? sigmaSpotlightCameraKey(adapterData) : null;
     if (result.movement === "animated") {
       startProjectCameraFrameTracking(
         SIGMA_COMMUNITY_SPOTLIGHT_CAMERA_ANIMATION_MS,
@@ -484,17 +516,20 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     }
   }
 
-  function scheduleSpotlightCameraUpdate(previousCommunityId: string | null, updateGeneration: number): void {
+  function scheduleSpotlightCameraUpdate(previousSpotlightKey: string | null, updateGeneration: number): void {
     const run = (): void => {
       deferredSpotlightCameraFrame = null;
       if (destroyed || updateGeneration !== generation) return;
       try {
+        const currentCommunityId = sigmaSpotlightCommunityId(adapterData);
+        const currentSpotlightKey = sigmaSpotlightCameraKey(adapterData);
         const spotlightCamera = maybeAnimateSigmaCommunitySpotlightCamera(
           sigma,
           sigmaRoot,
           adapterData,
-          sigmaSpotlightCommunityId(adapterData),
-          previousCommunityId,
+          currentCommunityId,
+          previousSpotlightKey === currentSpotlightKey ? currentCommunityId : null,
+          currentViewportSize,
           options.onFatalError
         );
         applySpotlightCameraResult(spotlightCamera);
@@ -557,7 +592,10 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       if (destroyed) return;
       const nextSize = readResizeEntrySize(entries) ?? readObservedRootSize();
       if (nextSize && lastObservedRootSize && sameRendererViewportSize(nextSize, lastObservedRootSize)) return;
-      if (nextSize) lastObservedRootSize = nextSize;
+      if (nextSize) {
+        lastObservedRootSize = nextSize;
+        currentViewportSize = nextSize;
+      }
       scheduleResizeRefresh();
     });
     resizeObserver.observe(sigmaRoot);
@@ -571,6 +609,12 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
       try {
         if (destroyed) return;
         suppressOverlayAnimationFastPathUntilSettled();
+        projector = createSigmaGlobalHitProjector({
+          adapterData,
+          viewport: options.viewport ?? DEFAULT_RENDERER_VIEWPORT,
+          viewportSize: currentViewportSize,
+          screenPointToWorldPoint: (point) => sigmaScreenPointToWorldPoint(sigma, point, rendererCoordinateOptions())
+        });
         sigma.refresh?.();
         overlayDomController?.reposition();
       } catch (error) {
@@ -628,7 +672,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     handleNodeHover(null);
     suppressOverlayAnimationFastPathUntilSettled();
     const startPoint = sigmaNodeWorldPoint(nodeId);
-    const pointerWorldPoint = sigmaScreenPointToWorldPoint(sigma, screenPoint, options);
+    const pointerWorldPoint = sigmaScreenPointToWorldPoint(sigma, screenPoint, rendererCoordinateOptions());
     activeNodeDrag = createSigmaGlobalNodeDragSession({
       nodeId,
       pinKey: sigmaPinKeyForNode(nodeId),
@@ -648,7 +692,7 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     const drag = activeNodeDrag;
     if (!drag || destroyed || !screenPoint) return;
     preventSigmaDefault(payload);
-    const pointerWorldPoint = sigmaScreenPointToWorldPoint(sigma, screenPoint, options);
+    const pointerWorldPoint = sigmaScreenPointToWorldPoint(sigma, screenPoint, rendererCoordinateOptions());
     moveSigmaGlobalNodeDragSession(drag, screenPoint, pointerWorldPoint);
     if (drag.moved) {
       applyNodeDragPoint(drag.nodeId, drag.currentPoint, drag.initiallyPinned, drag.initialPinPosition);
@@ -743,14 +787,20 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
   function sigmaCommunityCloudFor(communityId: string, wash: { cx: number; cy: number; rx: number; ry: number }): SigmaCommunityCloud {
     const fallbackBox = overlayBoxFromWorldEllipse(wash.cx, wash.cy, wash.rx, wash.ry);
     return sigmaCommunityCloud(
-      sigmaProjectedCloudHullPoints(cloudBasisByCommunityId.get(communityId), sigma, options),
-      fallbackBox
+      sigmaProjectedCloudHullPoints(cloudBasisByCommunityId.get(communityId), sigma, rendererCoordinateOptions()),
+      fallbackBox,
+      adapterData.renderable.communityMap?.active
+        ? {
+            minBoxWidth: SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH,
+            minBoxHeight: SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT
+          }
+        : {}
     );
   }
 
   function overlayBoxFromWorldEllipse(x: number, y: number, rx: number, ry: number): { left: number; top: number; width: number; height: number } {
-    const topLeft = sigmaWorldPointToScreenPoint(sigma, { x: x - rx, y: y - ry }, options);
-    const bottomRight = sigmaWorldPointToScreenPoint(sigma, { x: x + rx, y: y + ry }, options);
+    const topLeft = sigmaWorldPointToScreenPoint(sigma, { x: x - rx, y: y - ry }, rendererCoordinateOptions());
+    const bottomRight = sigmaWorldPointToScreenPoint(sigma, { x: x + rx, y: y + ry }, rendererCoordinateOptions());
     const left = Math.min(topLeft.x, bottomRight.x);
     const top = Math.min(topLeft.y, bottomRight.y);
     return {
@@ -777,8 +827,16 @@ export function createSigmaGlobalRenderer(options: SigmaGlobalRendererCreateOpti
     sigmaRoot.dataset.communityFocusId = focusCommunityId;
     sigmaRoot.dataset.communityContextId = currentCommunityId;
     sigmaRoot.dataset.sourceCommunityId = adapterData.sourceCommunityId ?? "";
+    sigmaRoot.dataset.communityMapLabelLimit = String(communityMap?.current?.labelBudget.limit ?? 0);
+    sigmaRoot.dataset.communityMapVisibleLabels = String(communityMap?.current?.labelBudget.visible ?? 0);
   }
 
+}
+
+function sigmaSpotlightCameraKey(adapterData: Parameters<typeof sigmaSpotlightCommunityId>[0]): string | null {
+  const communityId = sigmaSpotlightCommunityId(adapterData);
+  if (!communityId) return null;
+  return `${adapterData.renderable.communityMap?.active ? "reading" : "global"}:${communityId}`;
 }
 
 function createSigmaRoot(container: HTMLElement, theme: ThemeId): HTMLElement {
@@ -799,6 +857,7 @@ export function sigmaSettingsForTheme(theme: ThemeId): Record<string, unknown> {
     allowInvalidContainer: false,
     labelColor: sigmaLabelColor(theme),
     labelFont: tokens.vars["--font-ui"],
+    defaultDrawNodeLabel: drawSigmaReadingAwareNodeLabel,
     zoomingRatio: SIGMA_BUTTON_ZOOM_RATIO,
     // Sigma 默认 wheel 的兜底参数：wheel 已被 sigma-wheel-zoom controller 接管（preventSigmaDefault），
     // zoomingRatio/zoomDuration 只在 Sigma 内置缩放入口（如 animatedZoom）被触发时生效，
@@ -807,6 +866,41 @@ export function sigmaSettingsForTheme(theme: ThemeId): Record<string, unknown> {
     minCameraRatio: SIGMA_CAMERA_MIN_RATIO,
     maxCameraRatio: SIGMA_CAMERA_MAX_RATIO
   };
+}
+
+/** @internal 仅为单元测试直接断言而导出，生产中通过 sigmaSettingsForTheme 注入 Sigma。 */
+export function drawSigmaReadingAwareNodeLabel(
+  context: CanvasRenderingContext2D,
+  data: SigmaNodeLabelData,
+  settings: SigmaNodeLabelSettings
+): void {
+  if (!data.label) return;
+  const label = String(data.label);
+  const size = settings.labelSize;
+  const font = settings.labelFont;
+  const weight = settings.labelWeight;
+  const color = settings.labelColor.attribute
+    ? String(data[settings.labelColor.attribute] || settings.labelColor.color || "#000")
+    : settings.labelColor.color || "#000";
+  context.fillStyle = color;
+  context.font = `${weight} ${size}px ${font}`;
+  const rightX = data.x + data.size + 3;
+  const textWidth = context.measureText(label).width;
+  const canvasWidth = sigmaLabelCanvasCssWidth(context);
+  const leftX = data.x - data.size - 3 - textWidth;
+  const shouldDrawLeft = canvasWidth > 0
+    && rightX + textWidth > canvasWidth - SIGMA_NODE_LABEL_EDGE_GUTTER
+    && leftX >= SIGMA_NODE_LABEL_EDGE_GUTTER;
+  context.fillText(label, shouldDrawLeft ? leftX : rightX, data.y + size / 3);
+}
+
+function sigmaLabelCanvasCssWidth(context: CanvasRenderingContext2D): number {
+  const canvas = context.canvas;
+  const clientWidth = finiteNumber(canvas?.clientWidth, 0);
+  if (clientWidth > 0) return clientWidth;
+  const rectWidth = finiteNumber(canvas?.getBoundingClientRect?.().width, 0);
+  if (rectWidth > 0) return rectWidth;
+  return finiteNumber(canvas?.width, 0);
 }
 
 function sigmaLabelColor(theme: ThemeId): { color: string } {

--- a/packages/graph-engine/src/render/sigma-global-types.ts
+++ b/packages/graph-engine/src/render/sigma-global-types.ts
@@ -92,6 +92,7 @@ export interface SigmaGlobalRendererUpdateOptions {
   theme?: ThemeId;
   edgeStyle?: GraphEdgeStyleOptions;
   pins?: PinMap;
+  viewportSize?: RendererViewportSize;
 }
 
 export interface SigmaGlobalRenderer {

--- a/packages/graph-engine/src/render/sigma-global-types.ts
+++ b/packages/graph-engine/src/render/sigma-global-types.ts
@@ -80,6 +80,7 @@ export interface SigmaGlobalRendererCreateOptions {
   onNodeHover?: (nodeId: string | null) => void;
   onPinsChanged?: (pins: PinMap) => void;
   onDragActiveChange?: (dragging: boolean) => void;
+  onViewportSizeChange?: (size: RendererViewportSize) => void;
   onFatalError?: (error: unknown) => void;
   pins?: PinMap;
   runtime?: SigmaGlobalRendererRuntime;

--- a/packages/graph-engine/src/render/sigma-graphology-model.ts
+++ b/packages/graph-engine/src/render/sigma-graphology-model.ts
@@ -1,6 +1,7 @@
 import type { GraphEdgeStyleOptions, ThemeId } from "../types";
 import { getThemeTokens } from "../themes";
 import type { GraphRelationFocusDepth } from "./relation-focus";
+import { truncateLabel } from "../model/labels";
 import type {
   GraphRendererAdapterAggregation,
   GraphRendererAdapterCommunity,
@@ -86,6 +87,9 @@ export interface SigmaGlobalEdgeStyle {
   size: number;
 }
 
+const SIGMA_COMMUNITY_READING_LABEL_MAX_WIDTH = 180;
+const SIGMA_COMMUNITY_READING_NARROW_LABEL_MAX_WIDTH = 128;
+
 export function buildSigmaGlobalGraphologyGraph(
   adapterData: GraphRendererAdapterData,
   runtime: SigmaGlobalGraphologyRuntime,
@@ -97,9 +101,12 @@ export function buildSigmaGlobalGraphologyGraph(
   const aggregationRenderById = new Map(adapterData.renderable.aggregationContainers.map((aggregation) => [aggregation.id, aggregation]));
   const selectedCommunityIds = sigmaSelectedCommunityIds(adapterData);
   const spotlightCommunityIds = sigmaSpotlightCommunityIds(adapterData);
+  const communityReadingLabelBudget = adapterData.renderable.communityMap?.active
+    ? adapterData.renderable.communityMap.current?.labelBudget.limit ?? null
+    : null;
 
   for (const node of adapterData.nodes) {
-    graph.addNode(node.id, sigmaGlobalNodeAttributes(node, communityColorById, spotlightCommunityIds, theme));
+    graph.addNode(node.id, sigmaGlobalNodeAttributes(node, communityColorById, spotlightCommunityIds, theme, { communityReadingLabelBudget }));
   }
 
   for (const edge of adapterData.edges) {
@@ -148,10 +155,13 @@ export function patchSigmaGlobalGraphAttributes(
   const aggregationRenderById = new Map(adapterData.renderable.aggregationContainers.map((aggregation) => [aggregation.id, aggregation]));
   const selectedCommunityIds = sigmaSelectedCommunityIds(adapterData);
   const spotlightCommunityIds = sigmaSpotlightCommunityIds(adapterData);
+  const communityReadingLabelBudget = adapterData.renderable.communityMap?.active
+    ? adapterData.renderable.communityMap.current?.labelBudget.limit ?? null
+    : null;
 
   for (const node of adapterData.nodes) {
     if (!graph.hasNode(node.id)) continue;
-    graph.mergeNodeAttributes(node.id, sigmaGlobalNodeAttributes(node, communityColorById, spotlightCommunityIds, theme));
+    graph.mergeNodeAttributes(node.id, sigmaGlobalNodeAttributes(node, communityColorById, spotlightCommunityIds, theme, { communityReadingLabelBudget }));
   }
   for (const edge of adapterData.edges) {
     graph.mergeEdgeAttributes(edge.id, sigmaGlobalEdgeAttributes(edge, theme, edgeStyle, selectedCommunityIds));
@@ -172,7 +182,8 @@ export function sigmaGlobalNodeAttributes(
   node: GraphRendererAdapterNode,
   communityColorById: Map<string, string>,
   selectedCommunityIds: ReadonlySet<string> = new Set(),
-  theme: ThemeId
+  theme: ThemeId,
+  options: { communityReadingLabelBudget?: number | null } = {}
 ): SigmaGlobalGraphologyNodeAttributes {
   const spotlight = sigmaGlobalNodeSpotlightState(node, selectedCommunityIds);
   const baseSize = sigmaGlobalNodeSize(node);
@@ -180,7 +191,7 @@ export function sigmaGlobalNodeAttributes(
   return {
     x: finiteNumber(node.point.x, 0),
     y: finiteNumber(node.point.y, 0),
-    label: node.render.labelVisible ? node.label : "",
+    label: sigmaGlobalNodeCanvasLabel(node, options),
     size: spotlight.dimmed ? roundNumber(baseSize * 0.72, 2) : baseSize,
     color: spotlight.dimmed ? rgbaColor(baseColor, 0.2) : baseColor,
     type: "circle",
@@ -202,6 +213,20 @@ export function sigmaGlobalNodeAttributes(
     communityMapImportance: finiteNumber(node.render.communityMapImportance, 0),
     drawerTarget: node.drawerTarget
   };
+}
+
+export function sigmaGlobalNodeCanvasLabel(
+  node: GraphRendererAdapterNode,
+  options: { communityReadingLabelBudget?: number | null } = {}
+): string {
+  if (!node.render.labelVisible) return "";
+  const label = node.label || node.id;
+  const labelBudget = options.communityReadingLabelBudget;
+  if (!labelBudget || labelBudget <= 0) return label;
+  const maxWidth = labelBudget <= 4
+    ? SIGMA_COMMUNITY_READING_NARROW_LABEL_MAX_WIDTH
+    : SIGMA_COMMUNITY_READING_LABEL_MAX_WIDTH;
+  return truncateLabel(label, maxWidth).text;
 }
 
 export function sigmaSelectedCommunityIds(adapterData: GraphRendererAdapterData): Set<string> {

--- a/packages/graph-engine/src/render/sigma-hit-projector.ts
+++ b/packages/graph-engine/src/render/sigma-hit-projector.ts
@@ -51,7 +51,15 @@ export function createSigmaGlobalHitProjector(input: SigmaGlobalHitProjectorInpu
               input.viewportSize,
               input.adapterData.renderable.worldBounds
             );
-        return graphSpatialHitToGestureTarget(spatialIndex.hitTest(worldPoint));
+        const target = graphSpatialHitToGestureTarget(spatialIndex.hitTest(worldPoint));
+        if (
+          target.kind === "community-wash" &&
+          input.adapterData.sourceCommunityId &&
+          !input.adapterData.renderable.communityMap?.active
+        ) {
+          return { kind: "graph-blank" };
+        }
+        return target;
       }
 
       return { kind: "graph-blank" };

--- a/packages/graph-engine/src/render/sigma-overlay-dom.ts
+++ b/packages/graph-engine/src/render/sigma-overlay-dom.ts
@@ -431,10 +431,13 @@ export function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphR
   const nodes = adapterData.nodes;
   const seen = new Set<string>();
   const output: GraphRendererAdapterNode[] = [];
+  const totalLimit = adapterData.renderable.communityMap?.active
+    ? Number.POSITIVE_INFINITY
+    : SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT;
   const append = (candidates: GraphRendererAdapterNode[], limit: number) => {
     let count = 0;
     for (const node of candidates) {
-      if (output.length >= SIGMA_GLOBAL_NODE_HIT_TARGET_LIMIT || count >= limit || seen.has(node.id)) continue;
+      if (output.length >= totalLimit || count >= limit || seen.has(node.id)) continue;
       seen.add(node.id);
       output.push(node);
       count += 1;

--- a/packages/graph-engine/src/render/sigma-overlay-dom.ts
+++ b/packages/graph-engine/src/render/sigma-overlay-dom.ts
@@ -2,7 +2,14 @@ import type {
   GraphRendererAdapterData,
   GraphRendererAdapterNode
 } from "./adapter";
-import type { SigmaCommunityCloud } from "./community-cloud-geometry";
+import {
+  SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT,
+  SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH,
+  sigmaCommunityCloud,
+  sigmaCommunityCloudBasisById,
+  sigmaProjectedCloudHullPoints,
+  type SigmaCommunityCloud
+} from "./community-cloud-geometry";
 import type { GraphScreenPoint } from "./geometry";
 import {
   bindSigmaGlobalOverlayMouseDrag,
@@ -151,6 +158,7 @@ export function createSigmaOverlayDomController(input: SigmaOverlayDomController
       element.dataset.searchHit = node.searchHit ? "true" : "false";
       element.dataset.selected = node.selected ? "true" : "false";
       element.dataset.pinned = node.pinHint.pinned ? "true" : "false";
+      element.dataset.relationFocusDepth = node.relationFocusDepth ?? "none";
       element.dataset.communityDimmed = sigmaGlobalNodeSpotlightState(node, spotlightCommunityIds).dimmed ? "true" : "false";
       ordered.push(element);
     }
@@ -209,10 +217,7 @@ export function createSigmaOverlayDomController(input: SigmaOverlayDomController
       if (!community.wash) continue;
       const element = overlayLabelEntries.get(community.id);
       if (!element) continue;
-      const center = sigmaWorldPointToScreenPoint(sigma, {
-        x: community.wash.cx,
-        y: community.wash.cy - community.wash.ry * 0.16
-      }, options);
+      const center = communityLabelScreenPoint(community, adapterData, sigma, options);
       applyOverlayBox(element, {
         left: center.x,
         top: center.y,
@@ -374,6 +379,54 @@ export function createSigmaOverlayDomController(input: SigmaOverlayDomController
   }
 }
 
+function communityLabelScreenPoint(
+  community: GraphRendererAdapterData["renderable"]["communities"][number],
+  adapterData: GraphRendererAdapterData,
+  sigma: SigmaGlobalSigmaLike,
+  options: Pick<SigmaGlobalRendererCreateOptions, "viewport" | "viewportSize" | "adapterData">
+): GraphScreenPoint {
+  if (adapterData.renderable.communityMap?.active && community.wash) {
+    const fallbackBox = overlayBoxFromWorldEllipse(community.wash, sigma, options);
+    const cloud = sigmaCommunityCloud(
+      sigmaProjectedCloudHullPoints(
+        sigmaCommunityCloudBasisById(adapterData).get(community.id),
+        sigma,
+        options
+      ),
+      fallbackBox,
+      {
+        minBoxWidth: SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH,
+        minBoxHeight: SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT
+      }
+    );
+    return {
+      x: cloud.box.left + cloud.box.width / 2,
+      y: cloud.box.top + 15
+    };
+  }
+  return sigmaWorldPointToScreenPoint(sigma, {
+    x: community.wash?.cx ?? 0,
+    y: (community.wash?.cy ?? 0) - (community.wash?.ry ?? 0) * 0.16
+  }, options);
+}
+
+function overlayBoxFromWorldEllipse(
+  wash: { cx: number; cy: number; rx: number; ry: number },
+  sigma: SigmaGlobalSigmaLike,
+  options: Pick<SigmaGlobalRendererCreateOptions, "viewport" | "viewportSize" | "adapterData">
+): { left: number; top: number; width: number; height: number } {
+  const topLeft = sigmaWorldPointToScreenPoint(sigma, { x: wash.cx - wash.rx, y: wash.cy - wash.ry }, options);
+  const bottomRight = sigmaWorldPointToScreenPoint(sigma, { x: wash.cx + wash.rx, y: wash.cy + wash.ry }, options);
+  const left = Math.min(topLeft.x, bottomRight.x);
+  const top = Math.min(topLeft.y, bottomRight.y);
+  return {
+    left,
+    top,
+    width: Math.max(8, Math.abs(bottomRight.x - topLeft.x)),
+    height: Math.max(8, Math.abs(bottomRight.y - topLeft.y))
+  };
+}
+
 export function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphRendererAdapterNode[] {
   const nodes = adapterData.nodes;
   const seen = new Set<string>();
@@ -389,6 +442,9 @@ export function sigmaOverlayNodes(adapterData: GraphRendererAdapterData): GraphR
   };
   if (adapterData.selection.input?.kind !== "community") {
     append(nodes.filter((node) => node.selected), Number.POSITIVE_INFINITY);
+  }
+  if (adapterData.renderable.communityMap?.active) {
+    append(nodes, Number.POSITIVE_INFINITY);
   }
   append(nodes.filter((node) => node.searchHit), 80);
   append(nodes.filter((node) => node.pinHint.pinned), 80);

--- a/packages/graph-engine/src/render/sigma-zoom.ts
+++ b/packages/graph-engine/src/render/sigma-zoom.ts
@@ -11,7 +11,7 @@ export const SIGMA_WHEEL_ZOOM_SPEED = 0.0016;
 export const SIGMA_WHEEL_ZOOM_FACTOR_MIN = 0.2;
 export const SIGMA_WHEEL_ZOOM_FACTOR_MAX = 5;
 export const SIGMA_CAMERA_MIN_RATIO = 0.3;
-export const SIGMA_CAMERA_MAX_RATIO = 3;
+export const SIGMA_CAMERA_MAX_RATIO = 8;
 export const SIGMA_BUTTON_ZOOM_RATIO = 1.18;
 export const SIGMA_BUTTON_ZOOM_DURATION_MS = 140;
 

--- a/packages/graph-engine/test/community-cloud-geometry.test.ts
+++ b/packages/graph-engine/test/community-cloud-geometry.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT,
+  SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH,
   clampPointToScreenEllipse,
   clampPointToWorldEllipse,
   convexHull2d,
@@ -82,5 +84,38 @@ describe("community cloud geometry", () => {
     assert.ok(cloud.localPoints);
     assert.equal(cloud.localPoints?.length, 3);
     assert.ok(cloud.box.width >= 8 && cloud.box.height >= 8);
+  });
+
+  it("keeps near-linear community-reading clouds visibly readable", () => {
+    const cloud = sigmaCommunityCloud(
+      [{ x: 0, y: 1 }, { x: 130, y: 0 }, { x: 260, y: 2 }],
+      { left: -20, top: -20, width: 300, height: 40 },
+      {
+        minBoxWidth: SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH,
+        minBoxHeight: SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT
+      }
+    );
+
+    assert.ok(cloud.localPoints);
+    assert.equal(cloud.box.height, SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT);
+    assert.ok(cloud.box.width >= SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH);
+    assert.ok(cloud.box.top < 0, "the expanded cloud should grow around the thin hull");
+  });
+
+  it("does not inflate two-point community-reading clouds to an oversized fallback box", () => {
+    const cloud = sigmaCommunityCloud(
+      [{ x: 210, y: 220 }, { x: 250, y: 230 }],
+      { left: -30000, top: -30000, width: 60000, height: 60000 },
+      {
+        minBoxWidth: SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH,
+        minBoxHeight: SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT
+      }
+    );
+
+    assert.equal(cloud.localPoints, null);
+    assert.equal(cloud.box.width, SIGMA_READING_COMMUNITY_CLOUD_MIN_WIDTH);
+    assert.equal(cloud.box.height, SIGMA_READING_COMMUNITY_CLOUD_MIN_HEIGHT);
+    assert.ok(cloud.box.left > 150);
+    assert.ok(cloud.box.top > 180);
   });
 });

--- a/packages/graph-engine/test/render-model.test.ts
+++ b/packages/graph-engine/test/render-model.test.ts
@@ -776,6 +776,17 @@ describe("buildRenderableGraph", () => {
     assert.ok(graph.nodes.some((node) => node.displayMode === "point" || node.displayMode === "overview"), "ordinary nodes should remain point-like");
   });
 
+  it("tightens default community labels on narrow viewports", () => {
+    const graph = buildRenderableGraph(budgetGraph(5, 4), {
+      theme: "shan-shui",
+      focus: { kind: "community", id: "c1" },
+      viewportSize: { width: 390, height: 844 }
+    });
+
+    assert.equal(graph.communityMap.current?.labelBudget.limit, 2);
+    assert.ok(graph.nodes.filter((node) => node.labelVisible).length <= 2);
+  });
+
   it("uses the medium community band with all nodes present and no full cards", () => {
     const graph = buildRenderableGraph(budgetGraph(120, 600), {
       theme: "shan-shui",

--- a/packages/graph-engine/test/renderer-adapter-contract.test.ts
+++ b/packages/graph-engine/test/renderer-adapter-contract.test.ts
@@ -42,6 +42,23 @@ describe("graph renderer adapter contract", () => {
     assert.equal(typeof edge.render.traceable, "boolean");
   });
 
+  it("passes viewport size into focused community reading bounds", () => {
+    const wide = buildGraphRendererAdapterData(graphFixture(), {
+      focus: { kind: "community", id: "alpha" },
+      viewportSize: { width: 1600, height: 900 }
+    });
+    const narrow = buildGraphRendererAdapterData(graphFixture(), {
+      focus: { kind: "community", id: "alpha" },
+      viewportSize: { width: 390, height: 844 }
+    });
+
+    const wideRatio = wide.renderable.worldBounds.width / wide.renderable.worldBounds.height;
+    const narrowRatio = narrow.renderable.worldBounds.width / narrow.renderable.worldBounds.height;
+
+    assert.ok(Math.abs(wideRatio - 1600 / 900) < 0.05, `wide bounds should match viewport ratio, got ${wideRatio}`);
+    assert.ok(Math.abs(narrowRatio - 390 / 844) < 0.05, `narrow bounds should match viewport ratio, got ${narrowRatio}`);
+  });
+
   it("preserves shared object ids, selected state, search hits, Pin hints, aggregations, and drawer targets", () => {
     const adapter = buildGraphRendererAdapterData(graphFixture(), adapterOptions());
 

--- a/packages/graph-engine/test/runtime-state.test.ts
+++ b/packages/graph-engine/test/runtime-state.test.ts
@@ -152,6 +152,24 @@ describe("atlas state contract", () => {
     );
   });
 
+  it("preserves relative shape when explicit community coordinates are outside the legacy percent range", () => {
+    const model = buildAtlasModel({
+      nodes: [
+        { id: "a", label: "A", community: "edge-dense", x: 132, y: 126 },
+        { id: "b", label: "B", community: "edge-dense", x: 148, y: 142 },
+        { id: "c", label: "C", community: "edge-dense", x: 164, y: 158 }
+      ],
+      edges: []
+    });
+    deriveAtlasLayout(model);
+
+    const points = ["a", "b", "c"].map((id) => ({ x: model.byId[id].x, y: model.byId[id].y }));
+    assert.ok(new Set(points.map((point) => point.x)).size > 1, "x positions should not collapse to one clamp boundary");
+    assert.ok(new Set(points.map((point) => point.y)).size > 1, "y positions should not collapse to one clamp boundary");
+    assert.ok(points.every((point) => point.x >= 5 && point.x <= 95));
+    assert.ok(points.every((point) => point.y >= 8 && point.y <= 92));
+  });
+
   it("uses one visible snapshot for filters, search, density, and starts", () => {
     const model = buildAtlasModel(rawGraph);
     const layout = deriveAtlasLayout(model);

--- a/packages/graph-engine/test/sigma-global-camera.test.ts
+++ b/packages/graph-engine/test/sigma-global-camera.test.ts
@@ -8,6 +8,7 @@ import {
   moveSigmaCamera,
   readCameraState,
   restoreCameraState,
+  sigmaCommunitySpotlightCameraState,
   sigmaCommunitySpotlightCenter,
   sigmaGlobalCameraState,
   sigmaGraphPointToCameraPoint
@@ -161,6 +162,87 @@ describe("Sigma global camera helpers", () => {
     assert.deepEqual(sigmaCommunitySpotlightCenter(adapterDataWithoutWash(), "community-a"), { x: 30, y: 40 });
   });
 
+  it("keeps drawer offset out of community reading camera targets", () => {
+    const globalTarget = sigmaCommunitySpotlightCameraState(
+      sigmaLike({ x: 0, y: 0, angle: 0, ratio: 1 }),
+      adapterDataFixture(),
+      "community-a"
+    );
+    const readingTarget = sigmaCommunitySpotlightCameraState(
+      sigmaLike({ x: 0, y: 0, angle: 0, ratio: 1 }),
+      adapterDataWithCommunityReading(),
+      "community-a"
+    );
+
+    assert.equal(globalTarget?.x, 28);
+    assert.equal(readingTarget?.x, 30);
+    assert.equal(readingTarget?.y, 40);
+  });
+
+  it("centers community reading on visible community nodes instead of oversized wash geometry", () => {
+    const adapterData = adapterDataWithCommunityReading();
+    adapterData.renderable.communities = adapterData.renderable.communities.map((community) => ({
+      ...community,
+      wash: { cx: 5, cy: 10, rx: 90, ry: 80 }
+    }));
+
+    const target = sigmaCommunitySpotlightCameraState(
+      sigmaLike({ x: 0, y: 0, angle: 0, ratio: 1 }),
+      adapterData,
+      "community-a"
+    );
+
+    assert.equal(target?.x, 30);
+    assert.equal(target?.y, 40);
+  });
+
+  it("does not carry an over-zoomed global spotlight ratio into community reading", () => {
+    const target = sigmaCommunitySpotlightCameraState(
+      sigmaLike({ x: 0, y: 0, angle: 0, ratio: 0.72 }),
+      adapterDataWithCommunityReading(),
+      "community-a"
+    );
+
+    assert.equal(target?.ratio, 1);
+  });
+
+  it("widens community reading camera when projected nodes would overflow the viewport", () => {
+    const adapterData = adapterDataWithCommunityReading();
+    adapterData.nodes = [
+      nodeFixture("left", { x: -400, y: 0 }),
+      nodeFixture("right", { x: 400, y: 0 }),
+      nodeFixture("top", { x: 0, y: -260 })
+    ];
+
+    const target = sigmaCommunitySpotlightCameraState(
+      sigmaLikeWithProjection({ x: 0, y: 0, angle: 0, ratio: 1 }, { width: 500, height: 500 }),
+      adapterData,
+      "community-a",
+      { width: 500, height: 500 }
+    );
+
+    assert.ok((target?.ratio ?? 0) > 2, "community reading should zoom out until the nodes fit");
+  });
+
+  it("moves closer when projected community nodes are too small to read", () => {
+    const adapterData = adapterDataWithCommunityReading();
+    adapterData.nodes = [
+      nodeFixture("a", { x: -20, y: -16 }),
+      nodeFixture("b", { x: 20, y: -16 }),
+      nodeFixture("c", { x: 18, y: 16 }),
+      nodeFixture("d", { x: -18, y: 16 })
+    ];
+
+    const target = sigmaCommunitySpotlightCameraState(
+      sigmaLikeWithProjection({ x: 0, y: 0, angle: 0, ratio: 1 }, { width: 500, height: 500 }),
+      adapterData,
+      "community-a",
+      { width: 500, height: 500 }
+    );
+
+    assert.ok((target?.ratio ?? 1) < 0.4, "tight community reading should zoom in until the nodes are readable");
+  });
+
   it("does not decide selected community internally", () => {
     const sigma = sigmaLike({ x: 0, y: 0, angle: 0, ratio: 1 });
 
@@ -198,6 +280,24 @@ function sigmaLike(
     }
   };
   return output;
+}
+
+function sigmaLikeWithProjection(
+  state: SigmaGlobalCameraState,
+  size: { width: number; height: number }
+): SigmaGlobalSigmaLike {
+  return {
+    getCamera: () => ({
+      getState: () => state
+    }),
+    graphToViewport: (point, override) => {
+      const camera = { ...state, ...(override?.cameraState ?? {}) };
+      return {
+        x: size.width / 2 + (point.x - camera.x) / camera.ratio,
+        y: size.height / 2 + (point.y - camera.y) / camera.ratio
+      };
+    }
+  };
 }
 
 function rootWithReducedMotion(reduce: boolean): HTMLElement {
@@ -324,6 +424,19 @@ function adapterDataFixture(): GraphRendererAdapterData {
 function adapterDataWithoutWash(): GraphRendererAdapterData {
   const data = adapterDataFixture();
   data.renderable.communities = data.renderable.communities.map((community) => ({ ...community, wash: null }));
+  return data;
+}
+
+function adapterDataWithCommunityReading(): GraphRendererAdapterData {
+  const data = adapterDataFixture();
+  data.renderable.communityMap = {
+    active: true,
+    sourceCommunityId: "community-a",
+    motionMode: "frozen",
+    maxNodeDriftRatio: 0,
+    current: null,
+    rulesByCommunityId: {}
+  };
   return data;
 }
 

--- a/packages/graph-engine/test/sigma-global-camera.test.ts
+++ b/packages/graph-engine/test/sigma-global-camera.test.ts
@@ -157,9 +157,42 @@ describe("Sigma global camera helpers", () => {
   it("computes full graph camera state and community spotlight centers", () => {
     const adapterData = adapterDataFixture();
 
-    assert.deepEqual(sigmaGlobalCameraState({}, adapterData), { x: 50, y: 50, angle: 0, ratio: 1 });
+    assert.deepEqual(sigmaGlobalCameraState({}, adapterData), { x: 30, y: 40, angle: 0, ratio: 1 });
     assert.deepEqual(sigmaCommunitySpotlightCenter(adapterData, "community-a"), { x: 20, y: 30 });
     assert.deepEqual(sigmaCommunitySpotlightCenter(adapterDataWithoutWash(), "community-a"), { x: 30, y: 40 });
+  });
+
+  it("computes full graph camera reset in Sigma camera coordinates", () => {
+    const adapterData = adapterDataFixture();
+
+    assert.deepEqual(
+      sigmaGlobalCameraState({
+        graphToViewport: () => ({ x: 900, y: -400 }),
+        viewportToFramedGraph: () => ({ x: 1200, y: -800 })
+      }, adapterData),
+      { x: 0.5, y: 0.5, angle: 0, ratio: 1 }
+    );
+  });
+
+  it("zooms out full graph camera reset when global nodes would be cropped", () => {
+    const adapterData = adapterDataFixture();
+    adapterData.nodes = [
+      nodeFixture("left", { x: -400, y: 0 }),
+      nodeFixture("right", { x: 400, y: 0 }),
+      nodeFixture("top", { x: 0, y: -260 }),
+      nodeFixture("bottom", { x: 0, y: 260 })
+    ];
+    adapterData.renderable.worldBounds = { minX: -400, maxX: 400, minY: -260, maxY: 260 };
+
+    const target = sigmaGlobalCameraState(
+      sigmaLikeWithProjection({ x: 0, y: 0, angle: 0, ratio: 1 }, { width: 500, height: 500 }),
+      adapterData,
+      { width: 500, height: 500 }
+    );
+
+    assert.equal(target.x, 0.5);
+    assert.equal(target.y, 0.5);
+    assert.ok((target.ratio ?? 1) > 2, `full graph reset should zoom out enough to fit wide nodes, got ${JSON.stringify(target)}`);
   });
 
   it("keeps drawer offset out of community reading camera targets", () => {

--- a/packages/graph-engine/test/sigma-global-renderer.test.ts
+++ b/packages/graph-engine/test/sigma-global-renderer.test.ts
@@ -7,6 +7,7 @@ import {
   SIGMA_GLOBAL_RENDERER_BUNDLE_BOUNDARY,
   SIGMA_GLOBAL_RENDERER_ROUTE_MANAGER_OWNER,
   createSigmaGlobalRenderer,
+  drawSigmaReadingAwareNodeLabel,
   type SigmaGlobalGraphologyGraph,
   type SigmaGlobalRendererRuntime,
   type SigmaGlobalSigmaLike,
@@ -48,6 +49,48 @@ describe("Sigma global renderer production boundary", () => {
       () => createSigmaGlobalRenderer({} as never),
       /container|runtime/
     );
+  });
+
+  it("draws Sigma node labels to the left when a right-side label would be clipped", () => {
+    const context = fakeLabelContext(220);
+
+    drawSigmaReadingAwareNodeLabel(
+      context,
+      { x: 190, y: 80, size: 10, label: "右侧标签", color: "#123456" },
+      {
+        labelSize: 14,
+        labelFont: "Inter",
+        labelWeight: "600",
+        labelColor: { color: "#6b6256" }
+      }
+    );
+
+    assert.deepEqual(context.fillTextCalls, [
+      { text: "右侧标签", x: 137, y: 84.667 }
+    ]);
+  });
+
+  it("keeps normal Sigma node labels on the right side", () => {
+    const context = fakeLabelContext(320);
+
+    drawSigmaReadingAwareNodeLabel(
+      context,
+      { x: 80, y: 60, size: 10, label: "普通标签", color: "#123456" },
+      {
+        labelSize: 14,
+        labelFont: "Inter",
+        labelWeight: "600",
+        labelColor: { color: "#6b6256" }
+      }
+    );
+
+    assert.deepEqual(context.fillTextCalls, [
+      { text: "普通标签", x: 93, y: 64.667 }
+    ]);
+  });
+
+  it("uses the clipping-aware node label renderer in Sigma settings", () => {
+    assert.equal(sigmaSettingsForTheme("shan-shui").defaultDrawNodeLabel, drawSigmaReadingAwareNodeLabel);
   });
 
   it("builds a Graphology render graph entirely from adapter output", () => {
@@ -1553,6 +1596,30 @@ describe("Sigma global renderer production boundary", () => {
     renderer.destroy();
   });
 
+  it("uses updated viewport size for Sigma community reading camera updates", () => {
+    const runtime = fakeRuntime();
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData: adapterDataFixture({ selectedCommunityIds: [] }),
+      theme: "shan-shui",
+      runtime,
+      viewportSize: { width: 1600, height: 900 }
+    });
+    const sigma = runtime.instances[0];
+
+    renderer.update({
+      adapterData: wideCommunityReadingAdapterDataFixture(),
+      viewportSize: { width: 390, height: 844 }
+    });
+
+    assert.ok(
+      (sigma.camera.activeAnimationTarget?.ratio ?? 0) > 2,
+      `narrow community reading should zoom out with the updated viewport size, got ${JSON.stringify(sigma.camera.activeAnimationTarget)}`
+    );
+
+    renderer.destroy();
+  });
+
   it("sets the Sigma camera instantly when reduced motion is requested", () => {
     const runtime = fakeRuntime({ worldScale: 200 });
     const renderer = createSigmaGlobalRenderer({
@@ -2422,6 +2489,42 @@ function communityReadingAdapterDataFixture(options: {
   };
 }
 
+function wideCommunityReadingAdapterDataFixture(): GraphRendererAdapterData {
+  const data = communityReadingAdapterDataFixture();
+  const nextNodes = data.nodes.map((node) => node.id === "render-alpha"
+    ? { ...node, point: { x: -400, y: 0 } }
+    : node.id === "render-beta"
+    ? { ...node, point: { x: 400, y: 0 } }
+    : node);
+  const current = data.renderable.communityMap.current;
+  return {
+    ...data,
+    nodes: nextNodes,
+    renderable: {
+      ...data.renderable,
+      communityMap: {
+        ...data.renderable.communityMap,
+        current: current
+          ? {
+              ...current,
+              nodeRulesById: Object.fromEntries(nextNodes.map((node) => [
+                node.id,
+                {
+                  ...current.nodeRulesById[node.id],
+                  basePoint: node.point
+                }
+              ])),
+              layout: {
+                ...current.layout,
+                bounds: { minX: -400, minY: 0, maxX: 400, maxY: 0, width: 800, height: 0 }
+              }
+            }
+          : current
+      }
+    }
+  };
+}
+
 function adapterDataWithAddedNodeAndEdge(data: GraphRendererAdapterData = adapterDataFixture()): GraphRendererAdapterData {
   const seedNode = data.nodes[0];
   const seedEdge = data.edges[0];
@@ -2798,6 +2901,32 @@ function sigmaCommunityCloudShape(renderer: { overlayRoot: HTMLElement & { child
 
 function sigmaCommunityRegion(renderer: { overlayRoot: HTMLElement & { children: HTMLElement[] } }, communityId: string): HTMLElement | undefined {
   return renderer.overlayRoot.children.find((child) => child.dataset.communityId === communityId);
+}
+
+function fakeLabelContext(width: number): CanvasRenderingContext2D & {
+  fillTextCalls: Array<{ text: string; x: number; y: number }>;
+} {
+  const fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
+  return {
+    canvas: {
+      clientWidth: width,
+      width,
+      getBoundingClientRect: () => ({ width })
+    },
+    fillStyle: "",
+    font: "",
+    measureText: (text: string) => ({ width: text.length * 10 }),
+    fillText: (text: string, x: number, y: number) => {
+      fillTextCalls.push({ text, x: roundLabelTestNumber(x), y: roundLabelTestNumber(y) });
+    },
+    fillTextCalls
+  } as unknown as CanvasRenderingContext2D & {
+    fillTextCalls: Array<{ text: string; x: number; y: number }>;
+  };
+}
+
+function roundLabelTestNumber(value: number): number {
+  return Math.round(value * 1000) / 1000;
 }
 
 function densePointMapGraph(): GraphData {

--- a/packages/graph-engine/test/sigma-global-renderer.test.ts
+++ b/packages/graph-engine/test/sigma-global-renderer.test.ts
@@ -773,6 +773,33 @@ describe("Sigma global renderer production boundary", () => {
     assert.equal(disconnected, true);
   });
 
+  it("reports host resize so the route can rebuild viewport-sized community reading data", () => {
+    let resizeCallback: ResizeObserverCallback | null = null;
+    class FakeResizeObserver implements ResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    const observedSizes: Array<{ width: number; height: number }> = [];
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer({ ResizeObserver: FakeResizeObserver as typeof ResizeObserver }),
+      adapterData: communityReadingAdapterDataFixture(),
+      theme: "shan-shui",
+      runtime: fakeRuntime(),
+      viewportSize: { width: 1600, height: 900 },
+      onViewportSizeChange: (size) => observedSizes.push(size)
+    });
+
+    resizeCallback?.([resizeObserverEntry(390, 844)], {} as ResizeObserver);
+
+    assert.deepEqual(observedSizes, [{ width: 390, height: 844 }]);
+
+    renderer.destroy();
+  });
+
   it("repositions overlays on camera updates without rebuilding DOM or rebinding listeners", () => {
     const runtime = fakeRuntime();
     const renderer = createSigmaGlobalRenderer({
@@ -1536,6 +1563,90 @@ describe("Sigma global renderer production boundary", () => {
     renderer.destroy();
   });
 
+  it("routes DOM root canvas clicks through hit projection when Sigma does not emit clickStage", async () => {
+    const hits: unknown[] = [];
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData: {
+        ...adapterDataFixture({ selectedCommunityId: "adapter-community" }),
+        sourceCommunityId: "adapter-community"
+      },
+      theme: "shan-shui",
+      runtime: fakeRuntime(),
+      onHitTarget: (target) => hits.push(target)
+    });
+
+    renderer.root.dispatchEvent({
+      type: "click",
+      clientX: 250,
+      clientY: 250,
+      target: { closest: () => null }
+    } as unknown as Event);
+    await Promise.resolve();
+
+    assert.deepEqual(hits.at(-1), { kind: "graph-blank" });
+
+    renderer.destroy();
+  });
+
+  it("does not duplicate root canvas clicks when Sigma already emitted the stage click", async () => {
+    const hits: unknown[] = [];
+    const runtime = fakeRuntime();
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData: adapterDataFixture(),
+      theme: "shan-shui",
+      runtime,
+      onHitTarget: (target) => hits.push(target)
+    });
+    const sigma = runtime.instances[0];
+
+    sigma.emit("clickStage", sigmaEventPayload(null, 490, 490));
+    renderer.root.dispatchEvent({
+      type: "click",
+      clientX: 490,
+      clientY: 490,
+      target: { closest: () => null }
+    } as unknown as Event);
+    await Promise.resolve();
+
+    assert.deepEqual(hits, [{ kind: "graph-blank" }]);
+
+    renderer.destroy();
+  });
+
+  it("still lets returned source-context canvas clicks clear when Sigma reports a node click", async () => {
+    const hits: unknown[] = [];
+    const runtime = fakeRuntime();
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData: {
+        ...adapterDataFixture({ selectedCommunityId: "adapter-community" }),
+        sourceCommunityId: "adapter-community"
+      },
+      theme: "shan-shui",
+      runtime,
+      onHitTarget: (target) => hits.push(target)
+    });
+    const sigma = runtime.instances[0];
+
+    renderer.root.dispatchEvent({
+      type: "click",
+      clientX: 250,
+      clientY: 250,
+      target: { closest: () => null }
+    } as unknown as Event);
+    sigma.emit("clickNode", { node: "render-beta" });
+    await Promise.resolve();
+
+    assert.deepEqual(hits, [
+      { kind: "node", id: "render-beta" },
+      { kind: "graph-blank" }
+    ]);
+
+    renderer.destroy();
+  });
+
   it("patches node spotlight attributes in place when community selection changes", () => {
     const runtime = fakeRuntime();
     const renderer = createSigmaGlobalRenderer({
@@ -1596,6 +1707,29 @@ describe("Sigma global renderer production boundary", () => {
     renderer.destroy();
   });
 
+  it("does not move the Sigma camera for returned global source-community context alone", () => {
+    const runtime = fakeRuntime({ worldScale: 200 });
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData: nodeSpotlightAdapterData({ selectionKind: null }),
+      theme: "shan-shui",
+      runtime
+    });
+    const sigma = runtime.instances[0];
+
+    renderer.update({
+      adapterData: {
+        ...nodeSpotlightAdapterData({ selectionKind: null }),
+        sourceCommunityId: "community-1"
+      }
+    });
+
+    assert.equal(sigma.camera.animateCalls.length, 0);
+    assert.deepEqual(sigma.camera.getState(), { x: 0, y: 0, angle: 0, ratio: 1 });
+
+    renderer.destroy();
+  });
+
   it("uses updated viewport size for Sigma community reading camera updates", () => {
     const runtime = fakeRuntime();
     const renderer = createSigmaGlobalRenderer({
@@ -1615,6 +1749,37 @@ describe("Sigma global renderer production boundary", () => {
     assert.ok(
       (sigma.camera.activeAnimationTarget?.ratio ?? 0) > 2,
       `narrow community reading should zoom out with the updated viewport size, got ${JSON.stringify(sigma.camera.activeAnimationTarget)}`
+    );
+
+    renderer.destroy();
+  });
+
+  it("refits the Sigma community reading camera when the same community viewport narrows", () => {
+    const runtime = fakeRuntime();
+    const renderer = createSigmaGlobalRenderer({
+      container: fakeContainer(),
+      adapterData: adapterDataFixture({ selectedCommunityIds: [] }),
+      theme: "shan-shui",
+      runtime,
+      viewportSize: { width: 1600, height: 900 }
+    });
+    const sigma = runtime.instances[0];
+    const readingData = wideCommunityReadingAdapterDataFixture();
+
+    renderer.update({
+      adapterData: readingData,
+      viewportSize: { width: 390, height: 844 }
+    });
+    const firstTarget = sigma.camera.activeAnimationTarget;
+    renderer.update({
+      adapterData: readingData,
+      viewportSize: { width: 320, height: 844 }
+    });
+
+    assert.equal(sigma.camera.animateCalls.length, 2);
+    assert.ok(
+      (sigma.camera.activeAnimationTarget?.ratio ?? 0) > (firstTarget?.ratio ?? 0),
+      `narrow resize should refit the same community, got ${JSON.stringify({ before: firstTarget, after: sigma.camera.activeAnimationTarget })}`
     );
 
     renderer.destroy();
@@ -2000,7 +2165,7 @@ describe("Sigma global renderer production boundary", () => {
     const sigma = runtime.instances[0];
 
     assert.equal(sigma.settings.minCameraRatio, 0.3);
-    assert.equal(sigma.settings.maxCameraRatio, 3);
+    assert.equal(sigma.settings.maxCameraRatio, 8);
     assert.equal(sigma.settings.zoomingRatio, 1.18);
     assert.equal(sigma.settings.zoomDuration, 120);
   });
@@ -3087,6 +3252,10 @@ function fakeElement(_tagName: string, defaultView?: FakeDefaultView): HTMLEleme
       list.push(listener);
       listeners.set(type, list);
     },
+    removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      const list = listeners.get(type) ?? [];
+      listeners.set(type, list.filter((item) => item !== listener));
+    },
     dispatchEvent: (event: Event) => {
       for (const listener of listeners.get(event.type) ?? []) {
         if (typeof listener === "function") listener.call(element, event);
@@ -3099,6 +3268,7 @@ function fakeElement(_tagName: string, defaultView?: FakeDefaultView): HTMLEleme
     },
     getAttribute: (name: string) => attributes.get(name) ?? null,
     querySelector: () => null,
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 1000, height: 680, right: 1000, bottom: 680 }),
     remove: () => undefined
   };
   element.ownerDocument = {

--- a/packages/graph-engine/test/sigma-graphology-model.test.ts
+++ b/packages/graph-engine/test/sigma-graphology-model.test.ts
@@ -133,6 +133,24 @@ describe("Sigma graphology render model", () => {
     assert.equal(graph.getNodeAttribute("alpha", "y"), 222);
   });
 
+  it("truncates long canvas labels in narrow Sigma community reading", () => {
+    const data = sigmaCommunityReadingGraphData();
+    const longLabel = "一个标题非常长用来测试社区阅读标签截断是否稳定的核心节点";
+    data.nodes = data.nodes.map((node) => node.id === "alpha" ? { ...node, label: longLabel } : node);
+    const adapter = buildGraphRendererAdapterData(data, {
+      theme: "shan-shui",
+      focus: { kind: "community", id: "community-a" },
+      sourceCommunityId: "community-a",
+      viewportSize: { width: 390, height: 844 }
+    });
+    const graph = buildSigmaGlobalGraphologyGraph(adapter, { GraphologyGraph });
+    const canvasLabel = graph.getNodeAttribute("alpha", "label");
+
+    assert.ok(adapter.nodes.find((node) => node.id === "alpha")?.label === longLabel, "adapter keeps the full node title");
+    assert.ok(canvasLabel.endsWith("…"), `canvas label should be truncated, got ${canvasLabel}`);
+    assert.ok(canvasLabel.length < longLabel.length);
+  });
+
   it("detects patch eligibility from graph structure and theme", () => {
     const adapterData = adapterDataFixture();
     const sameShape = adapterDataFixture({ alphaLabel: "Alpha changed" });

--- a/packages/graph-engine/test/sigma-hit-projector.test.ts
+++ b/packages/graph-engine/test/sigma-hit-projector.test.ts
@@ -32,6 +32,23 @@ describe("Sigma hit projector", () => {
     );
   });
 
+  it("treats stage clicks on the returned source community wash as blank so users can clear the source highlight", () => {
+    const adapterData = {
+      ...adapterDataFixture(),
+      sourceCommunityId: "community-a"
+    };
+    const projector = createSigmaGlobalHitProjector(projectorInput({ adapterData }));
+
+    assert.deepEqual(
+      projector.targetFromSigmaHit({ screenPoint: { x: 50, y: 30 } }),
+      { kind: "graph-blank" }
+    );
+    assert.deepEqual(
+      projector.targetFromSigmaHit({ renderedObject: { kind: "community-wash", id: "community-a" } }),
+      { kind: "community-wash", id: "community-a" }
+    );
+  });
+
   it("translates rendered objects into graph gesture targets", () => {
     const adapterData = adapterDataFixture();
 
@@ -68,9 +85,9 @@ describe("Sigma hit projector", () => {
   });
 });
 
-function projectorInput() {
+function projectorInput(options: { adapterData?: GraphRendererAdapterData } = {}) {
   return {
-    adapterData: adapterDataFixture(),
+    adapterData: options.adapterData ?? adapterDataFixture(),
     viewport: { x: 0, y: 0, scale: 1 },
     viewportSize: { width: 100, height: 100 },
     screenPointToWorldPoint: (point: { x: number; y: number }) => point

--- a/packages/graph-engine/test/sigma-overlay-dom.test.ts
+++ b/packages/graph-engine/test/sigma-overlay-dom.test.ts
@@ -68,6 +68,24 @@ describe("Sigma overlay DOM controller", () => {
     assert.equal(nodeTarget(fixture.overlayRoot, "beta")?.dataset.relationFocusDepth, "first");
   });
 
+  it("keeps every community reading node reachable through the overlay hit layer", () => {
+    const nodes = Array.from({ length: 180 }, (_, index) => (
+      nodeFixture(`node-${index}`, {
+        selected: false,
+        searchHit: false,
+        pinned: false,
+        communityId: "community-a"
+      })
+    ));
+    const data = adapterDataFixture({
+      communityMapActive: true,
+      nodes
+    });
+
+    assert.equal(sigmaOverlayNodes(data).length, nodes.length);
+    assert.equal(sigmaOverlayNodes(data).at(-1)?.id, "node-179");
+  });
+
   it("binds pointer overlay drag and clears document listeners on pointerup", () => {
     const fixture = controllerFixture();
     fixture.controller.rebuild();

--- a/packages/graph-engine/test/sigma-overlay-dom.test.ts
+++ b/packages/graph-engine/test/sigma-overlay-dom.test.ts
@@ -51,6 +51,23 @@ describe("Sigma overlay DOM controller", () => {
     assert.equal(shape?.style.cursor, "default");
   });
 
+  it("creates community reading hit targets for ordinary visible nodes", () => {
+    const fixture = controllerFixture({
+      adapterData: adapterDataFixture({
+        communityMapActive: true,
+        nodes: [
+          nodeFixture("alpha", { relationFocusDepth: "focus" }),
+          nodeFixture("beta", { relationFocusDepth: "first" })
+        ]
+      })
+    });
+
+    fixture.controller.rebuild();
+
+    assert.equal(nodeTarget(fixture.overlayRoot, "alpha")?.dataset.relationFocusDepth, "focus");
+    assert.equal(nodeTarget(fixture.overlayRoot, "beta")?.dataset.relationFocusDepth, "first");
+  });
+
   it("binds pointer overlay drag and clears document listeners on pointerup", () => {
     const fixture = controllerFixture();
     fixture.controller.rebuild();
@@ -527,6 +544,7 @@ function nodeFixture(id: string, options: {
   searchHit?: boolean;
   pinned?: boolean;
   communityId?: string;
+  relationFocusDepth?: GraphRendererAdapterData["nodes"][number]["relationFocusDepth"];
 } = {}) {
   const index = Number(id.match(/\d+$/)?.[0] ?? 1);
   return {
@@ -539,7 +557,7 @@ function nodeFixture(id: string, options: {
     point: { x: 40 + index, y: 80 + index },
     selected: options.selected ?? false,
     searchHit: options.searchHit ?? false,
-    relationFocusDepth: "none" as const,
+    relationFocusDepth: options.relationFocusDepth ?? "none" as const,
     pinHint: {
       nodeId: id,
       wikiPath: `${id}.md`,

--- a/packages/graph-engine/test/sigma-zoom.test.ts
+++ b/packages/graph-engine/test/sigma-zoom.test.ts
@@ -15,7 +15,7 @@ describe("sigma zoom math", () => {
   it("keeps the zoom constants aligned with the global zoom design", () => {
     assert.equal(SIGMA_WHEEL_ZOOM_SPEED, 0.0016);
     assert.equal(SIGMA_CAMERA_MIN_RATIO, 0.3);
-    assert.equal(SIGMA_CAMERA_MAX_RATIO, 3);
+    assert.equal(SIGMA_CAMERA_MAX_RATIO, 8);
     assert.equal(SIGMA_BUTTON_ZOOM_RATIO, 1.18);
   });
 
@@ -52,7 +52,7 @@ describe("sigma zoom math", () => {
     assertClose(sigmaButtonZoomRatio(1, "in"), 1 / SIGMA_BUTTON_ZOOM_RATIO);
     assertClose(sigmaButtonZoomRatio(1, "out"), SIGMA_BUTTON_ZOOM_RATIO);
     assert.equal(sigmaButtonZoomRatio(0.31, "in"), SIGMA_CAMERA_MIN_RATIO);
-    assert.equal(sigmaButtonZoomRatio(2.9, "out"), SIGMA_CAMERA_MAX_RATIO);
+    assert.equal(sigmaButtonZoomRatio(7.9, "out"), SIGMA_CAMERA_MAX_RATIO);
   });
 });
 

--- a/tests/browser/graph-community-phase2-local-map.mjs
+++ b/tests/browser/graph-community-phase2-local-map.mjs
@@ -158,23 +158,21 @@ async function graphBlankPoint(page) {
     const host = document.querySelector(".sigma-global-route") || document.querySelector(".graph-host");
     if (!host) throw new Error("Missing Sigma global route for blank click");
     const rect = host.getBoundingClientRect();
-    const candidates = [
-      [0.08, 0.12],
-      [0.92, 0.12],
-      [0.08, 0.88],
-      [0.92, 0.88],
-      [0.5, 0.08],
-      [0.5, 0.92]
-    ];
+    const candidates = [];
+    for (const rx of [0.08, 0.18, 0.28, 0.38, 0.5, 0.62, 0.74, 0.86, 0.94]) {
+      for (const ry of [0.1, 0.2, 0.32, 0.44, 0.56, 0.68, 0.8, 0.9]) {
+        candidates.push([rx, ry]);
+      }
+    }
     for (const [rx, ry] of candidates) {
       const x = rect.left + rect.width * rx;
       const y = rect.top + rect.height * ry;
       const hit = document.elementFromPoint(x, y);
-      if (!hit?.closest?.(".drawer-panel-open, .drawer-panel, .sigma-global-community-region, .sigma-global-node-hit-target, .sigma-global-community-label, .sigma-global-aggregation-container")) {
+      if (!hit?.closest?.(".drawer-panel-open, .drawer-panel, .sigma-global-community-region, .sigma-global-node-hit-target, .sigma-global-community-label, .sigma-global-aggregation-container, .graph-toolbar, .graph-search")) {
         return { x, y };
       }
     }
-    return { x: rect.left + 12, y: rect.top + 12 };
+    throw new Error("Could not find a graph blank point outside communities, nodes, labels, and controls");
   });
 }
 

--- a/tests/browser/graph-community-reading-experience.mjs
+++ b/tests/browser/graph-community-reading-experience.mjs
@@ -1,0 +1,800 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const { chromium } = require("playwright");
+
+const workbenchUrl = process.env.GRAPH_COMMUNITY_EXPERIENCE_URL || "";
+const artifactDir = process.env.GRAPH_COMMUNITY_EXPERIENCE_ARTIFACT_DIR || "";
+const executablePath = process.env.GRAPH_COMMUNITY_EXPERIENCE_CHROME_EXECUTABLE || "";
+
+assert.notEqual(workbenchUrl, "", "GRAPH_COMMUNITY_EXPERIENCE_URL must point at the workbench dev server");
+assert.notEqual(artifactDir, "", "GRAPH_COMMUNITY_EXPERIENCE_ARTIFACT_DIR must point at an artifact directory");
+
+const COMMUNITY_CASES = [
+  { id: "dense-agent", slug: "dense-agent", label: "AI Agent 对比分析", minNodes: 16, minEdges: 18 },
+  { id: "small-chain", slug: "small-chain", label: "小型概念链", minNodes: 3, minEdges: 2 },
+  { id: "long-title", slug: "long-title", label: "长标题节点社区", minNodes: 5, minEdges: 4 },
+  { id: "edge-dense", slug: "edge-dense", label: "高密关系社区", minNodes: 7, minEdges: 10 },
+  { id: "flat-core", slug: "flat-core", label: "无明显核心社区", minNodes: 6, minEdges: 5 }
+];
+
+const browser = await chromium.launch(executablePath ? { executablePath } : {});
+
+try {
+  await fs.mkdir(artifactDir, { recursive: true });
+  const desktop = await runViewport({ width: 1440, height: 900 }, "desktop", { fullPath: true });
+  const narrow = await runViewport({ width: 390, height: 844 }, "narrow", { fullPath: false });
+  const report = {
+    checkedAt: new Date().toISOString(),
+    workbenchUrl,
+    visualReviewCriteria: [
+      "global ordinary",
+      "global selected community",
+      "Sigma community reading",
+      "color continuity",
+      "node-shape continuity",
+      "community centering/readability",
+      "quiet unselected community labels"
+    ],
+    desktop,
+    narrow
+  };
+  await fs.writeFile(path.join(artifactDir, "community-reading-experience-report.json"), `${JSON.stringify(report, null, 2)}\n`);
+  console.log(JSON.stringify(report, null, 2));
+} finally {
+  await closeBrowserForRegression(browser);
+}
+
+async function runViewport(viewport, label, options) {
+  const page = await openWorkbenchGraphPage(viewport);
+  const visualCases = [];
+  let fullPath = null;
+  try {
+    for (const community of COMMUNITY_CASES) {
+      await resetToPlainGlobal(page);
+      const global = await captureState(page, `${label}-${community.slug}-01-global.png`);
+
+      const selected = await openCommunitySummary(page, community);
+      const selectedShot = await captureState(page, `${label}-${community.slug}-02-selected.png`);
+      assert.equal(selected.summary.hasEnterCommunity, true, `${community.label}: summary should expose enter-community`);
+      assert.ok(selected.selected.dimmedLabelCount > 0, `${community.label}: unselected community labels should remain as quiet landmarks`);
+
+      await page.locator('[data-testid="graph-community-summary"] button', { hasText: "进入社区" }).click();
+      await waitForSigmaCommunityOrDump(page, community, label);
+      await page.waitForSelector('[data-testid="graph-community-summary"]', { state: "detached", timeout: 5_000 });
+      await waitForCommunityCentered(page, community, label);
+      await page.waitForTimeout(520);
+      await waitForCommunityCentered(page, community, label);
+      const readingShot = await captureState(page, `${label}-${community.slug}-03-community.png`);
+      const reading = await communityReadingSnapshot(page, community);
+      assertCommunityReading(community, reading);
+      assert.equal(
+        selected.selected.regionFill,
+        reading.regionFill,
+        `${community.label}: selected and reading community region color should stay continuous`
+      );
+
+      const record = { community, global, selected: selectedShot, reading: readingShot, readingState: reading };
+      visualCases.push(record);
+
+      if (options.fullPath && community.id === "dense-agent") {
+        fullPath = await runFullDesktopPath(page, community);
+      }
+
+      await clickReturnGlobal(page);
+      await waitForSigmaGlobalUnfocused(page);
+    }
+  } finally {
+    await page.close();
+  }
+  return { viewport: `${viewport.width}x${viewport.height}`, visualCases, fullPath };
+}
+
+async function runFullDesktopPath(page, community) {
+  const beforeSearch = await communityReadingSnapshot(page, community);
+  const hoverFocus = await hoverRelationFocus(page, "dense-overview", "dense-source-1");
+
+  await setGraphSearchQuery(page, "实践案例");
+  await page.waitForFunction(() => document.querySelector(".graph-search-status")?.textContent?.includes("1 个结果"));
+  assert.equal(await drawerTestId(page), "", "typing a community search query should not auto-open node content");
+  await page.locator('.graph-search-result-item[data-node-id="dense-source-1"]').click();
+  await page.waitForSelector(".graph-reader-drawer");
+  await page.waitForSelector('.sigma-global-node-hit-target[data-node-id="dense-source-1"][data-selected="true"]');
+  const afterSearchActivation = await interactionSnapshot(page, "dense-source-1");
+  assert.equal(afterSearchActivation.searchQuery, "实践案例", "search query should stay after result activation");
+  assert.equal(afterSearchActivation.drawerTestId, "graph-reader", "activating a search result should open node content");
+
+  await setTypeFilter(page, "source", false);
+  await page.waitForSelector('.sigma-community-hidden-node-hint[data-state="visible"]');
+  await page.waitForSelector(".graph-reader-hidden-badge");
+  const hiddenByFilter = await interactionSnapshot(page, "dense-source-1");
+  assert.equal(hiddenByFilter.hiddenReadingNode, "true", "filtering out the reading node should keep logical focus with a visible hint");
+  assert.equal(hiddenByFilter.drawerHiddenBadge, true, "reader title should explain the node is filtered hidden");
+
+  await setTypeFilter(page, "source", true);
+  await page.waitForFunction(() => {
+    return document.querySelector('.sigma-community-hidden-node-hint')?.getAttribute("data-state") === "hidden";
+  });
+  await page.waitForSelector('.sigma-global-node-hit-target[data-node-id="dense-source-1"][data-selected="true"]');
+
+  const beforeDrag = await nodeBox(page, "dense-source-1");
+  const drag = await dragSigmaNode(page, "dense-source-1", { dx: 72, dy: 28 });
+  await page.waitForSelector('.sigma-global-node-hit-target[data-node-id="dense-source-1"][data-pinned="true"]');
+  const afterDrag = await nodeBox(page, "dense-source-1");
+  assertPointShifted(afterDrag, beforeDrag, "dragging inside community reading should move the selected node");
+
+  await page.getByRole("button", { name: /重置布局/ }).click();
+  await page.waitForFunction(() => document.querySelector('.sigma-global-node-hit-target[data-node-id="dense-source-1"]')?.getAttribute("data-pinned") !== "true");
+  const afterReset = await interactionSnapshot(page, "dense-source-1");
+  assert.equal(afterReset.nodePinned, "false", "reset layout should clear the community drag pin");
+
+  await clickReturnGlobal(page);
+  await waitForSigmaGlobalUnfocused(page);
+  await waitForSelectedCommunity(page, community.id);
+  const returned = await sigmaSnapshot(page);
+  assert.equal(returned.communitySummaryOpen, false, "returning global should not reopen the community summary drawer");
+  assert.equal(returned.sourceCommunityId, community.id, "returning global should keep source community context");
+  assert.equal(returned.searchQuery, "", "returning global should clear community-local search");
+  assert.equal(returned.typeFiltersActive, false, "returning global should clear community-local type filters");
+
+  return { beforeSearch, hoverFocus, afterSearchActivation, hiddenByFilter, drag, afterDrag, afterReset, returned };
+}
+
+async function openWorkbenchGraphPage(viewport) {
+  const page = await browser.newPage({ viewport });
+  page.__graphDiagnostics = [];
+  page.on("console", (message) => {
+    if (message.type() !== "error" && message.type() !== "warning") return;
+    pushGraphDiagnostic(page, {
+      kind: "console",
+      type: message.type(),
+      text: message.text()
+    });
+  });
+  page.on("pageerror", (error) => {
+    pushGraphDiagnostic(page, {
+      kind: "pageerror",
+      message: error.message
+    });
+  });
+  page.on("requestfailed", (request) => {
+    if (!request.url().includes("/api/")) return;
+    pushGraphDiagnostic(page, {
+      kind: "requestfailed",
+      method: request.method(),
+      url: request.url(),
+      failure: request.failure()?.errorText || ""
+    });
+  });
+  page.on("response", async (response) => {
+    if (!response.url().includes("/api/")) return;
+    const contentType = response.headers()["content-type"] || "";
+    let bodyPreview = "";
+    if (!contentType.includes("text/event-stream")) {
+      bodyPreview = await response.text().catch((error) => `<<body unavailable: ${error.message}>>`);
+    }
+    pushGraphDiagnostic(page, {
+      kind: "response",
+      method: response.request().method(),
+      url: response.url(),
+      status: response.status(),
+      contentType,
+      bodyLength: bodyPreview.length,
+      bodyPreview: bodyPreview.slice(0, 220)
+    });
+  });
+  await page.addInitScript(() => {
+    window.localStorage.setItem("llm-wiki-agent-main-view", "graph");
+    window.localStorage.setItem("llm-wiki-agent-theme", "light");
+    window.localStorage.setItem("llm-wiki-agent-drawer-width", "320");
+    window.localStorage.setItem("llm-wiki-agent-sidebar-collapsed", "true");
+    window.localStorage.setItem("llm-wiki:graph:toolbar:panel", "closed");
+  });
+  await page.goto(workbenchUrl);
+  await page.waitForSelector(".app-shell");
+  const kbButton = page.getByRole("button", { name: /Sigma Community Experience|sigma-community-experience/ });
+  if (await kbButton.count() && await kbButton.first().isVisible()) await kbButton.first().click();
+  const graphButton = page.getByRole("button", { name: /图谱/ });
+  if (await graphButton.count() && await graphButton.first().isVisible() && await graphButton.first().isEnabled()) {
+    await graphButton.first().click();
+  }
+  await waitForSigmaGlobal(page);
+  return page;
+}
+
+function pushGraphDiagnostic(page, entry) {
+  const diagnostics = page.__graphDiagnostics || [];
+  diagnostics.push({ at: new Date().toISOString(), ...entry });
+  page.__graphDiagnostics = diagnostics.slice(-80);
+}
+
+async function captureState(page, filename) {
+  const screenshotPath = path.join(artifactDir, filename);
+  await page.screenshot({ fullPage: true, path: screenshotPath });
+  return { screenshotPath, snapshot: await sigmaSnapshot(page) };
+}
+
+async function resetToPlainGlobal(page) {
+  await closeDrawerIfOpen(page);
+  await clickReturnGlobal(page);
+  await waitForSigmaGlobalUnfocused(page);
+  await closeGraphToolbarPanel(page);
+  await clickGlobalBlank(page);
+  await waitForPlainGlobal(page);
+  await clickReturnGlobal(page);
+  await waitForPlainGlobal(page);
+  await page.waitForTimeout(450);
+}
+
+async function closeGraphToolbarPanel(page) {
+  const toolbar = page.locator(".graph-toolbar").first();
+  const open = await toolbar.evaluate((element) => element.getAttribute("data-panel") !== "closed").catch(() => false);
+  if (!open) return;
+  const panel = await toolbar.evaluate((element) => element.getAttribute("data-panel")).catch(() => "");
+  const buttonName = panel === "legend" ? "图例" : "筛选";
+  await toolbar.evaluate((element, buttonName) => {
+    const button = [...element.querySelectorAll("button")]
+      .find((item) => item.textContent?.trim() === buttonName);
+    button?.click();
+  }, buttonName);
+  await page.waitForFunction(() => document.querySelector(".graph-toolbar")?.getAttribute("data-panel") === "closed", undefined, { timeout: 2_000 })
+    .catch(async (error) => {
+      const current = await toolbar.evaluate((element) => element.getAttribute("data-panel")).catch(() => "closed");
+      if (current !== "closed") throw error;
+    });
+}
+
+async function openCommunitySummaryFromRegion(page, communityId) {
+  await closeDrawerIfOpen(page);
+  await clickCommunityRegion(page, communityId);
+  try {
+    await page.waitForSelector('[data-testid="graph-community-summary"]');
+  } catch (error) {
+    const screenshotPath = path.join(artifactDir, `summary-open-timeout-${communityId}.png`);
+    await page.screenshot({ fullPage: true, path: screenshotPath }).catch(() => undefined);
+    const diagnostics = await communityRegionDiagnostics(page, communityId).catch((diagnosticError) => ({ error: String(diagnosticError) }));
+    throw new assert.AssertionError({
+      message: `${communityId}: community summary did not open. Diagnostics: ${JSON.stringify({ screenshotPath, diagnostics })}`,
+      actual: error,
+      expected: "community summary drawer",
+      operator: "strictEqual"
+    });
+  }
+  return {
+    selected: await selectedCommunitySnapshot(page, communityId),
+    summary: await communitySummarySnapshot(page)
+  };
+}
+
+async function openCommunitySummary(page, community) {
+  try {
+    const selected = await openCommunitySummaryFromRegion(page, community.id);
+    assertSelectedCommunity(community, selected);
+    return selected;
+  } catch (error) {
+    pushGraphDiagnostic(page, {
+      kind: "community-region-open-fallback",
+      communityId: community.id,
+      message: error instanceof Error ? error.message : String(error)
+    });
+  }
+  const selected = await openCommunitySummaryFromToolbar(page, community.id);
+  assertSelectedCommunity(community, selected);
+  return selected;
+}
+
+async function openCommunitySummaryFromToolbar(page, communityId) {
+  await closeDrawerIfOpen(page);
+  await ensureFilterPanelOpen(page);
+  const legend = page.locator(".community-legend");
+  await legend.waitFor();
+  const collapsed = await legend.evaluate((element) => element.getAttribute("data-state") === "collapsed");
+  if (collapsed) {
+    await page.locator(".community-legend-toggle").click({ force: true });
+  }
+  await page.locator(`.community-legend-row[data-community-id="${cssString(communityId)}"]`).click({ force: true });
+  await page.waitForSelector('[data-testid="graph-community-summary"]');
+  await closeGraphToolbarPanel(page);
+  return {
+    selected: await selectedCommunitySnapshot(page, communityId),
+    summary: await communitySummarySnapshot(page)
+  };
+}
+
+function assertSelectedCommunity(community, selected) {
+  assert.deepEqual(
+    selected.selected.selectedRegions,
+    [community.id],
+    `${community.label}: global selected state should target the requested community`
+  );
+  assert.deepEqual(
+    selected.selected.selectedLabels,
+    [community.id],
+    `${community.label}: global selected label should target the requested community`
+  );
+}
+
+async function communityRegionDiagnostics(page, communityId) {
+  return page.evaluate((communityId) => {
+    const region = document.querySelector(`.sigma-global-community-region[data-community-id="${CSS.escape(communityId)}"]`);
+    const rect = region?.getBoundingClientRect();
+    if (!rect) return { missing: true };
+    const candidates = [
+      [0.5, 0.5],
+      [0.5, 0.34],
+      [0.34, 0.5],
+      [0.66, 0.5],
+      [0.5, 0.66],
+      [0.25, 0.25],
+      [0.75, 0.75]
+    ];
+    return {
+      rect: rectOf(rect),
+      candidates: candidates.map(([rx, ry]) => {
+        const x = rect.left + rect.width * rx;
+        const y = rect.top + rect.height * ry;
+        const hit = document.elementFromPoint(x, y);
+        return {
+          rx,
+          ry,
+          x: Math.round(x * 1000) / 1000,
+          y: Math.round(y * 1000) / 1000,
+          tag: hit?.tagName || "",
+          className: String(hit?.getAttribute?.("class") || ""),
+          nodeId: hit?.closest?.(".sigma-global-node-hit-target")?.getAttribute("data-node-id") || "",
+          regionId: hit?.closest?.(".sigma-global-community-region")?.getAttribute("data-community-id") || "",
+          labelId: hit?.closest?.(".sigma-global-community-label")?.getAttribute("data-community-id") || ""
+        };
+      })
+    };
+
+    function rectOf(value) {
+      return {
+        left: Math.round(value.left * 1000) / 1000,
+        top: Math.round(value.top * 1000) / 1000,
+        width: Math.round(value.width * 1000) / 1000,
+        height: Math.round(value.height * 1000) / 1000,
+        right: Math.round(value.right * 1000) / 1000,
+        bottom: Math.round(value.bottom * 1000) / 1000
+      };
+    }
+  }, communityId);
+}
+
+async function selectedCommunitySnapshot(page, communityId) {
+  return page.evaluate((communityId) => {
+    const selectedRegion = document.querySelector(`.sigma-global-community-region[data-community-id="${CSS.escape(communityId)}"]`);
+    const selectedShape = selectedRegion?.querySelector("svg *");
+    return {
+      selectedRegions: Array.from(document.querySelectorAll(".sigma-global-community-region[data-selected='true']"))
+        .map((region) => region.getAttribute("data-community-id") || "")
+        .filter(Boolean)
+        .sort(),
+      selectedLabels: Array.from(document.querySelectorAll(".sigma-global-community-label[data-selected='true']"))
+        .map((label) => label.getAttribute("data-community-id") || "")
+        .filter(Boolean)
+        .sort(),
+      dimmedLabelCount: Array.from(document.querySelectorAll(".sigma-global-community-label[data-dim='true']")).length,
+      regionFill: selectedShape ? getComputedStyle(selectedShape).fill : ""
+    };
+  }, communityId);
+}
+
+async function communitySummarySnapshot(page) {
+  return page.evaluate(() => {
+    const drawer = document.querySelector('[data-testid="graph-community-summary"]');
+    return {
+      title: drawer?.querySelector("h2")?.textContent || "",
+      hasEnterCommunity: [...(drawer?.querySelectorAll("button") || [])].some((button) => button.textContent?.includes("进入社区"))
+    };
+  });
+}
+
+async function communityReadingSnapshot(page, community) {
+  return page.evaluate((community) => {
+    const stage = document.querySelector(".graph-stage")?.getBoundingClientRect();
+    const route = document.querySelector(".sigma-global-route");
+    const renderer = document.querySelector(".sigma-global-renderer");
+    const region = document.querySelector(`.sigma-global-community-region[data-community-id="${CSS.escape(community.id)}"]`);
+    const shape = region?.querySelector("svg *");
+    const regionRect = region?.getBoundingClientRect();
+    const centerDistance = stage && regionRect ? {
+      x: round((regionRect.left + regionRect.width / 2) - (stage.left + stage.width / 2)),
+      y: round((regionRect.top + regionRect.height / 2) - (stage.top + stage.height / 2)),
+      xRatio: round(Math.abs((regionRect.left + regionRect.width / 2) - (stage.left + stage.width / 2)) / Math.max(1, stage.width)),
+      yRatio: round(Math.abs((regionRect.top + regionRect.height / 2) - (stage.top + stage.height / 2)) / Math.max(1, stage.height))
+    } : null;
+    return {
+      route: document.querySelector(".graph-host")?.getAttribute("data-llm-wiki-graph-route") || "",
+      renderer: renderer?.getAttribute("data-renderer") || "",
+      nodeCount: Number(renderer?.getAttribute("data-node-count") || "0"),
+      edgeCount: Number(renderer?.getAttribute("data-edge-count") || "0"),
+      communityFocusId: renderer?.getAttribute("data-community-focus-id") || "",
+      sourceCommunityId: renderer?.getAttribute("data-source-community-id") || "",
+      communityMapLabelLimit: Number(renderer?.getAttribute("data-community-map-label-limit") || "0"),
+      communityMapVisibleLabels: Number(renderer?.getAttribute("data-community-map-visible-labels") || "0"),
+      hiddenReadingNode: route?.getAttribute("data-hidden-reading-node") || "",
+      communitySummaryOpen: Boolean(document.querySelector('[data-testid="graph-community-summary"]')),
+      readerOpen: Boolean(document.querySelector(".graph-reader-drawer")),
+      regionCount: document.querySelectorAll(".sigma-global-community-region").length,
+      labelCount: document.querySelectorAll(".sigma-global-community-label").length,
+      regionFill: shape ? getComputedStyle(shape).fill : "",
+      stage: stage ? rectOf(stage) : null,
+      region: regionRect ? rectOf(regionRect) : null,
+      centerDistance
+    };
+
+    function rectOf(rect) {
+      return {
+        left: round(rect.left),
+        top: round(rect.top),
+        width: round(rect.width),
+        height: round(rect.height),
+        right: round(rect.right),
+        bottom: round(rect.bottom)
+      };
+    }
+    function round(value) {
+      return Math.round(value * 1000) / 1000;
+    }
+  }, community);
+}
+
+function assertCommunityReading(community, snapshot) {
+  assert.equal(snapshot.route, "sigma-global", `${community.label}: community reading should stay on Sigma route`);
+  assert.equal(snapshot.renderer, "sigma-global", `${community.label}: Sigma renderer should remain mounted`);
+  assert.equal(snapshot.communityFocusId, community.id, `${community.label}: should focus the requested community`);
+  assert.equal(snapshot.sourceCommunityId, community.id, `${community.label}: should keep source community context`);
+  assert.equal(snapshot.communitySummaryOpen, false, `${community.label}: community summary drawer should close on entry`);
+  assert.equal(snapshot.readerOpen, false, `${community.label}: node reader should not open by default`);
+  assert.equal(snapshot.regionCount, 1, `${community.label}: only focused community region should remain`);
+  assert.equal(snapshot.labelCount, 1, `${community.label}: only current community location label should remain`);
+  assert.ok(snapshot.nodeCount >= community.minNodes, `${community.label}: should show current community nodes`);
+  assert.ok(snapshot.edgeCount >= community.minEdges, `${community.label}: should show internal community relationships`);
+  assert.ok(snapshot.centerDistance, `${community.label}: should provide centering geometry`);
+  assert.ok(snapshot.centerDistance.xRatio <= 0.28, `${community.label}: community should be horizontally centered enough (${snapshot.centerDistance.xRatio})`);
+  assert.ok(snapshot.centerDistance.yRatio <= 0.28, `${community.label}: community should be vertically centered enough (${snapshot.centerDistance.yRatio})`);
+  assert.ok(
+    snapshot.region.width > 40 && snapshot.region.height > 40,
+    `${community.label}: community region should be visible and readable. Snapshot: ${JSON.stringify(snapshot)}`
+  );
+}
+
+async function interactionSnapshot(page, nodeId) {
+  return page.evaluate((nodeId) => {
+    const route = document.querySelector(".sigma-global-route");
+    const node = document.querySelector(`.sigma-global-node-hit-target[data-node-id="${CSS.escape(nodeId)}"]`);
+    return {
+      drawerTestId: document.querySelector(".drawer-panel-open .graph-reader-drawer") ? "graph-reader" : "",
+      searchQuery: document.querySelector(".graph-search-input")?.value || "",
+      hiddenReadingNode: route?.getAttribute("data-hidden-reading-node") || "",
+      hiddenReadingNodeId: route?.getAttribute("data-hidden-reading-node-id") || "",
+      drawerHiddenBadge: Boolean(document.querySelector(".graph-reader-hidden-badge")),
+      nodeSelected: node?.getAttribute("data-selected") || "",
+      nodePinned: node?.getAttribute("data-pinned") || ""
+    };
+  }, nodeId);
+}
+
+async function hoverRelationFocus(page, focusNodeId, firstNeighborId) {
+  const focusBox = await nodeBox(page, focusNodeId);
+  await page.mouse.move(focusBox.centerX, focusBox.centerY);
+  await page.waitForSelector(`.sigma-global-node-hit-target[data-node-id="${cssString(focusNodeId)}"][data-relation-focus-depth="focus"]`);
+  await page.waitForSelector(`.sigma-global-node-hit-target[data-node-id="${cssString(firstNeighborId)}"][data-relation-focus-depth="first"]`);
+  return page.evaluate(({ focusNodeId, firstNeighborId }) => {
+    const node = (id) => document.querySelector(`.sigma-global-node-hit-target[data-node-id="${CSS.escape(id)}"]`);
+    return {
+      focusNodeId,
+      focusDepth: node(focusNodeId)?.getAttribute("data-relation-focus-depth") || "",
+      firstNeighborId,
+      firstNeighborDepth: node(firstNeighborId)?.getAttribute("data-relation-focus-depth") || ""
+    };
+  }, { focusNodeId, firstNeighborId });
+}
+
+async function sigmaSnapshot(page) {
+  return page.evaluate(() => ({
+    nodeCount: Number(document.querySelector(".sigma-global-renderer")?.getAttribute("data-node-count") || "0"),
+    edgeCount: Number(document.querySelector(".sigma-global-renderer")?.getAttribute("data-edge-count") || "0"),
+    communityCount: Number(document.querySelector(".sigma-global-renderer")?.getAttribute("data-community-count") || "0"),
+    communityFocusId: document.querySelector(".sigma-global-renderer")?.getAttribute("data-community-focus-id") || "",
+    sourceCommunityId: document.querySelector(".sigma-global-renderer")?.getAttribute("data-source-community-id") || "",
+    selectedRegions: Array.from(document.querySelectorAll(".sigma-global-community-region[data-selected='true']"))
+      .map((region) => region.getAttribute("data-community-id") || "")
+      .filter(Boolean)
+      .sort(),
+    selectedLabels: Array.from(document.querySelectorAll(".sigma-global-community-label[data-selected='true']"))
+      .map((label) => label.getAttribute("data-community-id") || "")
+      .filter(Boolean)
+      .sort(),
+    communitySummaryOpen: Boolean(document.querySelector('[data-testid="graph-community-summary"]')),
+    searchQuery: document.querySelector(".graph-search-input")?.value || "",
+    typeFiltersActive: document.querySelector(".sigma-global-route")?.getAttribute("data-type-filters-active") === "true"
+  }));
+}
+
+async function waitForSigmaGlobal(page) {
+  await page.waitForSelector(".sigma-global-route[data-route='sigma-global']");
+  await page.waitForSelector(".sigma-global-renderer[data-renderer='sigma-global']");
+  await page.waitForSelector(".sigma-global-community-region");
+  await page.waitForSelector(".sigma-global-community-label");
+}
+
+async function waitForSigmaCommunity(page, communityId) {
+  await waitForSigmaGlobal(page);
+  await page.waitForFunction((communityId) => {
+    const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
+    const visibleRegions = document.querySelectorAll(".sigma-global-community-region");
+    const visibleLabels = document.querySelectorAll(".sigma-global-community-label");
+    return root?.getAttribute("data-community-focus-id") === communityId
+      && root?.getAttribute("data-source-community-id") === communityId
+      && visibleRegions.length === 1
+      && visibleLabels.length === 1;
+  }, communityId);
+}
+
+async function waitForSigmaCommunityOrDump(page, community, viewportLabel) {
+  try {
+    await waitForSigmaCommunity(page, community.id);
+  } catch (error) {
+    const screenshotPath = path.join(artifactDir, `${viewportLabel}-${community.slug}-enter-timeout.png`);
+    await page.screenshot({ fullPage: true, path: screenshotPath }).catch(() => undefined);
+    const snapshot = await sigmaSnapshot(page).catch((snapshotError) => ({ snapshotError: String(snapshotError) }));
+    const diagnostics = page.__graphDiagnostics || [];
+    throw new assert.AssertionError({
+      message: `${community.label}: enter-community did not reach Sigma community reading. Diagnostics: ${JSON.stringify({ screenshotPath, snapshot, diagnostics })}`,
+      actual: error,
+      expected: "focused Sigma community reading",
+      operator: "strictEqual"
+    });
+  }
+}
+
+async function waitForCommunityCentered(page, community, viewportLabel) {
+  try {
+    await page.waitForFunction((community) => {
+      const stage = document.querySelector(".graph-stage")?.getBoundingClientRect();
+      const region = document.querySelector(`.sigma-global-community-region[data-community-id="${CSS.escape(community.id)}"]`)?.getBoundingClientRect();
+      if (!stage || !region || region.width <= 0 || region.height <= 0) return false;
+      const xRatio = Math.abs((region.left + region.width / 2) - (stage.left + stage.width / 2)) / Math.max(1, stage.width);
+      const yRatio = Math.abs((region.top + region.height / 2) - (stage.top + stage.height / 2)) / Math.max(1, stage.height);
+      return xRatio <= 0.28 && yRatio <= 0.28;
+    }, community, { timeout: 4_000 });
+  } catch (error) {
+    const screenshotPath = path.join(artifactDir, `${viewportLabel}-${community.slug}-center-timeout.png`);
+    await page.screenshot({ fullPage: true, path: screenshotPath }).catch(() => undefined);
+    const snapshot = await communityReadingSnapshot(page, community).catch((snapshotError) => ({ snapshotError: String(snapshotError) }));
+    throw new assert.AssertionError({
+      message: `${community.label}: community did not settle centered enough. Diagnostics: ${JSON.stringify({ screenshotPath, snapshot })}`,
+      actual: error,
+      expected: "centered community reading",
+      operator: "strictEqual"
+    });
+  }
+}
+
+async function waitForSigmaGlobalUnfocused(page) {
+  await waitForSigmaGlobal(page);
+  await page.waitForFunction(() => {
+    const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
+    return root?.getAttribute("data-community-focus-id") === ""
+      && Number(root?.getAttribute("data-community-count") || "0") > 1;
+  });
+}
+
+async function waitForSelectedCommunity(page, communityId) {
+  await page.waitForFunction((communityId) => {
+    return [...document.querySelectorAll(".sigma-global-community-region[data-selected='true']")]
+      .map((region) => region.getAttribute("data-community-id") || "")
+      .includes(communityId);
+  }, communityId);
+}
+
+async function waitForNoSelectedCommunity(page) {
+  await page.waitForFunction(() => {
+    return document.querySelectorAll(".sigma-global-community-region[data-selected='true']").length === 0
+      && document.querySelectorAll(".sigma-global-community-label[data-selected='true']").length === 0;
+  });
+}
+
+async function waitForPlainGlobal(page) {
+  await waitForNoSelectedCommunity(page);
+  await page.waitForFunction(() => {
+    const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
+    return root?.getAttribute("data-community-focus-id") === ""
+      && root?.getAttribute("data-source-community-id") === "";
+  });
+}
+
+async function clickCommunityRegion(page, communityId) {
+  const point = await findCommunityRegionPoint(page, communityId);
+  await page.mouse.click(point.x, point.y);
+}
+
+async function findCommunityRegionPoint(page, communityId) {
+  return page.evaluate((communityId) => {
+    const region = document.querySelector(`.sigma-global-community-region[data-community-id="${CSS.escape(communityId)}"]`);
+    if (!region) throw new Error(`Missing Sigma community region ${communityId}`);
+    const rect = region.getBoundingClientRect();
+    const candidates = [
+      [0.5, 0.5],
+      [0.5, 0.34],
+      [0.34, 0.5],
+      [0.66, 0.5],
+      [0.5, 0.66]
+    ];
+    for (const [rx, ry] of candidates) {
+      const x = rect.left + rect.width * rx;
+      const y = rect.top + rect.height * ry;
+      const hit = document.elementFromPoint(x, y);
+      const hitRegionId = hit?.closest?.(".sigma-global-community-region")?.getAttribute("data-community-id") || "";
+      if (hitRegionId === communityId && !hit?.closest?.(".sigma-global-node-hit-target")) return { x, y };
+    }
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  }, communityId);
+}
+
+async function clickGlobalBlank(page) {
+  const point = await graphBlankPoint(page);
+  await page.mouse.click(point.x, point.y);
+}
+
+async function graphBlankPoint(page) {
+  return page.evaluate(() => {
+    const host = document.querySelector(".sigma-global-route") || document.querySelector(".graph-host");
+    if (!host) throw new Error("Missing Sigma global route for blank click");
+    const rect = host.getBoundingClientRect();
+    const candidates = [];
+    for (const rx of [0.08, 0.18, 0.28, 0.38, 0.5, 0.62, 0.74, 0.86, 0.94]) {
+      for (const ry of [0.1, 0.2, 0.32, 0.44, 0.56, 0.68, 0.8, 0.9]) {
+        candidates.push([rx, ry]);
+      }
+    }
+    for (const [rx, ry] of candidates) {
+      const x = rect.left + rect.width * rx;
+      const y = rect.top + rect.height * ry;
+      const hit = document.elementFromPoint(x, y);
+      if (!hit?.closest?.(".drawer-panel-open, .drawer-panel, .sigma-global-community-region, .sigma-global-node-hit-target, .sigma-global-community-label, .sigma-global-aggregation-container, .graph-toolbar, .graph-search")) {
+        return { x, y };
+      }
+    }
+    throw new Error("Could not find a graph blank point outside communities, nodes, labels, and controls");
+  });
+}
+
+async function clickReturnGlobal(page) {
+  await page.getByRole("button", { name: "回全图" }).click({ force: true }).catch(() => undefined);
+  const returned = await page.waitForFunction(() => {
+    const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
+    return root?.getAttribute("data-community-focus-id") === ""
+      && Number(root?.getAttribute("data-community-count") || "0") > 1;
+  }, undefined, { timeout: 1200 })
+    .then(() => true)
+    .catch(() => false);
+  if (returned) return;
+  await dispatchGraphBlankDoubleClick(page);
+}
+
+async function dispatchGraphBlankDoubleClick(page) {
+  const rootFound = await page.evaluate(() => {
+    const root = document.querySelector(".sigma-global-renderer") || document.querySelector("[data-llm-wiki-graph-root='true']");
+    if (!root) return false;
+    const rect = root.getBoundingClientRect();
+    const x = rect.left + Math.max(12, Math.min(32, rect.width * 0.08));
+    const y = rect.top + Math.max(12, Math.min(32, rect.height * 0.08));
+    root.dispatchEvent(new MouseEvent("dblclick", {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+      detail: 2,
+      view: window
+    }));
+    return true;
+  });
+  assert.equal(rootFound, true, "graph blank double-click fallback should dispatch to the graph root");
+}
+
+async function closeDrawerIfOpen(page) {
+  const button = page.locator(".drawer-header button[aria-label='关闭']");
+  if (await button.count()) {
+    await button.first().click({ force: true });
+    await page.waitForSelector(".drawer-panel-open", { state: "detached", timeout: 3_000 }).catch(() => undefined);
+  }
+}
+
+async function drawerTestId(page) {
+  return page.evaluate(() => {
+    if (document.querySelector(".drawer-panel-open .graph-reader-drawer")) return "graph-reader";
+    return document.querySelector(".drawer-panel-open [data-testid]")?.getAttribute("data-testid") || "";
+  });
+}
+
+async function setGraphSearchQuery(page, query) {
+  const input = page.locator(".graph-search-input");
+  await input.waitFor();
+  await input.fill(query);
+}
+
+async function setTypeFilter(page, type, enabled) {
+  await ensureFilterPanelOpen(page);
+  const locator = page.locator(`.graph-type-filter input[data-type="${cssString(type)}"]`);
+  await locator.waitFor();
+  await locator.setChecked(enabled);
+}
+
+async function ensureFilterPanelOpen(page) {
+  const open = await page.locator('.graph-toolbar[data-panel="filters"]').count();
+  if (open) return;
+  await page.getByRole("button", { name: "筛选" }).click();
+  await page.waitForSelector('.graph-toolbar[data-panel="filters"]');
+}
+
+async function nodeBox(page, nodeId) {
+  return page.locator(`.sigma-global-node-hit-target[data-node-id="${cssString(nodeId)}"]`).evaluate((node) => {
+    const rect = node.getBoundingClientRect();
+    return {
+      left: round(rect.left),
+      top: round(rect.top),
+      width: round(rect.width),
+      height: round(rect.height),
+      centerX: round(rect.left + rect.width / 2),
+      centerY: round(rect.top + rect.height / 2)
+    };
+    function round(value) {
+      return Math.round(value * 1000) / 1000;
+    }
+  });
+}
+
+async function dragSigmaNode(page, nodeId, delta) {
+  const locator = page.locator(`.sigma-global-node-hit-target[data-node-id="${cssString(nodeId)}"]`);
+  await locator.waitFor();
+  const start = await nodeBox(page, nodeId);
+  const end = { x: start.centerX + delta.dx, y: start.centerY + delta.dy };
+  await page.mouse.move(start.centerX, start.centerY);
+  await page.mouse.down();
+  await page.mouse.move(start.centerX + delta.dx / 2, start.centerY + delta.dy / 2, { steps: 6 });
+  await page.mouse.move(end.x, end.y, { steps: 6 });
+  await page.mouse.up();
+  return {
+    start: { x: round(start.centerX), y: round(start.centerY) },
+    end: { x: round(end.x), y: round(end.y) },
+    delta
+  };
+}
+
+function assertPointShifted(after, before, label) {
+  assert.ok(
+    Math.abs(after.centerX - before.centerX) >= 12 || Math.abs(after.centerY - before.centerY) >= 12,
+    `${label}: before=${JSON.stringify(before)} after=${JSON.stringify(after)}`
+  );
+}
+
+function cssString(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function round(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+async function closeBrowserForRegression(browser) {
+  let closed = false;
+  const closePromise = browser.close()
+    .then(() => {
+      closed = true;
+    })
+    .catch(() => {
+      closed = true;
+    });
+  await Promise.race([
+    closePromise,
+    new Promise((resolve) => setTimeout(resolve, 5_000))
+  ]);
+  const browserProcess = typeof browser.process === "function" ? browser.process() : null;
+  if (!closed) browserProcess?.kill("SIGKILL");
+}

--- a/tests/browser/graph-community-reading-experience.mjs
+++ b/tests/browser/graph-community-reading-experience.mjs
@@ -71,13 +71,10 @@ async function runViewport(viewport, label, options) {
       const readingShot = await captureState(page, `${label}-${community.slug}-03-community.png`);
       const reading = await communityReadingSnapshot(page, community);
       assertCommunityReading(community, reading);
-      assert.equal(
-        selected.selected.regionFill,
-        reading.regionFill,
-        `${community.label}: selected and reading community region color should stay continuous`
-      );
+      const visualReview = reviewVisualContinuity(community, selected.selected, reading);
+      assertVisualReview(visualReview);
 
-      const record = { community, global, selected: selectedShot, reading: readingShot, readingState: reading };
+      const record = { community, global, selected: selectedShot, reading: readingShot, readingState: reading, visualReview };
       visualCases.push(record);
 
       if (options.fullPath && community.id === "dense-agent") {
@@ -110,6 +107,11 @@ async function runFullDesktopPath(page, community) {
   await setTypeFilter(page, "source", false);
   await page.waitForSelector('.sigma-community-hidden-node-hint[data-state="visible"]');
   await page.waitForSelector(".graph-reader-hidden-badge");
+  await page.waitForFunction(() => {
+    const status = document.querySelector(".graph-search-status")?.textContent || "";
+    return status.includes("0 个结果");
+  });
+  assert.equal(await page.locator('.graph-search-result-item[data-node-id="dense-source-1"]').count(), 0, "type filter should remove hidden nodes from community search results");
   const hiddenByFilter = await interactionSnapshot(page, "dense-source-1");
   assert.equal(hiddenByFilter.hiddenReadingNode, "true", "filtering out the reading node should keep logical focus with a visible hint");
   assert.equal(hiddenByFilter.drawerHiddenBadge, true, "reader title should explain the node is filtered hidden");
@@ -222,6 +224,7 @@ async function resetToPlainGlobal(page) {
   await clickReturnGlobal(page);
   await waitForSigmaGlobalUnfocused(page);
   await closeGraphToolbarPanel(page);
+  await page.waitForTimeout(520);
   await clickGlobalBlank(page);
   await waitForPlainGlobal(page);
   await clickReturnGlobal(page);
@@ -270,18 +273,7 @@ async function openCommunitySummaryFromRegion(page, communityId) {
 }
 
 async function openCommunitySummary(page, community) {
-  try {
-    const selected = await openCommunitySummaryFromRegion(page, community.id);
-    assertSelectedCommunity(community, selected);
-    return selected;
-  } catch (error) {
-    pushGraphDiagnostic(page, {
-      kind: "community-region-open-fallback",
-      communityId: community.id,
-      message: error instanceof Error ? error.message : String(error)
-    });
-  }
-  const selected = await openCommunitySummaryFromToolbar(page, community.id);
+  const selected = await openCommunitySummaryFromRegion(page, community.id);
   assertSelectedCommunity(community, selected);
   return selected;
 }
@@ -320,6 +312,7 @@ function assertSelectedCommunity(community, selected) {
 async function communityRegionDiagnostics(page, communityId) {
   return page.evaluate((communityId) => {
     const region = document.querySelector(`.sigma-global-community-region[data-community-id="${CSS.escape(communityId)}"]`);
+    const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
     const rect = region?.getBoundingClientRect();
     if (!rect) return { missing: true };
     const candidates = [
@@ -378,8 +371,24 @@ async function selectedCommunitySnapshot(page, communityId) {
         .filter(Boolean)
         .sort(),
       dimmedLabelCount: Array.from(document.querySelectorAll(".sigma-global-community-label[data-dim='true']")).length,
-      regionFill: selectedShape ? getComputedStyle(selectedShape).fill : ""
+      regionFill: selectedShape ? getComputedStyle(selectedShape).fill : "",
+      region: selectedRegion ? rectOf(selectedRegion.getBoundingClientRect()) : null,
+      nodeLabelNoiseCount: Array.from(document.querySelectorAll(".sigma-global-node-hit-target[data-community-dimmed='true']")).filter((node) => {
+        const label = node.getAttribute("aria-label") || "";
+        const id = node.getAttribute("data-node-id") || "";
+        return label && label !== id;
+      }).length
     };
+
+    function rectOf(rect) {
+      return {
+        width: round(rect.width),
+        height: round(rect.height)
+      };
+    }
+    function round(value) {
+      return Math.round(value * 1000) / 1000;
+    }
   }, communityId);
 }
 
@@ -460,6 +469,77 @@ function assertCommunityReading(community, snapshot) {
   assert.ok(
     snapshot.region.width > 40 && snapshot.region.height > 40,
     `${community.label}: community region should be visible and readable. Snapshot: ${JSON.stringify(snapshot)}`
+  );
+}
+
+function reviewVisualContinuity(community, selected, reading) {
+  const selectedAspectRatio = selected.region ? selected.region.width / Math.max(1, selected.region.height) : 0;
+  const readingAspectRatio = reading.region ? reading.region.width / Math.max(1, reading.region.height) : 0;
+  const aspectDrift = selectedAspectRatio && readingAspectRatio
+    ? Math.abs(selectedAspectRatio - readingAspectRatio) / Math.max(selectedAspectRatio, readingAspectRatio)
+    : 1;
+  const checks = [
+    {
+      name: "color continuity",
+      pass: selected.regionFill === reading.regionFill,
+      details: {
+        selectedRegionFill: selected.regionFill,
+        readingRegionFill: reading.regionFill
+      }
+    },
+    {
+      name: "node-shape continuity",
+      pass: aspectDrift <= 0.38,
+      details: {
+        selectedAspectRatio: round(selectedAspectRatio),
+        readingAspectRatio: round(readingAspectRatio),
+        aspectDrift: round(aspectDrift)
+      }
+    },
+    {
+      name: "community centering/readability",
+      pass: Boolean(reading.centerDistance)
+        && reading.centerDistance.xRatio <= 0.28
+        && reading.centerDistance.yRatio <= 0.28
+        && reading.region?.width > 40
+        && reading.region?.height > 40
+        && reading.communityMapVisibleLabels <= reading.communityMapLabelLimit,
+      details: {
+        centerDistance: reading.centerDistance,
+        region: reading.region,
+        labelBudget: {
+          limit: reading.communityMapLabelLimit,
+          visible: reading.communityMapVisibleLabels
+        }
+      }
+    },
+    {
+      name: "quiet unselected community landmarks",
+      pass: selected.dimmedLabelCount > 0
+        && selected.nodeLabelNoiseCount === 0
+        && reading.regionCount === 1
+        && reading.labelCount === 1,
+      details: {
+        globalDimmedCommunityLabels: selected.dimmedLabelCount,
+        globalDimmedNodeLabelNoise: selected.nodeLabelNoiseCount,
+        readingRegionCount: reading.regionCount,
+        readingLabelCount: reading.labelCount
+      }
+    }
+  ];
+  return {
+    communityId: community.id,
+    communityLabel: community.label,
+    pass: checks.every((check) => check.pass),
+    checks
+  };
+}
+
+function assertVisualReview(review) {
+  assert.equal(
+    review.pass,
+    true,
+    `${review.communityLabel}: visual review failed ${JSON.stringify(review.checks.filter((check) => !check.pass))}`
   );
 }
 
@@ -601,12 +681,23 @@ async function waitForNoSelectedCommunity(page) {
 }
 
 async function waitForPlainGlobal(page) {
-  await waitForNoSelectedCommunity(page);
-  await page.waitForFunction(() => {
-    const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
-    return root?.getAttribute("data-community-focus-id") === ""
-      && root?.getAttribute("data-source-community-id") === "";
-  });
+  try {
+    await waitForNoSelectedCommunity(page);
+    await page.waitForFunction(() => {
+      const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
+      return root?.getAttribute("data-community-focus-id") === ""
+        && root?.getAttribute("data-source-community-id") === "";
+    });
+  } catch (error) {
+    const snapshot = await sigmaSnapshot(page).catch((snapshotError) => ({ snapshotError: String(snapshotError) }));
+    const diagnostics = page.__graphDiagnostics || [];
+    throw new assert.AssertionError({
+      message: `Expected plain global graph. Snapshot: ${JSON.stringify({ snapshot, diagnostics })}`,
+      actual: error,
+      expected: "plain global graph",
+      operator: "strictEqual"
+    });
+  }
 }
 
 async function clickCommunityRegion(page, communityId) {
@@ -638,64 +729,90 @@ async function findCommunityRegionPoint(page, communityId) {
 }
 
 async function clickGlobalBlank(page) {
-  const point = await graphBlankPoint(page);
-  await page.mouse.click(point.x, point.y);
+  const candidates = await graphBlankCandidates(page);
+  for (const point of candidates) {
+    pushGraphDiagnostic(page, {
+      kind: "blank-click",
+      point
+    });
+    await page.mouse.click(point.x, point.y);
+    await page.waitForTimeout(120);
+    const snapshot = await sigmaSnapshot(page);
+    const hit = await lastSigmaHit(page);
+    pushGraphDiagnostic(page, {
+      kind: "blank-click-after",
+      hit,
+      snapshot
+    });
+    if (
+      snapshot.sourceCommunityId === "" &&
+      snapshot.selectedRegions.length === 0 &&
+      snapshot.selectedLabels.length === 0
+    ) {
+      return;
+    }
+    await closeDrawerIfOpen(page);
+  }
+  throw new Error(`Could not clear the graph with ${candidates.length} blank candidates`);
 }
 
-async function graphBlankPoint(page) {
+async function lastSigmaHit(page) {
+  return page.evaluate(() => {
+    const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
+    return {
+      kind: root?.getAttribute("data-last-hit-kind") || "",
+      id: root?.getAttribute("data-last-hit-id") || ""
+    };
+  });
+}
+
+async function graphBlankCandidates(page) {
   return page.evaluate(() => {
     const host = document.querySelector(".sigma-global-route") || document.querySelector(".graph-host");
     if (!host) throw new Error("Missing Sigma global route for blank click");
     const rect = host.getBoundingClientRect();
+    const nodeRects = [...document.querySelectorAll(".sigma-global-node-hit-target")]
+      .map((element) => element.getBoundingClientRect())
+      .filter((item) => item.width > 0 && item.height > 0)
+      .map((item) => ({
+        left: item.left - 24,
+        top: item.top - 24,
+        right: item.right + 24,
+        bottom: item.bottom + 24
+      }));
     const candidates = [];
     for (const rx of [0.08, 0.18, 0.28, 0.38, 0.5, 0.62, 0.74, 0.86, 0.94]) {
       for (const ry of [0.1, 0.2, 0.32, 0.44, 0.56, 0.68, 0.8, 0.9]) {
         candidates.push([rx, ry]);
       }
     }
+    const points = [];
     for (const [rx, ry] of candidates) {
       const x = rect.left + rect.width * rx;
       const y = rect.top + rect.height * ry;
+      if (nodeRects.some((node) => x >= node.left && x <= node.right && y >= node.top && y <= node.bottom)) continue;
       const hit = document.elementFromPoint(x, y);
       if (!hit?.closest?.(".drawer-panel-open, .drawer-panel, .sigma-global-community-region, .sigma-global-node-hit-target, .sigma-global-community-label, .sigma-global-aggregation-container, .graph-toolbar, .graph-search")) {
-        return { x, y };
+        points.push({
+          x,
+          y,
+          hitTag: hit?.tagName || "",
+          hitClass: typeof hit?.className === "string" ? hit.className : String(hit?.className || "")
+        });
       }
     }
+    if (points.length) return points.slice(0, 16);
     throw new Error("Could not find a graph blank point outside communities, nodes, labels, and controls");
   });
 }
 
 async function clickReturnGlobal(page) {
-  await page.getByRole("button", { name: "回全图" }).click({ force: true }).catch(() => undefined);
-  const returned = await page.waitForFunction(() => {
+  await page.getByRole("button", { name: "回全图" }).click({ force: true });
+  await page.waitForFunction(() => {
     const root = document.querySelector(".sigma-global-renderer[data-renderer='sigma-global']");
     return root?.getAttribute("data-community-focus-id") === ""
       && Number(root?.getAttribute("data-community-count") || "0") > 1;
-  }, undefined, { timeout: 1200 })
-    .then(() => true)
-    .catch(() => false);
-  if (returned) return;
-  await dispatchGraphBlankDoubleClick(page);
-}
-
-async function dispatchGraphBlankDoubleClick(page) {
-  const rootFound = await page.evaluate(() => {
-    const root = document.querySelector(".sigma-global-renderer") || document.querySelector("[data-llm-wiki-graph-root='true']");
-    if (!root) return false;
-    const rect = root.getBoundingClientRect();
-    const x = rect.left + Math.max(12, Math.min(32, rect.width * 0.08));
-    const y = rect.top + Math.max(12, Math.min(32, rect.height * 0.08));
-    root.dispatchEvent(new MouseEvent("dblclick", {
-      bubbles: true,
-      cancelable: true,
-      clientX: x,
-      clientY: y,
-      detail: 2,
-      view: window
-    }));
-    return true;
-  });
-  assert.equal(rootFound, true, "graph blank double-click fallback should dispatch to the graph root");
+  }, undefined, { timeout: 2_000 });
 }
 
 async function closeDrawerIfOpen(page) {

--- a/tests/graph-community-reading-experience.regression-1.sh
+++ b/tests/graph-community-reading-experience.regression-1.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+# Regression: first real Sigma community reading experience path and screenshot review.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/tests/lib/graph-html-engine-helpers.sh"
+
+tmp_dir="$(mktemp -d)"
+server_pid=""
+web_pid=""
+server_port="${GRAPH_COMMUNITY_EXPERIENCE_SERVER_PORT:-18790}"
+web_port="${GRAPH_COMMUNITY_EXPERIENCE_WEB_PORT:-15183}"
+artifact_dir="${GRAPH_COMMUNITY_EXPERIENCE_ARTIFACT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/llm-wiki-community-experience.XXXXXX")}"
+
+cleanup() {
+    if [ -d "$artifact_dir" ]; then
+        cp "$tmp_dir/server.log" "$artifact_dir/server.log" 2>/dev/null || true
+        cp "$tmp_dir/web.log" "$artifact_dir/web.log" 2>/dev/null || true
+    fi
+    if [ -n "$server_pid" ]; then kill "$server_pid" 2>/dev/null || true; fi
+    if [ -n "$web_pid" ]; then kill "$web_pid" 2>/dev/null || true; fi
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+if lsof -i TCP:"$server_port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port $server_port is already in use"
+fi
+if lsof -i TCP:"$web_port" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port $web_port is already in use"
+fi
+
+npm run build -w @llm-wiki/graph-engine > /dev/null 2>&1 \
+    || fail "graph-engine build should succeed before community reading experience regression"
+
+workbench_kb="$tmp_dir/home/llm-wiki/sigma-community-experience"
+mkdir -p "$workbench_kb/wiki/entities" "$tmp_dir/home/.llm-wiki-agent"
+
+cat > "$workbench_kb/.wiki-schema.md" <<'EOF'
+# Test schema
+EOF
+
+cat > "$workbench_kb/purpose.md" <<'EOF'
+# Sigma Community Experience
+EOF
+
+node - "$workbench_kb" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const kb = process.argv[2];
+const nodes = [];
+const edges = [];
+const communities = [
+  { id: "dense-agent", label: "AI Agent 对比分析", color_index: 0 },
+  { id: "small-chain", label: "小型概念链", color_index: 1 },
+  { id: "long-title", label: "长标题节点社区", color_index: 2 },
+  { id: "edge-dense", label: "高密关系社区", color_index: 3 },
+  { id: "flat-core", label: "无明显核心社区", color_index: 4 }
+];
+
+function addNode(community, id, label, type, x, y, weight) {
+  const sourcePath = `wiki/entities/${id}.md`;
+  nodes.push({
+    id,
+    label,
+    title: label,
+    type,
+    community,
+    path: sourcePath,
+    source_path: sourcePath,
+    content: `${label} 是 ${community} 社区里的测试节点。`,
+    x,
+    y,
+    weight
+  });
+}
+
+function addEdge(id, from, to, relation_type = "依赖", weight = 0.8, confidence = "EXTRACTED") {
+  edges.push({ id, from, to, type: confidence, confidence, relation_type, weight });
+}
+
+[
+  ["dense-overview", "AI Agent 对比分析总览", "topic", 40, 38, 96],
+  ["dense-source-1", "AI Agent 实践案例", "source", 31, 48, 88],
+  ["dense-framework", "Agent 框架谱系", "entity", 47, 46, 82],
+  ["dense-eval", "Agent 评测维度", "topic", 58, 39, 76],
+  ["dense-tools", "工具调用编排", "entity", 54, 54, 72],
+  ["dense-memory", "长期记忆策略", "entity", 68, 51, 66],
+  ["dense-rag", "RAG 协作边界", "topic", 70, 64, 64],
+  ["dense-orchestration", "多代理协作", "entity", 38, 62, 60],
+  ["dense-agent-benchmark", "Agent Benchmark 来源", "source", 24, 60, 56],
+  ["dense-cost", "成本对比", "comparison", 79, 43, 52],
+  ["dense-latency", "延迟瓶颈", "comparison", 84, 55, 48],
+  ["dense-safety", "安全边界", "topic", 61, 73, 46],
+  ["dense-copilot", "Copilot 模式", "entity", 46, 75, 44],
+  ["dense-autonomy", "自主性等级", "topic", 30, 73, 42],
+  ["dense-workflow", "工作流代理", "entity", 18, 47, 40],
+  ["dense-handoff", "人机交接", "entity", 22, 34, 38]
+].forEach(([id, label, type, x, y, weight]) => addNode("dense-agent", id, label, type, x, y, weight));
+
+[
+  ["dense-e1", "dense-overview", "dense-source-1", "实现", 1],
+  ["dense-e2", "dense-overview", "dense-framework", "依赖", 1],
+  ["dense-e3", "dense-overview", "dense-eval", "依赖", 0.95],
+  ["dense-e4", "dense-framework", "dense-tools", "实现", 0.9],
+  ["dense-e5", "dense-tools", "dense-memory", "依赖", 0.8],
+  ["dense-e6", "dense-memory", "dense-rag", "衍生", 0.75],
+  ["dense-e7", "dense-tools", "dense-orchestration", "实现", 0.85],
+  ["dense-e8", "dense-source-1", "dense-agent-benchmark", "对比", 0.82, "INFERRED"],
+  ["dense-e9", "dense-eval", "dense-cost", "对比", 0.72],
+  ["dense-e10", "dense-cost", "dense-latency", "对比", 0.7],
+  ["dense-e11", "dense-eval", "dense-safety", "矛盾", 0.64, "AMBIGUOUS"],
+  ["dense-e12", "dense-safety", "dense-copilot", "依赖", 0.6],
+  ["dense-e13", "dense-copilot", "dense-autonomy", "衍生", 0.56],
+  ["dense-e14", "dense-autonomy", "dense-workflow", "实现", 0.54],
+  ["dense-e15", "dense-workflow", "dense-handoff", "依赖", 0.52],
+  ["dense-e16", "dense-handoff", "dense-source-1", "补充", 0.5],
+  ["dense-e17", "dense-rag", "dense-eval", "桥接", 0.48],
+  ["dense-e18", "dense-orchestration", "dense-autonomy", "桥接", 0.46],
+  ["dense-e19", "dense-agent-benchmark", "dense-cost", "对比", 0.44],
+  ["dense-e20", "dense-memory", "dense-safety", "矛盾", 0.42, "AMBIGUOUS"]
+].forEach(([id, from, to, relation, weight, confidence]) => addEdge(id, from, to, relation, weight, confidence));
+
+[
+  ["small-a", "小社区入口", "topic", 128, 28, 70],
+  ["small-b", "小社区证据", "source", 140, 40, 55],
+  ["small-c", "小社区结论", "entity", 152, 30, 50]
+].forEach(([id, label, type, x, y, weight]) => addNode("small-chain", id, label, type, x, y, weight));
+addEdge("small-e1", "small-a", "small-b", "依赖", 0.8);
+addEdge("small-e2", "small-b", "small-c", "衍生", 0.7);
+
+[
+  ["long-a", "一个标题非常长用来测试社区阅读标签截断是否稳定的核心节点", "topic", 33, 132, 76],
+  ["long-b", "另一个同样很长的标题用于观察窄屏里文字不会盖住关系线", "entity", 53, 146, 70],
+  ["long-c", "长标题来源材料节点带有补充说明", "source", 70, 126, 62],
+  ["long-d", "标题长度接近边界的对比分析节点", "comparison", 84, 146, 56],
+  ["long-e", "短标题锚点", "entity", 103, 132, 50]
+].forEach(([id, label, type, x, y, weight]) => addNode("long-title", id, label, type, x, y, weight));
+addEdge("long-e1", "long-a", "long-b", "依赖", 0.8);
+addEdge("long-e2", "long-b", "long-c", "补充", 0.7);
+addEdge("long-e3", "long-c", "long-d", "对比", 0.65);
+addEdge("long-e4", "long-d", "long-e", "衍生", 0.55);
+
+["A", "B", "C", "D", "E", "F", "G"].forEach((letter, index) => {
+  addNode("edge-dense", `edge-${letter}`, `高密关系节点${letter}`, index % 3 === 0 ? "topic" : index % 3 === 1 ? "entity" : "source", 132 + (index % 3) * 16, 126 + Math.floor(index / 3) * 16, 68 - index);
+});
+[
+  ["edge-e1", "edge-A", "edge-B"], ["edge-e2", "edge-A", "edge-C"], ["edge-e3", "edge-A", "edge-D"],
+  ["edge-e4", "edge-B", "edge-C"], ["edge-e5", "edge-B", "edge-E"], ["edge-e6", "edge-C", "edge-F"],
+  ["edge-e7", "edge-D", "edge-E"], ["edge-e8", "edge-D", "edge-G"], ["edge-e9", "edge-E", "edge-F"],
+  ["edge-e10", "edge-F", "edge-G"], ["edge-e11", "edge-C", "edge-G"], ["edge-e12", "edge-B", "edge-G"]
+].forEach(([id, from, to], index) => addEdge(id, from, to, index % 3 === 0 ? "实现" : index % 3 === 1 ? "对比" : "依赖", 0.45 + index * 0.03));
+
+[
+  ["flat-a", "平权节点A", "topic", 194, 70],
+  ["flat-b", "平权节点B", "entity", 218, 75],
+  ["flat-c", "平权节点C", "source", 236, 92],
+  ["flat-d", "平权节点D", "topic", 228, 116],
+  ["flat-e", "平权节点E", "entity", 204, 120],
+  ["flat-f", "平权节点F", "source", 188, 98]
+].forEach(([id, label, type, x, y]) => addNode("flat-core", id, label, type, x, y, 50));
+[
+  ["flat-e1", "flat-a", "flat-b"], ["flat-e2", "flat-b", "flat-c"], ["flat-e3", "flat-c", "flat-d"],
+  ["flat-e4", "flat-d", "flat-e"], ["flat-e5", "flat-e", "flat-f"], ["flat-e6", "flat-f", "flat-a"]
+].forEach(([id, from, to]) => addEdge(id, from, to, "补充", 0.58));
+
+for (const node of nodes) {
+  const file = path.join(kb, node.source_path);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `# ${node.label}\n\n${node.content}\n\n它属于 ${node.community} 社区。\n`);
+}
+
+const communityPayload = communities.map((community) => {
+  const members = nodes.filter((node) => node.community === community.id).map((node) => node.id);
+  const first = members[0] || null;
+  return {
+    id: community.id,
+    label: community.label,
+    node_count: members.length,
+    color_index: community.color_index,
+    recommended_start_node_id: first,
+    members,
+    is_primary: community.id === "dense-agent"
+  };
+});
+
+const graph = {
+  meta: {
+    build_date: "2026-07-05T00:00:00.000Z",
+    wiki_title: "Sigma Community Experience",
+    total_nodes: nodes.length,
+    total_edges: edges.length
+  },
+  nodes,
+  edges,
+  learning: {
+    version: 1,
+    entry: { recommended_start_node_id: "dense-overview", recommended_start_reason: "密集社区入口", default_mode: "global" },
+    views: {
+      path: { enabled: false, start_node_id: null, node_ids: [], degraded: true },
+      community: { enabled: true, community_id: "dense-agent", label: "AI Agent 对比分析", node_ids: communityPayload[0].members, is_weak: false, degraded: false },
+      global: { enabled: true, node_ids: nodes.map((node) => node.id), degraded: false }
+    },
+    communities: communityPayload
+  }
+};
+
+fs.writeFileSync(path.join(kb, "wiki/graph-data.json"), `${JSON.stringify(graph, null, 2)}\n`);
+NODE
+
+cat > "$tmp_dir/home/.llm-wiki-agent/config.json" <<JSON
+{
+  "version": 1,
+  "externalKnowledgeBases": [],
+  "lastUsedKbPath": "$workbench_kb"
+}
+JSON
+
+HOME="$tmp_dir/home" HOST=127.0.0.1 PORT="$server_port" "$REPO_ROOT/node_modules/.bin/tsx" "$REPO_ROOT/workbench/server/src/index.ts" > "$tmp_dir/server.log" 2>&1 &
+server_pid="$!"
+HOME="$tmp_dir/home" LLM_WIKI_AGENT_API_ORIGIN="http://127.0.0.1:$server_port" npm run dev -w @llm-wiki-agent/web -- --host 127.0.0.1 --port "$web_port" --force > "$tmp_dir/web.log" 2>&1 &
+web_pid="$!"
+
+for _ in $(seq 1 120); do
+    if curl -fsS "http://127.0.0.1:$server_port/api/knowledge-bases" >/dev/null 2>&1 \
+        && curl -fsS "http://127.0.0.1:$web_port" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.25
+done
+
+curl -fsS "http://127.0.0.1:$server_port/api/knowledge-bases" >/dev/null 2>&1 \
+    || fail "workbench server did not start; see $tmp_dir/server.log"
+curl -fsS "http://127.0.0.1:$web_port" >/dev/null 2>&1 \
+    || fail "workbench web did not start; see $tmp_dir/web.log"
+
+playwright_node_path="${GRAPH_COMMUNITY_EXPERIENCE_PLAYWRIGHT_NODE_PATH:-}"
+if [ -z "$playwright_node_path" ]; then
+    playwright_node_path="$(
+        node -e 'const path=require("path"); try { console.log(path.dirname(path.dirname(require.resolve("playwright/package.json")))); } catch { process.exit(1); }' 2>/dev/null || true
+    )"
+fi
+if [ -z "$playwright_node_path" ] || [ ! -d "$playwright_node_path/playwright" ]; then
+    fail "Playwright is not installed locally. Install Playwright or set GRAPH_COMMUNITY_EXPERIENCE_PLAYWRIGHT_NODE_PATH."
+fi
+
+chrome_executable="${GRAPH_COMMUNITY_EXPERIENCE_CHROME_EXECUTABLE:-}"
+if [ -z "$chrome_executable" ]; then
+    candidate="$(
+        NODE_PATH="$playwright_node_path" node -e 'const { chromium } = require("playwright"); console.log(chromium.executablePath())'
+    )"
+    if [ -x "$candidate" ]; then
+        chrome_executable="$candidate"
+    elif [ -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then
+        chrome_executable="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    fi
+fi
+
+GRAPH_COMMUNITY_EXPERIENCE_URL="http://127.0.0.1:$web_port" \
+GRAPH_COMMUNITY_EXPERIENCE_CHROME_EXECUTABLE="$chrome_executable" \
+GRAPH_COMMUNITY_EXPERIENCE_ARTIFACT_DIR="$artifact_dir" \
+NODE_PATH="$playwright_node_path" \
+node "$REPO_ROOT/tests/browser/graph-community-reading-experience.mjs" \
+    || fail "Sigma community reading experience browser regression should pass"
+
+echo "PASS: graph community reading experience regression"
+echo "ARTIFACTS: $artifact_dir"

--- a/workbench/web/src/App.tsx
+++ b/workbench/web/src/App.tsx
@@ -653,6 +653,7 @@ function App() {
 			return;
 		}
 		if (command.kind === "enter-community") {
+			setDrawer(closedDrawer());
 			setSelectionCommand({ id: command.communityId, type: "enter-community" });
 			return;
 		}

--- a/workbench/web/src/lib/graph-community-enter.ts
+++ b/workbench/web/src/lib/graph-community-enter.ts
@@ -2,9 +2,9 @@ import type { GraphEngine, Selection } from "@llm-wiki/graph-engine";
 
 /**
  * Entering a community records where the user came from, then changes the graph
- * route to the DOM/SVG reading view. Source context is separate from selection:
- * it can restore the global highlight on return without making every community
- * node look selected/core inside the reading view.
+ * route to Sigma community reading. Source context is separate from selection:
+ * it can restore the global highlight on return without making every node in
+ * that community look selected/core inside the reading view.
  */
 export function applyCommunityEnter(engine: GraphEngine, communityId: string): Selection | null {
 	engine.setSourceCommunityContext(communityId);


### PR DESCRIPTION
## Summary
- 完成 #101 的真实体验验收和截图回归
- 修复社区阅读居中、颜色/形状连续性、返回全图后来源社区点击清理等体验断点
- 强化桌面和窄屏浏览器回归，覆盖搜索、筛选、拖动、返回全图等完整路径

## Verification
- npm run test -w @llm-wiki/graph-engine
- npm run test -w @llm-wiki-agent/web
- npm run typecheck
- npm run lint -w @llm-wiki-agent/web
- node --check tests/browser/graph-community-reading-experience.mjs
- GRAPH_COMMUNITY_EXPERIENCE_ARTIFACT_DIR=/tmp/llm-wiki-issue101-final-artifacts bash tests/graph-community-reading-experience.regression-1.sh

Closes #101