### PR TITLE
feat(workbench): 建立 HTTP 契约骨架并打通 health 竖线 (#165)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2842,6 +2842,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2858,6 +2859,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2874,6 +2876,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2890,6 +2893,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2906,6 +2910,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2922,6 +2927,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2938,6 +2944,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2954,6 +2961,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2970,6 +2978,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2986,6 +2995,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3002,6 +3012,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3018,6 +3029,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3034,6 +3046,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3050,6 +3063,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3066,6 +3080,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3082,6 +3097,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3098,6 +3114,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3114,6 +3131,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3130,6 +3148,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3146,6 +3165,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3162,6 +3182,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3178,6 +3199,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3194,6 +3216,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3210,6 +3233,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3226,6 +3250,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3242,6 +3267,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3592,6 +3618,10 @@
     },
     "node_modules/@llm-wiki/graph-engine": {
       "resolved": "packages/graph-engine",
+      "link": true
+    },
+    "node_modules/@llm-wiki/workbench-contracts": {
+      "resolved": "packages/workbench-contracts",
       "link": true
     },
     "node_modules/@mistralai/mistralai": {
@@ -11079,6 +11109,32 @@
         "node": ">=14.17"
       }
     },
+    "packages/workbench-contracts": {
+      "name": "@llm-wiki/workbench-contracts",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0",
+        "typescript": "~6.0.2"
+      }
+    },
+    "packages/workbench-contracts/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "workbench/server": {
       "name": "@llm-wiki-agent/server",
       "version": "0.0.1",
@@ -11089,6 +11145,7 @@
         "@earendil-works/pi-coding-agent": "^0.79.4",
         "@hono/node-server": "^1.13.0",
         "@llm-wiki/graph-engine": "0.0.0",
+        "@llm-wiki/workbench-contracts": "0.0.0",
         "hono": "^4.6.0",
         "typebox": "^1.1.38"
       },
@@ -11104,6 +11161,7 @@
       "license": "MIT",
       "dependencies": {
         "@llm-wiki/graph-engine": "0.0.0",
+        "@llm-wiki/workbench-contracts": "0.0.0",
         "@tailwindcss/vite": "^4.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -11116,7 +11174,8 @@
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.5.4",
         "tailwindcss": "^4.0.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/packages/workbench-contracts/package.json
+++ b/packages/workbench-contracts/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@llm-wiki/workbench-contracts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "llm-wiki 工作台前后端共享 HTTP/SSE 契约（Zod）",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --import tsx --test test/*.test.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "~6.0.2"
+  }
+}

--- a/packages/workbench-contracts/src/errors.ts
+++ b/packages/workbench-contracts/src/errors.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+
+/**
+ * Workbench HTTP 第一批稳定错误码。
+ *
+ * 前端业务逻辑只依赖 code 做程序化判断，不依赖中文 message。新增 code 是
+ * 可接受的演进，但已有 code 的语义保持不变。错误码用稳定英文。
+ */
+export const WorkbenchErrorCodeSchema = z.enum([
+	"INVALID_JSON", // JSON body 解析失败
+	"INVALID_REQUEST", // 字段类型不对或整体不符合 schema
+	"MISSING_FIELD", // 缺少必填字段
+	"NO_ACTIVE_KB", // 当前没有选择知识库
+	"KB_NOT_REGISTERED", // 知识库未登记或已失效
+	"FORBIDDEN_PATH", // 路径越界或无权限
+	"FORBIDDEN_ORIGIN", // 请求来源不是工作台可信来源
+	"FORBIDDEN_LOCAL_API", // 本地 API 缺少或携带了错误的 capability token
+	"NOT_FOUND", // 资源不存在
+	"CONFLICT", // 资源冲突（如初始化已有库存在冲突文件）
+	"UNSUPPORTED_PLATFORM", // 当前平台不支持
+	"BUSY", // 资源忙（如当前对话正在生成）
+	"INTERNAL_ERROR", // 兜底内部错误
+]);
+export type WorkbenchErrorCode = z.infer<typeof WorkbenchErrorCodeSchema>;
+
+/**
+ * 错误码到 HTTP 状态码的大类映射。HTTP 状态表达大类，code 表达精确原因。
+ */
+export const errorCodeToHttpStatus: Readonly<
+	Record<WorkbenchErrorCode, number>
+> = {
+	INVALID_JSON: 400,
+	INVALID_REQUEST: 400,
+	MISSING_FIELD: 400,
+	NO_ACTIVE_KB: 400,
+	KB_NOT_REGISTERED: 404,
+	FORBIDDEN_PATH: 403,
+	FORBIDDEN_ORIGIN: 403,
+	FORBIDDEN_LOCAL_API: 403,
+	NOT_FOUND: 404,
+	CONFLICT: 409,
+	UNSUPPORTED_PLATFORM: 501,
+	BUSY: 409,
+	INTERNAL_ERROR: 500,
+};
+
+// ============= typed / redacted error details =============
+//
+// details 是失败 envelope 的结构化补充信息。
+// 红线（由 schema 形状与构造方共同保证）：绝不包含本机绝对路径、Error.stack、
+// API key、认证文件路径、原始 request body 或原始 prompt。
+// 每个错误码对应一个公开 details schema；构造 details 时用对应 schema。
+
+/** MISSING_FIELD：缺失字段名。 */
+export const MissingFieldDetailsSchema = z.object({
+	field: z.string(),
+});
+export type MissingFieldDetails = z.infer<typeof MissingFieldDetailsSchema>;
+
+/** INVALID_REQUEST：字段级校验问题，不含原始 body。 */
+export const InvalidRequestDetailsSchema = z.object({
+	issues: z.array(
+		z.object({
+			path: z.string(),
+			message: z.string(),
+		}),
+	),
+});
+export type InvalidRequestDetails = z.infer<typeof InvalidRequestDetailsSchema>;
+
+/** FORBIDDEN_PATH：越界原因，不返回本机绝对路径。 */
+export const ForbiddenPathDetailsSchema = z.object({
+	reason: z.enum(["outside-root", "not-registered", "symlink-escape"]),
+});
+export type ForbiddenPathDetails = z.infer<typeof ForbiddenPathDetailsSchema>;
+
+/** NOT_FOUND：可选资源标识（公开名 / 相对片段，非绝对路径）。 */
+export const NotFoundDetailsSchema = z.object({
+	resource: z.string().optional(),
+});
+export type NotFoundDetails = z.infer<typeof NotFoundDetailsSchema>;
+
+/** CONFLICT：冲突文件名 / 相对片段列表，非本机绝对路径。 */
+export const ConflictDetailsSchema = z.object({
+	conflicts: z.array(z.string()).optional(),
+});
+export type ConflictDetails = z.infer<typeof ConflictDetailsSchema>;
+
+/** INTERNAL_ERROR：dev/test 可带脱敏 diagnostic id，不带 stack / path / key。 */
+export const InternalErrorDetailsSchema = z.object({
+	diagnosticId: z.string().optional(),
+});
+export type InternalErrorDetails = z.infer<
+	typeof InternalErrorDetailsSchema
+>;
+
+/**
+ * details 字段的运行时总 schema：宽松结构化 JSON。envelope 解析时用它做形状
+ * 校验；具体结构由对应 per-code schema 在构造方保证，前端按 code 判别。
+ */
+export const ErrorDetailsSchema = z.record(z.string(), z.unknown());
+export type ErrorDetails = z.infer<typeof ErrorDetailsSchema>;

--- a/packages/workbench-contracts/src/health.ts
+++ b/packages/workbench-contracts/src/health.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+/**
+ * GET /api/health 响应 data。
+ *
+ * health 是只读心跳端点，无副作用：不读写文件、不触发模型、不改配置、不发起 SSE。
+ * 因此它在本地 API 信任边界里属于只读白名单，不需要可信来源 token（见 spec §9）。
+ */
+export const HealthDataSchema = z.object({
+	status: z.literal("ok"),
+	timestamp: z.number().int().nonnegative(),
+	service: z.string(),
+});
+export type HealthData = z.infer<typeof HealthDataSchema>;

--- a/packages/workbench-contracts/src/index.ts
+++ b/packages/workbench-contracts/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @llm-wiki/workbench-contracts
+ *
+ * 工作台前后端共享的 HTTP/SSE 契约。只承担契约职责：Zod schema、从 schema
+ * 推导的 TypeScript 类型、稳定错误码、JSON envelope。不读写文件、不调用
+ * Hono / React / pi-agent、不知道任何业务实现。
+ *
+ * server 和 web 只从 package export import，不深路径读取 src。
+ * Zod 只服务工作台 HTTP/SSE 契约；pi-agent Extension 的 tool parameters
+ * 继续用 TypeBox，两者职责不混淆。
+ */
+
+export * from "./errors.js";
+export * from "./json.js";
+export * from "./health.js";

--- a/packages/workbench-contracts/src/json.ts
+++ b/packages/workbench-contracts/src/json.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+import { ErrorDetailsSchema, WorkbenchErrorCodeSchema } from "./errors.js";
+import type { ErrorDetails, WorkbenchErrorCode } from "./errors.js";
+
+/**
+ * 成功 envelope schema 工厂：`{ ok: true, data: Data }`。
+ * data 由调用方传入具体领域 schema。普通 JSON 接口成功一律走这个结构，
+ * 替代历史 `{ ok: true, items / active / config / content / ... }` 混用。
+ */
+export function SuccessEnvelopeSchema<Data>(data: z.ZodType<Data>) {
+	return z.object({
+		ok: z.literal(true),
+		data,
+	});
+}
+export type SuccessEnvelope<Data> = { ok: true; data: Data };
+
+/**
+ * 失败 envelope schema：`{ ok: false, code, message, details? }`。
+ * details 形状宽松（见 errors.ErrorDetailsSchema），具体结构由 per-code
+ * schema 在构造方保证。
+ */
+export const FailureEnvelopeSchema = z.object({
+	ok: z.literal(false),
+	code: WorkbenchErrorCodeSchema,
+	message: z.string(),
+	details: ErrorDetailsSchema.optional(),
+});
+export type FailureEnvelope = {
+	ok: false;
+	code: WorkbenchErrorCode;
+	message: string;
+	details?: ErrorDetails;
+};
+
+/**
+ * 普通 JSON 接口的完整 envelope（按 `ok` 判别联合）。
+ * 文件下载成功返回文件 Response，不包 envelope；SSE 不套 envelope。
+ */
+export function JsonEnvelopeSchema<Data>(data: z.ZodType<Data>) {
+	return z.discriminatedUnion("ok", [
+		SuccessEnvelopeSchema(data),
+		FailureEnvelopeSchema,
+	]);
+}
+
+/** 构造成功 envelope。后端 response helper 与测试 mock 都用这个。 */
+export function success<Data>(data: Data): SuccessEnvelope<Data> {
+	return { ok: true, data };
+}
+
+/** 构造失败 envelope。details 省略时不写入字段。 */
+export function failure(
+	code: WorkbenchErrorCode,
+	message: string,
+	details?: ErrorDetails,
+): FailureEnvelope {
+	return details === undefined
+		? { ok: false, code, message }
+		: { ok: false, code, message, details };
+}

--- a/packages/workbench-contracts/test/contracts.test.ts
+++ b/packages/workbench-contracts/test/contracts.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	ConflictDetailsSchema,
+	errorCodeToHttpStatus,
+	FailureEnvelopeSchema,
+	failure,
+	ForbiddenPathDetailsSchema,
+	HealthDataSchema,
+	InvalidRequestDetailsSchema,
+	JsonEnvelopeSchema,
+	MissingFieldDetailsSchema,
+	NotFoundDetailsSchema,
+	SuccessEnvelopeSchema,
+	success,
+	WorkbenchErrorCodeSchema,
+} from "../src/index.js";
+
+test("WorkbenchErrorCode 包含第一批稳定错误码", () => {
+	const codes = WorkbenchErrorCodeSchema.options;
+	for (const expected of [
+		"INVALID_JSON",
+		"INVALID_REQUEST",
+		"MISSING_FIELD",
+		"NO_ACTIVE_KB",
+		"KB_NOT_REGISTERED",
+		"FORBIDDEN_PATH",
+		"FORBIDDEN_ORIGIN",
+		"FORBIDDEN_LOCAL_API",
+		"NOT_FOUND",
+		"CONFLICT",
+		"UNSUPPORTED_PLATFORM",
+		"BUSY",
+		"INTERNAL_ERROR",
+	]) {
+		assert.ok(codes.includes(expected as never), `missing code ${expected}`);
+	}
+});
+
+test("errorCodeToHttpStatus 覆盖所有 code 且只用 spec 约定的大类状态码", () => {
+	const allowed = [400, 403, 404, 409, 500, 501];
+	for (const code of WorkbenchErrorCodeSchema.options) {
+		const status = errorCodeToHttpStatus[code];
+		assert.ok(allowed.includes(status), `${code} -> ${status}`);
+	}
+	assert.equal(errorCodeToHttpStatus.NOT_FOUND, 404);
+	assert.equal(errorCodeToHttpStatus.FORBIDDEN_PATH, 403);
+	assert.equal(errorCodeToHttpStatus.FORBIDDEN_ORIGIN, 403);
+	assert.equal(errorCodeToHttpStatus.CONFLICT, 409);
+	assert.equal(errorCodeToHttpStatus.BUSY, 409);
+	assert.equal(errorCodeToHttpStatus.UNSUPPORTED_PLATFORM, 501);
+	assert.equal(errorCodeToHttpStatus.INTERNAL_ERROR, 500);
+});
+
+test("成功 envelope 接受 { ok: true, data } 并保留 data", () => {
+	const schema = SuccessEnvelopeSchema(HealthDataSchema);
+	const parsed = schema.parse({
+		ok: true,
+		data: { status: "ok", timestamp: 1, service: "s" },
+	});
+	assert.deepEqual(parsed.data, {
+		status: "ok",
+		timestamp: 1,
+		service: "s",
+	});
+});
+
+test("失败 envelope 接受 { ok: false, code, message, details? }", () => {
+	assert.equal(
+		FailureEnvelopeSchema.safeParse({
+			ok: false,
+			code: "MISSING_FIELD",
+			message: "缺少 path",
+		}).success,
+		true,
+	);
+	assert.equal(
+		FailureEnvelopeSchema.safeParse({
+			ok: false,
+			code: "INVALID_REQUEST",
+			message: "x",
+			details: { issues: [{ path: "name", message: "required" }] },
+		}).success,
+		true,
+	);
+});
+
+test("失败 envelope 拒绝未知 code 和缺字段", () => {
+	assert.equal(
+		FailureEnvelopeSchema.safeParse({ ok: false, code: "NOPE", message: "x" })
+			.success,
+		false,
+	);
+	assert.equal(
+		FailureEnvelopeSchema.safeParse({ ok: false, code: "NOT_FOUND" }).success,
+		false,
+	);
+});
+
+test("JsonEnvelopeSchema 按 ok 判别，能区分成功/失败", () => {
+	const schema = JsonEnvelopeSchema(HealthDataSchema);
+	assert.equal(
+		schema.safeParse({
+			ok: true,
+			data: { status: "ok", timestamp: 1, service: "s" },
+		}).success,
+		true,
+	);
+	assert.equal(
+		schema.safeParse({ ok: false, code: "BUSY", message: "忙" }).success,
+		true,
+	);
+});
+
+test("success() / failure() helper 构造正确结构", () => {
+	assert.deepEqual(success(1), { ok: true, data: 1 });
+	assert.deepEqual(failure("NOT_FOUND", "找不到"), {
+		ok: false,
+		code: "NOT_FOUND",
+		message: "找不到",
+	});
+	assert.deepEqual(failure("MISSING_FIELD", "缺少", { field: "path" }), {
+		ok: false,
+		code: "MISSING_FIELD",
+		message: "缺少",
+		details: { field: "path" },
+	});
+});
+
+test("typed details schema 校验结构化形状", () => {
+	assert.equal(
+		MissingFieldDetailsSchema.safeParse({ field: "path" }).success,
+		true,
+	);
+	assert.equal(MissingFieldDetailsSchema.safeParse({ field: 1 }).success, false);
+
+	const issues = InvalidRequestDetailsSchema.parse({
+		issues: [{ path: "name", message: "required" }],
+	});
+	assert.equal(issues.issues.length, 1);
+
+	assert.equal(
+		ForbiddenPathDetailsSchema.safeParse({ reason: "outside-root" }).success,
+		true,
+	);
+	// FORBIDDEN_PATH reason 是固定枚举：拒绝把本机绝对路径塞进 reason
+	assert.equal(
+		ForbiddenPathDetailsSchema.safeParse({ reason: "/Users/leak" }).success,
+		false,
+	);
+
+	assert.equal(
+		NotFoundDetailsSchema.safeParse({ resource: "kb:demo" }).success,
+		true,
+	);
+	assert.equal(
+		ConflictDetailsSchema.safeParse({ conflicts: ["purpose.md"] }).success,
+		true,
+	);
+});
+
+test("HealthData schema 校验心跳 data", () => {
+	assert.equal(
+		HealthDataSchema.safeParse({
+			status: "ok",
+			timestamp: 100,
+			service: "s",
+		}).success,
+		true,
+	);
+	// status 不是 'ok' / timestamp 非正整数 都拒绝
+	assert.equal(
+		HealthDataSchema.safeParse({
+			status: "down",
+			timestamp: 100,
+			service: "s",
+		}).success,
+		false,
+	);
+	assert.equal(
+		HealthDataSchema.safeParse({
+			status: "ok",
+			timestamp: -1,
+			service: "s",
+		}).success,
+		false,
+	);
+});

--- a/packages/workbench-contracts/tsconfig.json
+++ b/packages/workbench-contracts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmitOnError": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workbench/server/package.json
+++ b/workbench/server/package.json
@@ -7,11 +7,11 @@
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
-    "prebuild": "npm run build -w @llm-wiki/graph-engine",
+    "prebuild": "npm run build -w @llm-wiki/workbench-contracts && npm run build -w @llm-wiki/graph-engine",
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "pretypecheck": "npm run build -w @llm-wiki/graph-engine",
+    "pretypecheck": "npm run build -w @llm-wiki/workbench-contracts && npm run build -w @llm-wiki/graph-engine",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
@@ -20,6 +20,7 @@
     "@earendil-works/pi-coding-agent": "^0.79.4",
     "@hono/node-server": "^1.13.0",
     "@llm-wiki/graph-engine": "0.0.0",
+    "@llm-wiki/workbench-contracts": "0.0.0",
     "hono": "^4.6.0",
     "typebox": "^1.1.38"
   },

--- a/workbench/server/src/app.test.ts
+++ b/workbench/server/src/app.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { failure } from "@llm-wiki/workbench-contracts";
+
+import { createApp } from "./app.js";
+import { HttpContractError } from "./http/request.js";
+
+type EnvelopeJson = {
+	ok?: boolean;
+	code?: string;
+	message?: string;
+	details?: { diagnosticId?: string; field?: string } | null;
+	data?: { status?: string; service?: string; timestamp?: number };
+};
+
+test("GET /api/health 返回统一成功 envelope", async () => {
+	const app = createApp({ mode: "test" });
+	const res = await app.request("/api/health");
+	assert.equal(res.status, 200);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, true);
+	assert.equal(json.data?.status, "ok");
+	assert.equal(json.data?.service, "llm-wiki-agent/server");
+	assert.equal(typeof json.data?.timestamp, "number");
+	assert.ok((json.data?.timestamp ?? -1) >= 0);
+});
+
+test("createApp().request 可直接调用，不启动端口、不 bootstrap、不读写真实用户目录", async () => {
+	// 不传任何真实依赖；health 不触碰文件系统。证明 route 测试无需真实端口。
+	const app = createApp();
+	const res = await app.request("/api/health");
+	assert.equal(res.status, 200);
+});
+
+test("route 抛 HttpContractError 时映射为对应失败 envelope 和状态码", async () => {
+	const app = createApp();
+	app.get("/api/contract-bad", () => {
+		throw new HttpContractError("MISSING_FIELD", "缺少 path", {
+			field: "path",
+		});
+	});
+	const res = await app.request("/api/contract-bad");
+	assert.equal(res.status, 400); // MISSING_FIELD -> 400
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, false);
+	assert.equal(json.code, "MISSING_FIELD");
+	assert.equal(json.message, "缺少 path");
+	assert.equal(json.details?.field, "path");
+});
+
+test("未捕获错误兜底为 INTERNAL_ERROR，绝不泄露 message/stack/路径/key", async () => {
+	const app = createApp({ mode: "test" });
+	app.get("/api/throw", () => {
+		throw new Error("/Users/secret/path boom api_key=sk-leak");
+	});
+	const res = await app.request("/api/throw");
+	assert.equal(res.status, 500);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, false);
+	assert.equal(json.code, "INTERNAL_ERROR");
+	assert.equal(json.message, "服务器内部错误");
+	const body = JSON.stringify(json);
+	assert.equal(body.includes("secret"), false);
+	assert.equal(body.includes("api_key"), false);
+	assert.equal(body.includes("leak"), false);
+	assert.equal(body.includes("Users"), false);
+	assert.equal(body.includes("stack"), false);
+	// test 模式带脱敏 diagnosticId，且它本身不含敏感信息
+	assert.equal(typeof json.details?.diagnosticId, "string");
+	assert.ok((json.details?.diagnosticId ?? "").length > 0);
+});
+
+test("dev 模式 INTERNAL_ERROR 默认不带 details", async () => {
+	const app = createApp({ mode: "dev" });
+	app.get("/api/throw", () => {
+		throw new Error("boom");
+	});
+	const res = await app.request("/api/throw");
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.details, undefined);
+});
+
+test("注入 deps.security 后作用于 /api/* 请求（#166 接入点预留）", async () => {
+	let called = 0;
+	const app = createApp({
+		security: async (_c, next) => {
+			called += 1;
+			await next();
+		},
+	});
+	const res = await app.request("/api/health");
+	assert.equal(res.status, 200);
+	assert.equal(called, 1);
+});
+
+test("deps.security 直接返回响应时短路（模拟 #166 对会改状态端点的拒绝）", async () => {
+	const app = createApp({
+		security: async (c) =>
+			c.json(failure("FORBIDDEN_LOCAL_API", "缺少 capability token"), 403),
+	});
+	// 临时挂一个会改状态的端点，模拟 #166 之后的迁移路由
+	app.post("/api/sensitive", (c) => c.json({ ok: true }));
+	const res = await app.request("/api/sensitive", { method: "POST" });
+	assert.equal(res.status, 403);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.code, "FORBIDDEN_LOCAL_API");
+});

--- a/workbench/server/src/app.ts
+++ b/workbench/server/src/app.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { MiddlewareHandler } from "hono";
+
+import { failure } from "@llm-wiki/workbench-contracts";
+
+import { HttpContractError } from "./http/request.js";
+import { createHealthRoutes } from "./routes/health.js";
+
+export type WorkbenchAppMode = "test" | "dev" | "desktop";
+
+/**
+ * createApp 的依赖注入。route 测试传 fake deps，不读写真实
+ * `~/.llm-wiki-agent/` 或知识库目录。
+ */
+export interface WorkbenchAppDeps {
+	/**
+	 * 运行模式。test 模式下 INTERNAL_ERROR 带脱敏 diagnostic id；
+	 * dev/desktop 默认不带 details。
+	 */
+	mode?: WorkbenchAppMode;
+	/**
+	 * 可信来源 / capability token 统一检查接入点（#166 注入实现）。
+	 * 会改文件、触发模型、改配置、启动 SSE 的端点都应在此校验；
+	 * 生产实现内部负责把 health 等只读白名单端点豁免（见 spec §9）。
+	 */
+	security?: MiddlewareHandler;
+}
+
+/**
+ * 组装工作台 Hono app：统一错误兜底 + 可信来源接入点 + 已迁移 route module。
+ *
+ * createApp 只做请求处理组装，不监听端口、不 bootstrap、不恢复 watcher、
+ * 不读写真实用户目录。bootstrap / serve / watcher 都留在 index.ts。
+ *
+ * route 测试可直接 `createApp(deps).request('/api/health')`，无需启动端口。
+ */
+export function createApp(deps: WorkbenchAppDeps = {}): Hono {
+	const app = new Hono();
+
+	// 1. 统一错误兜底：
+	//    - HttpContractError -> 失败 envelope（code/message/details），状态码由 code 决定。
+	//    - 其它未捕获错误 -> INTERNAL_ERROR envelope（500），绝不泄露 stack / 路径 / key。
+	app.onError((err, c) => {
+		if (err instanceof HttpContractError) {
+			return c.json(
+				failure(err.code, err.message, err.details),
+				err.httpStatus as ContentfulStatusCode,
+			);
+		}
+		const details =
+			deps.mode === "test"
+				? { diagnosticId: redactedDiagnosticId() }
+				: undefined;
+		return c.json(failure("INTERNAL_ERROR", "服务器内部错误", details), 500);
+	});
+
+	// 2. 可信来源 / capability token 统一接入点（#166 实现；#165 预留）。
+	//    注入 deps.security 后，所有 /api/* 请求先过它。
+	if (deps.security) {
+		app.use("/api/*", deps.security);
+	}
+
+	// 3. 已迁移 route module：统一经过 request / response / security 接入点。
+	app.route("/api/health", createHealthRoutes());
+
+	return app;
+}
+
+/**
+ * 生成脱敏 diagnostic id：随机 token，不含错误 message / stack / 路径 / key。
+ * 服务端日志据此 token 关联详细错误（日志关联在后续阶段实现）。
+ */
+function redactedDiagnosticId(): string {
+	return randomUUID().slice(0, 8);
+}

--- a/workbench/server/src/http/request.ts
+++ b/workbench/server/src/http/request.ts
@@ -1,0 +1,57 @@
+import type { Context } from "hono";
+import type { ZodType } from "zod";
+import {
+	errorCodeToHttpStatus,
+	type ErrorDetails,
+	type WorkbenchErrorCode,
+} from "@llm-wiki/workbench-contracts";
+
+/**
+ * 工作台 HTTP 契约错误：带稳定 code、可公开 details、HTTP 大类状态码。
+ * route 抛出后由 createApp 的 onError 统一映射成失败 envelope。
+ */
+export class HttpContractError extends Error {
+	constructor(
+		public readonly code: WorkbenchErrorCode,
+		message: string,
+		public readonly details?: ErrorDetails,
+	) {
+		super(message);
+		this.name = "HttpContractError";
+	}
+	get httpStatus(): number {
+		return errorCodeToHttpStatus[this.code];
+	}
+}
+
+/**
+ * 解析 JSON body。解析失败抛 INVALID_JSON 契约错误（由 onError 映射为 envelope）。
+ */
+export async function parseJsonBody(c: Context): Promise<unknown> {
+	try {
+		return await c.req.json();
+	} catch {
+		throw new HttpContractError("INVALID_JSON", "请求体不是有效的 JSON");
+	}
+}
+
+/**
+ * 解析并按 schema 校验 JSON body。校验失败抛 INVALID_REQUEST，details 只含
+ * 字段级 issues（path + message），不含原始 body。
+ */
+export async function parseValidatedBody<T>(
+	c: Context,
+	schema: ZodType<T>,
+): Promise<T> {
+	const raw = await parseJsonBody(c);
+	const result = schema.safeParse(raw);
+	if (!result.success) {
+		throw new HttpContractError("INVALID_REQUEST", "请求字段不符合 schema", {
+			issues: result.error.issues.map((issue) => ({
+				path: issue.path.join("."),
+				message: issue.message,
+			})),
+		});
+	}
+	return result.data;
+}

--- a/workbench/server/src/http/response.ts
+++ b/workbench/server/src/http/response.ts
@@ -1,0 +1,34 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+
+import {
+	errorCodeToHttpStatus,
+	failure,
+	success,
+	type ErrorDetails,
+	type WorkbenchErrorCode,
+} from "@llm-wiki/workbench-contracts";
+
+/**
+ * 写成功 envelope：`{ ok: true, data }`，HTTP 200。
+ * 普通 JSON 接口成功一律走这个 helper，替代历史 `{ ok: true, items / active / ... }`。
+ */
+export function jsonOk<T>(c: Context, data: T): Response {
+	return c.json(success(data));
+}
+
+/**
+ * 写失败 envelope：`{ ok: false, code, message, details? }`。
+ * HTTP 状态码由 code 决定（errorCodeToHttpStatus）。
+ */
+export function jsonError(
+	c: Context,
+	code: WorkbenchErrorCode,
+	message: string,
+	details?: ErrorDetails,
+): Response {
+	return c.json(
+		failure(code, message, details),
+		errorCodeToHttpStatus[code] as ContentfulStatusCode,
+	);
+}

--- a/workbench/server/src/index.ts
+++ b/workbench/server/src/index.ts
@@ -20,7 +20,6 @@
  */
 
 import { serve } from "@hono/node-server";
-import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
@@ -28,6 +27,7 @@ import { promisify } from "node:util";
 
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 
+import { createApp } from "./app.js";
 import {
 	artifactEvents,
 	getArtifact,
@@ -165,15 +165,9 @@ function localHostOnly(rawHost: string | undefined): string {
 	return "127.0.0.1";
 }
 
-const app = new Hono();
-
-app.get("/api/health", (c) => {
-	return c.json({
-		status: "ok",
-		timestamp: Date.now(),
-		service: "llm-wiki-agent/server",
-	});
-});
+// createApp 组装统一 middleware / 错误兜底 / 已迁移 route module（health）。
+// 未迁移的 legacy route 继续挂在这个 app 上，等后续 issue 逐个迁移。
+const app = createApp();
 
 app.get("/api/events", (c) => {
 	return streamSSE(c, async (stream) => {

--- a/workbench/server/src/routes/health.ts
+++ b/workbench/server/src/routes/health.ts
@@ -1,0 +1,23 @@
+import { Hono } from "hono";
+import type { HealthData } from "@llm-wiki/workbench-contracts";
+
+import { jsonOk } from "../http/response.js";
+
+/**
+ * GET /api/health —— 只读心跳端点。
+ *
+ * 无副作用：不读写文件、不触发模型、不改配置、不发起 SSE。因此在本地 API
+ * 信任边界里属于只读白名单（见 spec §9），#166 的可信来源检查应豁免它。
+ */
+export function createHealthRoutes(): Hono {
+	const router = new Hono();
+	router.get("/", (c) => {
+		const data: HealthData = {
+			status: "ok",
+			timestamp: Date.now(),
+			service: "llm-wiki-agent/server",
+		};
+		return jsonOk(c, data);
+	});
+	return router;
+}

--- a/workbench/web/package.json
+++ b/workbench/web/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
-    "prebuild": "npm run build -w @llm-wiki/graph-engine",
+    "prebuild": "npm run build -w @llm-wiki/workbench-contracts && npm run build -w @llm-wiki/graph-engine",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -15,12 +15,14 @@
     "test:unit": "node --import tsx --test test/*.test.ts",
     "test:dom": "node --test-concurrency=1 --import tsx --import ./test/setup-dom.ts --test test/*.test.tsx",
     "visual:paper": "node --import tsx test/visual/paper-ui.ts",
-    "pretypecheck": "npm run build -w @llm-wiki/graph-engine",
+    "pretypecheck": "npm run build -w @llm-wiki/workbench-contracts && npm run build -w @llm-wiki/graph-engine",
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
     "@llm-wiki/graph-engine": "0.0.0",
+    "@llm-wiki/workbench-contracts": "0.0.0",
     "@tailwindcss/vite": "^4.0.0",
+    "zod": "^4.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/workbench/web/src/lib/api.ts
+++ b/workbench/web/src/lib/api.ts
@@ -247,16 +247,8 @@ export type ToolStatusContractEvent =
 	| AssistantErrorEvent;
 
 // ============= API =============
-
-export async function getHealth(): Promise<{
-	status: string;
-	timestamp: number;
-	service: string;
-}> {
-	const res = await fetch("/api/health");
-	if (!res.ok) throw new Error(`Health check failed: HTTP ${res.status}`);
-	return res.json();
-}
+// health 已迁移到统一契约路径 ./api/health（createApp + workbench-contracts）。
+// 其余函数仍是 legacy，等待按 issue 逐个迁移到 ./api/<domain>。
 
 export async function listKnowledgeBases(): Promise<KnowledgeBaseInfo[]> {
 	const res = await fetch("/api/knowledge-bases");

--- a/workbench/web/src/lib/api/client.ts
+++ b/workbench/web/src/lib/api/client.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+import {
+	FailureEnvelopeSchema,
+	SuccessEnvelopeSchema,
+	type FailureEnvelope,
+} from "@llm-wiki/workbench-contracts";
+
+/**
+ * 工作台统一底层 API client。
+ *
+ * 只服务已迁移到统一 JSON envelope（`{ ok:true, data } | { ok:false, code,
+ * message, details? }`）的 endpoint（migrated-json）。不吞旧响应格式：遇到旧
+ * 格式（无 ok 字段、`{ ok:true, items }` 等）一律判为契约不符并抛
+ * ContractMismatchError。未迁移 endpoint 继续走 legacy api.ts，互不污染。
+ */
+
+/** 后端失败 envelope 抛出的错误。业务逻辑用 code 判断，不依赖 message。 */
+export class ApiError extends Error {
+	code: string;
+	details: unknown;
+	constructor(failure: FailureEnvelope) {
+		super(failure.message);
+		this.name = "ApiError";
+		this.code = failure.code;
+		this.details = failure.details;
+	}
+}
+
+/** 响应既不是统一成功也不是统一失败 envelope（旧格式 / 畸形）时抛出。 */
+export class ContractMismatchError extends Error {
+	path: string;
+	status: number;
+	constructor(path: string, status: number) {
+		super(`响应不符合工作台统一契约（${path}）`);
+		this.name = "ContractMismatchError";
+		this.path = path;
+		this.status = status;
+	}
+}
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+export interface RequestOptions<T> {
+	/** 响应 data 的 Zod schema；client 用它校验成功 envelope 的 data。 */
+	responseSchema: z.ZodType<T>;
+	method?: HttpMethod;
+	body?: unknown;
+	signal?: AbortSignal;
+}
+
+/**
+ * 发起请求并按统一 envelope 解析响应。
+ *
+ * - 成功 envelope -> 返回 data（已按 responseSchema 校验）。
+ * - 失败 envelope -> 抛 ApiError（带 code / details）。
+ * - 旧格式 / data 校验失败 -> 抛 ContractMismatchError，绝不静默吞掉。
+ */
+export async function request<T>(
+	path: string,
+	options: RequestOptions<T>,
+): Promise<T> {
+	const init: RequestInit = { method: options.method ?? "GET" };
+	if (options.body !== undefined) {
+		init.headers = { "Content-Type": "application/json" };
+		init.body = JSON.stringify(options.body);
+	}
+	if (options.signal) {
+		init.signal = options.signal;
+	}
+
+	const res = await fetch(path, init);
+	const json: unknown = await res.json();
+
+	const failureParse = FailureEnvelopeSchema.safeParse(json);
+	if (failureParse.success) {
+		throw new ApiError(failureParse.data);
+	}
+
+	const successParse = SuccessEnvelopeSchema(
+		options.responseSchema,
+	).safeParse(json);
+	if (!successParse.success) {
+		throw new ContractMismatchError(path, res.status);
+	}
+	return successParse.data.data;
+}

--- a/workbench/web/src/lib/api/health.ts
+++ b/workbench/web/src/lib/api/health.ts
@@ -1,0 +1,11 @@
+import { HealthDataSchema, type HealthData } from "@llm-wiki/workbench-contracts";
+
+import { request } from "./client";
+
+/**
+ * GET /api/health —— 通过统一 client 调用 migrated-json endpoint。
+ * 旧 api.ts 的 getHealth 已移除，health 全部走新契约路径。
+ */
+export function getHealth(): Promise<HealthData> {
+	return request("/api/health", { responseSchema: HealthDataSchema });
+}

--- a/workbench/web/test/api-client.test.ts
+++ b/workbench/web/test/api-client.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { z } from "zod";
+
+import { ApiError, ContractMismatchError, request } from "../src/lib/api/client";
+
+const itemSchema = z.object({
+	status: z.literal("ok"),
+	timestamp: z.number(),
+});
+type Item = z.infer<typeof itemSchema>;
+
+function stubFetch(body: unknown, status = 200) {
+	const calls: Array<{ url: string; init?: RequestInit }> = [];
+	globalThis.fetch = ((input: URL | string, init?: RequestInit) => {
+		calls.push({ url: String(input), init });
+		return Promise.resolve(
+			new Response(JSON.stringify(body), {
+				status,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	}) as typeof globalThis.fetch;
+	return calls;
+}
+
+describe("workbench api client", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("成功 envelope 返回已校验 data", async () => {
+		stubFetch({ ok: true, data: { status: "ok", timestamp: 1 } });
+		const data = await request("/api/health", { responseSchema: itemSchema });
+		assert.deepEqual(data, { status: "ok", timestamp: 1 });
+	});
+
+	it("失败 envelope 抛 ApiError，带 code", async () => {
+		stubFetch(
+			{ ok: false, code: "INTERNAL_ERROR", message: "服务器内部错误" },
+			500,
+		);
+		await assert.rejects(
+			() => request("/api/x", { responseSchema: itemSchema }),
+			(err) => err instanceof ApiError && err.code === "INTERNAL_ERROR",
+		);
+	});
+
+	it("旧格式响应（无 ok 字段）抛 ContractMismatchError，不吞旧格式", async () => {
+		stubFetch({ status: "ok", timestamp: 1, service: "s" });
+		await assert.rejects(
+			() => request("/api/legacy", { responseSchema: itemSchema }),
+			(err) => err instanceof ContractMismatchError,
+		);
+	});
+
+	it("旧格式 { ok:true, items } 也判为契约不符", async () => {
+		stubFetch({ ok: true, items: [{ a: 1 }] });
+		await assert.rejects(
+			() => request("/api/legacy2", { responseSchema: itemSchema }),
+			(err) => err instanceof ContractMismatchError,
+		);
+	});
+
+	it("data 不符合 responseSchema 时抛 ContractMismatchError", async () => {
+		stubFetch({ ok: true, data: { status: "down", timestamp: 1 } });
+		await assert.rejects(
+			() => request("/api/x", { responseSchema: itemSchema }),
+			(err) => err instanceof ContractMismatchError,
+		);
+	});
+
+	it("POST 请求传递 method/body/Content-Type", async () => {
+		const calls = stubFetch({
+			ok: true,
+			data: { status: "ok", timestamp: 1 },
+		});
+		await request("/api/x", {
+			method: "POST",
+			body: { foo: "bar" },
+			responseSchema: itemSchema,
+		});
+		const init = calls[0]?.init;
+		assert.equal(init?.method, "POST");
+		const headers = init?.headers as Record<string, string> | undefined;
+		assert.equal(headers?.["Content-Type"], "application/json");
+		assert.deepEqual(JSON.parse(String(init?.body)), { foo: "bar" });
+	});
+
+	it("request<T> 的返回类型是 responseSchema 推导的 data", async () => {
+		stubFetch({ ok: true, data: { status: "ok", timestamp: 7 } });
+		const data: Item = await request("/api/health", {
+			responseSchema: itemSchema,
+		});
+		// 编译期校验：data 类型为 Item；运行期校验：值正确
+		assert.equal(data.timestamp, 7);
+	});
+});


### PR DESCRIPTION
Closes #165.

## 目标

建立 workbench HTTP 契约第一条可验证竖线（**不是迁移所有路由**）：新增 contracts 包 + 统一 JSON envelope + 基础错误码 + `createApp(deps)` + 前端 client，用 `/api/health` 证明 **schema → route → client → test** 端到端跑通。

## 实现

- **新增独立 workspace 包 `@llm-wiki/workbench-contracts`**（Zod envelope / 错误码 / typed-redacted details / health schema），可独立 build/typecheck/test。
- **后端抽出 `createApp(deps)`**：统一 `onError` 兜底（`HttpContractError`→失败 envelope，未捕获→`INTERNAL_ERROR`，**绝不泄露 stack/路径/key**）+ 预留 `deps.security` 可信来源/capability token 接入点（#166 实现）+ `routes/health.ts`；`index.ts` 改用 `createApp()`，未迁移 legacy 路由继续挂在同一 app。
- **前端新增 `api/client.ts`**（只认统一 envelope，不吞旧格式，旧格式抛 `ContractMismatchError`）+ `api/health.ts`；删除旧 `api.ts` 的 `getHealth`（无调用方）。
- **server/web 只从 package export 引用 contracts**，不深路径 import。
- TypeBox 不动（只服务 pi-agent tool parameters）；Zod 只服务 HTTP/SSE 契约。

## 本 PR 迁移 endpoint

- `migrated-json`：`GET /api/health`

## 仍为 legacy（未迁移）

所有其它 `/api/*` 路由：knowledge-bases、knowledge-base（active context）、graph（`/layout`/`rebuild`/`/events`）、conversations、prompt、batch-digest、refs/page、commands、config、models、auth（`/status`/`/set`/`/test`）、artifacts（`/files`）、system/choose-directory、echo。按 #168–#176 逐张迁移。

## 安全边界（PRODUCT.md §6.8）

- `createApp` 的 `INTERNAL_ERROR` 路径不泄露 `err.message`/stack/路径/key，测试用一个含 `/Users/secret/path`、`api_key=sk-leak` 的抛错验证响应体不含这些串。
- details schema 形状安全（字段名 / `issues`（path+message，无原始 body）/ `reason` 枚举 / `diagnosticId`），不放绝对路径/key/body。
- `/api/health` 是只读心跳白名单（无副作用），#166 的 capability token 应豁免它，接入点已预留并注释说明。

## 验证

| 项 | 结果 |
|---|---|
| contracts build / typecheck / test | ✓ 9/9 |
| server typecheck | ✓ |
| server route 测试 `app.test.ts`（`createApp().request`，fake deps，不读写真实目录） | ✓ 7/7 |
| server 全部 test | ✓ 49/49 |
| web typecheck | ✓ |
| web client 测试 `api-client.test.ts`（mock fetch，覆盖成功/失败/旧格式/schema mismatch） | ✓ 7/7 |
| web 全部 test（unit + dom） | ✓ 108/108 |
| `npm run typecheck`（全 workspace） | ✓ |
| `git diff --check` | ✓ |
| 独立 code review（adversarial） | 无阻塞性问题 |

## CHANGELOG

未更新根 `CHANGELOG.md`：该 CHANGELOG 是 Skill 用户功能发布记录（v3.6.x 图谱/阅读/视觉），本 PR 是 workbench 内部 HTTP 契约基础设施（spec 明确"不改变用户看到的功能"，health 无 UI 调用方、用户无感知）。workbench 架构决策走 `PRODUCT.md` / ADR / spec。

## 设计依据

`docs/superpowers/specs/2026-07-10-workbench-http-routing-contracts-design.md`（父 issue #158，已随设计分支合并入 main）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)