### PR TITLE
feat(server): 本地 API 安全边界 — loopback + capability token + 可信来源 (#166)

### DIFF
--- a/packages/workbench-contracts/src/endpoints.ts
+++ b/packages/workbench-contracts/src/endpoints.ts
@@ -362,8 +362,72 @@ export function isMigratedJsonPath(path: string): path is MigratedJsonPath {
 	return (MIGRATED_JSON_PATHS as readonly string[]).includes(path);
 }
 
-// 注：按 method + path 查询 endpoint、把 safety 映射成 token 要求等安全边界
-// 查询留给 #166 实现时按需补（本 PR 只提供 metadata 单一来源，不预判其 API 形态）。
+// ============= 从 registry 派生：安全边界查询（#166） =============
+//
+// 把 (method, path) 映射到 endpoint 的 safety，供本地 API 安全中间件判定
+// “该请求是否需要本次启动的 capability token”。与 migrated-json 派生一样，
+// 这里只读 ENDPOINT_REGISTRY 单一来源，不维护第二份分类表。
+//
+// path 用 Hono 风格 `:param` 登记动态段（如 `/api/artifacts/:id/files/:filename`）。
+// 下面把每条 entry 的 pattern 预编译成 RegExp，请求时按 method + path 匹配。
+
+/**
+ * 携带本地 capability token 的请求头名（#166）。
+ * 后端中间件据此头校验，dev 代理 / 未来桌面壳据此头注入。单一来源，避免双端
+ * 各写一份字面量后漂移（漂移会导致安全检查静默失效）。
+ */
+export const CAPABILITY_TOKEN_HEADER = "X-LLM-Wiki-Workbench-Token";
+
+/** 把 Hono 风格 `:param` path 编译成完整匹配的 RegExp（:param -> [^/]+）。 */
+function compilePathPattern(pattern: string): RegExp {
+	const escaped = pattern
+		.split("/")
+		.map((segment) =>
+			segment.startsWith(":")
+				? `[^/]+`
+				: segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+		)
+		.join("/");
+	return new RegExp(`^${escaped}$`);
+}
+
+/** 预编译的 registry：entry + 可匹配 path 的 RegExp。模块加载时一次性建好。 */
+interface CompiledEntry {
+	readonly entry: EndpointEntry;
+	readonly pattern: RegExp;
+}
+const COMPILED_REGISTRY: readonly CompiledEntry[] = ENDPOINT_REGISTRY.map(
+	(entry) => ({ entry, pattern: compilePathPattern(entry.path) }),
+);
+
+/**
+ * 按 (method, path) 查找 endpoint 元数据。path 支持动态段实际值匹配
+ * （如 `/api/artifacts/abc/files/x.md` 命中 `/api/artifacts/:id/files/:filename`）。
+ * 未登记 endpoint 返回 undefined。
+ */
+export function findEndpoint(
+	method: string,
+	path: string,
+): EndpointEntry | undefined {
+	const normalized = method.toUpperCase();
+	for (const { entry, pattern } of COMPILED_REGISTRY) {
+		if (entry.method === normalized && pattern.test(path)) return entry;
+	}
+	return undefined;
+}
+
+/**
+ * 该请求是否需要本地 capability token（#166 安全中间件消费）。
+ *
+ * - 命中 `state-changing` endpoint → 需要 token。
+ * - 命中 `read-only` endpoint → 豁免（显式白名单）。
+ * - 未登记 endpoint → **安全默认：需要 token**（fail closed，避免漏网的新增状态改写路由）。
+ */
+export function requiresCapabilityToken(method: string, path: string): boolean {
+	const entry = findEndpoint(method, path);
+	if (!entry) return true;
+	return entry.safety === "state-changing";
+}
 
 // ============= 静态自检（编译期护栏，被 typecheck 覆盖） =============
 //

--- a/packages/workbench-contracts/test/endpoints.test.ts
+++ b/packages/workbench-contracts/test/endpoints.test.ts
@@ -6,8 +6,10 @@ import {
 	EndpointKindSchema,
 	EndpointSafetySchema,
 	ENDPOINT_REGISTRY,
+	findEndpoint,
 	isMigratedJsonPath,
 	MIGRATED_JSON_PATHS,
+	requiresCapabilityToken,
 } from "../src/index.js";
 
 test("ENDPOINT_REGISTRY 每条 entry 形状合法", () => {
@@ -96,4 +98,50 @@ test("isMigratedJsonPath 接受 migrated-json、拒绝 legacy path", () => {
 		isMigratedJsonPath("/api/artifacts/x/files/y.md"),
 		false, // file-download，不是 migrated-json
 	);
+});
+
+// ============= #166 安全边界查询 =============
+
+test("禁止 GET 产生副作用：registry 里没有任何 GET 被标记为 state-changing", () => {
+	// spec §9：禁止 GET 产生副作用。数据层护栏——所有 GET 必须是只读白名单。
+	// 这条不变量保证安全中间件只要把 read-only 放行，就绝不会漏放一个会改状态的 GET。
+	for (const entry of ENDPOINT_REGISTRY) {
+		if (entry.method === "GET") {
+			assert.equal(
+				entry.safety,
+				"read-only",
+				`GET ${entry.path} 不允许标记为 state-changing`,
+			);
+		}
+	}
+});
+
+test("findEndpoint 命中静态 path 与动态段 path", () => {
+	assert.equal(findEndpoint("GET", "/api/health")?.path, "/api/health");
+	// 方法不匹配
+	assert.equal(findEndpoint("POST", "/api/health"), undefined);
+	// 动态段：:id / :filename 实际值匹配
+	const file = findEndpoint("GET", "/api/artifacts/abc-123/files/report.md");
+	assert.equal(file?.path, "/api/artifacts/:id/files/:filename");
+	assert.equal(file?.kind, "file-download");
+	assert.equal(file?.safety, "read-only");
+	// 方法小写也归一
+	assert.equal(findEndpoint("get", "/api/health")?.path, "/api/health");
+});
+
+test("requiresCapabilityToken：state-changing 需要、read-only 豁免、未登记 fail closed", () => {
+	// read-only 白名单豁免 token
+	assert.equal(requiresCapabilityToken("GET", "/api/health"), false);
+	assert.equal(requiresCapabilityToken("GET", "/api/events"), false); // 只读 SSE
+	assert.equal(
+		requiresCapabilityToken("GET", "/api/artifacts/x/files/y.md"),
+		false,
+	); // 文件下载
+	// state-changing 需要 token
+	assert.equal(requiresCapabilityToken("POST", "/api/prompt"), true);
+	assert.equal(requiresCapabilityToken("POST", "/api/knowledge-bases/new"), true);
+	assert.equal(requiresCapabilityToken("PUT", "/api/graph/layout"), true);
+	assert.equal(requiresCapabilityToken("DELETE", "/api/knowledge-base"), true);
+	// 未登记 endpoint 安全默认：需要 token（避免漏网的新增状态改写路由）
+	assert.equal(requiresCapabilityToken("POST", "/api/unknown-new-route"), true);
 });

--- a/workbench/server/src/index.ts
+++ b/workbench/server/src/index.ts
@@ -75,6 +75,12 @@ import {
 	unregisterExternalKnowledgeBase,
 } from "./knowledge-bases.js";
 import { listPageRefs, readWikiPage } from "./pages.js";
+import { localHostOnly } from "./security/host.js";
+import { createSecurityMiddleware } from "./security/middleware.js";
+import {
+	generateCapabilityToken,
+	writeCapabilityToken,
+} from "./security/token.js";
 import {
 	buildKnowledgeContextMessage,
 	contextBudgetFromWindow,
@@ -158,16 +164,24 @@ function errorStatus(err: unknown, fallback: 400 | 500 = 500): 400 | 403 | 500 {
 	return fallback;
 }
 
-function localHostOnly(rawHost: string | undefined): string {
-	const host = rawHost?.trim() || "127.0.0.1";
-	if (host === "127.0.0.1" || host === "localhost" || host === "::1") return host;
-	console.warn(`[llm-wiki-agent/server] ignoring unsafe HOST=${host}; binding to 127.0.0.1`);
-	return "127.0.0.1";
-}
+// 本次启动生成本地 capability token（#166）。token 写入运行期文件，供同机可信
+// dev 代理 / 未来桌面壳读取后注入请求头；token 不进 URL / 日志 / config。
+const capabilityToken = generateCapabilityToken();
+await writeCapabilityToken(capabilityToken);
+
+// 可信来源 Origin（辅助信号）：dev web origin。桌面壳 origin 待桌面安装版落地时
+// 在此追加。origin 仅作辅助 deny，会改状态 endpoint 仍必须带 token（见 middleware）。
+const trustedOrigins = new Set(["http://localhost:5180", "http://127.0.0.1:5180"]);
 
 // createApp 组装统一 middleware / 错误兜底 / 已迁移 route module（health）。
 // 未迁移的 legacy route 继续挂在这个 app 上，等后续 issue 逐个迁移。
-const app = createApp();
+// security 中间件挂在所有 /api/* 之前：read-only 白名单豁免，state-changing 强制 token + 可信来源。
+const app = createApp({
+	security: createSecurityMiddleware({
+		token: capabilityToken,
+		trustedOrigins,
+	}),
+});
 
 app.get("/api/events", (c) => {
 	return streamSSE(c, async (stream) => {

--- a/workbench/server/src/security/host.test.ts
+++ b/workbench/server/src/security/host.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isLoopbackHost, localHostOnly } from "./host.js";
+
+test("localHostOnly 空 / loopback 原样放行", () => {
+	assert.equal(localHostOnly(undefined), "127.0.0.1");
+	assert.equal(localHostOnly(""), "127.0.0.1");
+	assert.equal(localHostOnly("  "), "127.0.0.1");
+	assert.equal(localHostOnly("127.0.0.1"), "127.0.0.1");
+	assert.equal(localHostOnly("localhost"), "localhost");
+	assert.equal(localHostOnly("::1"), "::1");
+});
+
+test("localHostOnly 非法 host 一律降级回 127.0.0.1（不对局域网开放）", () => {
+	// 0.0.0.0 会把本地 API 暴露到所有网卡，必须被拒
+	assert.equal(localHostOnly("0.0.0.0"), "127.0.0.1");
+	assert.equal(localHostOnly("192.168.1.5"), "127.0.0.1");
+	assert.equal(localHostOnly("example.com"), "127.0.0.1");
+});
+
+test("isLoopbackHost 直接判别", () => {
+	assert.equal(isLoopbackHost("127.0.0.1"), true);
+	assert.equal(isLoopbackHost("localhost"), true);
+	assert.equal(isLoopbackHost("::1"), true);
+	assert.equal(isLoopbackHost("0.0.0.0"), false);
+	assert.equal(isLoopbackHost("10.0.0.1"), false);
+});

--- a/workbench/server/src/security/host.ts
+++ b/workbench/server/src/security/host.ts
@@ -1,0 +1,30 @@
+/**
+ * 安全 host 边界：后端默认只绑定 loopback（spec §9 / PRODUCT.md §6.8）。
+ *
+ * 本地 API 不对局域网或任意网页开放。不安全 HOST 不被信任，统一降级回
+ * 127.0.0.1 并告警，避免误配置把会改状态的本地 API 暴露到 0.0.0.0。
+ *
+ * 抽到独立模块是为了让“loopback-only”可以被路由测试直接覆盖（原本埋在
+ * index.ts 启动流程里，无法单测）。
+ */
+
+/** 允许绑定的 loopback host 集合。其余地址一律拒绝。 */
+export const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+/** host 是否属于 loopback。 */
+export function isLoopbackHost(host: string): boolean {
+	return LOOPBACK_HOSTS.has(host.trim());
+}
+
+/**
+ * 把用户/环境配置的 HOST 收敛成安全的 loopback host。
+ * 空 -> 127.0.0.1；loopback 原样通过；非 loopback -> 告警并降级回 127.0.0.1。
+ */
+export function localHostOnly(rawHost: string | undefined): string {
+	const host = rawHost?.trim() || "127.0.0.1";
+	if (isLoopbackHost(host)) return host;
+	console.warn(
+		`[llm-wiki-agent/server] ignoring unsafe HOST=${host}; binding to 127.0.0.1`,
+	);
+	return "127.0.0.1";
+}

--- a/workbench/server/src/security/middleware.test.ts
+++ b/workbench/server/src/security/middleware.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createApp } from "../app.js";
+import { CAPABILITY_TOKEN_HEADER } from "./token.js";
+import { createSecurityMiddleware } from "./middleware.js";
+
+const TOKEN = "test-capability-token-secret-do-not-log-7f3e";
+const TRUSTED_ORIGIN = "http://localhost:5180";
+const TRUSTED_ORIGINS = new Set([TRUSTED_ORIGIN]);
+
+type EnvelopeJson = {
+	ok?: boolean;
+	code?: string;
+	message?: string;
+};
+
+/**
+ * 搭一个带真实 security 中间件 + 若干 registry 路径的测试 app：
+ *  - GET /api/health                         read-only（createApp 自带）
+ *  - POST /api/echo                          read-only（POST 不等于要 token）
+ *  - GET /api/artifacts/:id/files/:filename  file-download read-only
+ *  - POST /api/knowledge-bases/new           state-changing
+ *  - POST /api/prompt                        state-changing（SSE 启动）
+ */
+function buildApp(
+	token: string = TOKEN,
+	trustedOrigins: ReadonlySet<string> = TRUSTED_ORIGINS,
+) {
+	const app = createApp({
+		security: createSecurityMiddleware({ token, trustedOrigins }),
+	});
+	app.post("/api/echo", (c) => c.json({ ok: true }));
+	app.get("/api/artifacts/:id/files/:filename", (c) => c.json({ ok: true }));
+	app.post("/api/knowledge-bases/new", (c) => c.json({ ok: true }));
+	app.post("/api/prompt", (c) => c.json({ ok: true }));
+	return app;
+}
+
+function headers(overrides: Record<string, string> = {}): Record<string, string> {
+	return overrides;
+}
+
+// ============= read-only 白名单 =============
+
+test("read-only GET 白名单：无需 token / 来源即放行", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/health");
+	assert.equal(res.status, 200);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, true);
+});
+
+test("read-only GET 即便来源不可信也放行（无副作用白名单）", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/health", {
+		headers: headers({ origin: "http://evil.example" }),
+	});
+	assert.equal(res.status, 200);
+});
+
+test("POST 不等于需要 token：read-only 的 POST /api/echo 无 token 放行", async () => {
+	// 证明判据是 endpoint 的 safety，不是 HTTP method
+	const app = buildApp();
+	const res = await app.request("/api/echo", { method: "POST" });
+	assert.equal(res.status, 200);
+});
+
+test("文件下载 GET 无 token / 来源即放行", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/artifacts/abc/files/report.md");
+	assert.equal(res.status, 200);
+});
+
+// ============= token 校验 =============
+
+test("state-changing POST 缺 token -> 403 FORBIDDEN_LOCAL_API", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({ origin: TRUSTED_ORIGIN }),
+	});
+	assert.equal(res.status, 403);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, false);
+	assert.equal(json.code, "FORBIDDEN_LOCAL_API");
+});
+
+test("state-changing POST token 错误 -> 403 FORBIDDEN_LOCAL_API", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({
+			origin: TRUSTED_ORIGIN,
+			[CAPABILITY_TOKEN_HEADER]: "wrong-token",
+		}),
+	});
+	assert.equal(res.status, 403);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.code, "FORBIDDEN_LOCAL_API");
+});
+
+test("state-changing POST 带正确 token + 可信来源 -> 200", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({
+			origin: TRUSTED_ORIGIN,
+			[CAPABILITY_TOKEN_HEADER]: TOKEN,
+		}),
+	});
+	assert.equal(res.status, 200);
+});
+
+test("SSE 启动 POST /api/prompt 同样要求 token（缺 -> 403）", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/prompt", {
+		method: "POST",
+		headers: headers({ origin: TRUSTED_ORIGIN }),
+	});
+	assert.equal(res.status, 403);
+	assert.equal(((await res.json()) as EnvelopeJson).code, "FORBIDDEN_LOCAL_API");
+});
+
+test("未登记 endpoint 默认要求 token（fail closed，防漏网新路由）", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/brand-new-not-registered", {
+		method: "POST",
+		headers: headers({ origin: TRUSTED_ORIGIN }),
+	});
+	assert.equal(res.status, 403);
+	// 未登记路由没有 handler，但安全中间件先短路，仍返回 FORBIDDEN_LOCAL_API
+	assert.equal(((await res.json()) as EnvelopeJson).code, "FORBIDDEN_LOCAL_API");
+});
+
+// ============= 来源校验（辅助 deny） =============
+
+test("不可信来源即便带正确 token -> 403 FORBIDDEN_ORIGIN", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({
+			origin: "http://evil.example",
+			[CAPABILITY_TOKEN_HEADER]: TOKEN,
+		}),
+	});
+	assert.equal(res.status, 403);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.code, "FORBIDDEN_ORIGIN");
+});
+
+test("null origin（桌面 WebView）不单独放行：仍需 token（#9）", async () => {
+	const app = buildApp();
+	// null + 无 token -> 拒（不能因 null 就放行）
+	const denied = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({ origin: "null" }),
+	});
+	assert.equal(denied.status, 403);
+	assert.equal(
+		((await denied.json()) as EnvelopeJson).code,
+		"FORBIDDEN_LOCAL_API",
+	);
+	// null + 正确 token -> 放行（token 才是依据）
+	const allowed = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({
+			origin: "null",
+			[CAPABILITY_TOKEN_HEADER]: TOKEN,
+		}),
+	});
+	assert.equal(allowed.status, 200);
+});
+
+test("缺省 origin（非浏览器可信客户端 / 同源）带 token 放行", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({ [CAPABILITY_TOKEN_HEADER]: TOKEN }),
+	});
+	assert.equal(res.status, 200);
+});
+
+// ============= token 不进 URL / 日志 =============
+
+test("token 不接受经 URL query 传递：URL 带 token 仍被拒（token 不在 URL）", async () => {
+	const app = buildApp();
+	// token 只认请求头；放进 URL query 不生效 -> 拒绝
+	const res = await app.request(
+		`/api/knowledge-bases/new?token=${encodeURIComponent(TOKEN)}`,
+		{ method: "POST", headers: headers({ origin: TRUSTED_ORIGIN }) },
+	);
+	assert.equal(res.status, 403);
+	assert.equal(
+		((await res.json()) as EnvelopeJson).code,
+		"FORBIDDEN_LOCAL_API",
+	);
+});
+
+test("错误 token 的失败 envelope 不回显 token；成功响应也不含 token", async () => {
+	const app = buildApp();
+	const denied = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({
+			origin: TRUSTED_ORIGIN,
+			[CAPABILITY_TOKEN_HEADER]: "wrong-token",
+		}),
+	});
+	const deniedBody = JSON.stringify(await denied.json());
+	assert.equal(deniedBody.includes(TOKEN), false);
+
+	const allowed = await app.request("/api/knowledge-bases/new", {
+		method: "POST",
+		headers: headers({
+			origin: TRUSTED_ORIGIN,
+			[CAPABILITY_TOKEN_HEADER]: TOKEN,
+		}),
+	});
+	const allowedBody = JSON.stringify(await allowed.json());
+	assert.equal(allowedBody.includes(TOKEN), false);
+});
+
+test("请求处理过程中 token 不写入任何 console 输出（不进日志）", async () => {
+	const app = buildApp();
+	const sink: string[] = [];
+	const originals = {
+		log: console.log,
+		warn: console.warn,
+		error: console.error,
+		info: console.info,
+		debug: console.debug,
+	};
+	const tap = (...args: unknown[]) => void sink.push(args.map(String).join(" "));
+	Object.assign(console, { log: tap, warn: tap, error: tap, info: tap, debug: tap });
+	try {
+		await app.request("/api/knowledge-bases/new", {
+			method: "POST",
+			headers: headers({
+				origin: TRUSTED_ORIGIN,
+				[CAPABILITY_TOKEN_HEADER]: TOKEN,
+			}),
+		});
+	} finally {
+		Object.assign(console, originals);
+	}
+	const combined = sink.join("\n");
+	assert.equal(
+		combined.includes(TOKEN),
+		false,
+		"capability token 不得出现在任何 console 日志中",
+	);
+});

--- a/workbench/server/src/security/middleware.ts
+++ b/workbench/server/src/security/middleware.ts
@@ -1,0 +1,87 @@
+import { timingSafeEqual } from "node:crypto";
+
+import type { MiddlewareHandler } from "hono";
+
+import { requiresCapabilityToken } from "@llm-wiki/workbench-contracts";
+
+import { jsonError } from "../http/response.js";
+import { CAPABILITY_TOKEN_HEADER } from "./token.js";
+
+/** 桌面 WebView 会发出的字面量 "null" origin（spec §9）。 */
+const NULL_ORIGIN = "null";
+
+export interface SecurityMiddlewareOptions {
+	/** 本次启动生成的 capability token（首要防线）。 */
+	token: string;
+	/**
+	 * 可信来源 Origin 集合（仅作辅助 deny 信号）。dev 默认含 web origin；
+	 * 桌面壳将来追加桌面 origin。
+	 *
+	 * 注意：即便 origin 在白名单内，会改状态的 endpoint 仍要求 token —— origin
+	 * 绝不作唯一安全依据（spec §9 / #10）。
+	 */
+	trustedOrigins: ReadonlySet<string>;
+}
+
+/** timing-safe 比较 token：长度不同先返回 false（避免 timingSafeEqual 抛错）。 */
+function tokenMatches(provided: string, expected: string): boolean {
+	const a = Buffer.from(provided);
+	const b = Buffer.from(expected);
+	if (a.length !== b.length) return false;
+	return timingSafeEqual(a, b);
+}
+
+/**
+ * 本地 API 统一安全入口中间件（#166）。
+ *
+ * 判定以 @llm-wiki/workbench-contracts 的 ENDPOINT_REGISTRY 为单一来源
+ *（`requiresCapabilityToken` 派生自 registry，不维护第二份分类表）：
+ *
+ *  - read-only endpoint（health / 只读 SSE / 文件下载 / 各类 list·read）→ 显式
+ *    白名单，豁免 token 与来源检查。
+ *  - state-changing endpoint（含未登记，fail closed）→ 必须同时满足：
+ *      1. 来源不是“已知的不可信”：Origin 缺省 / "null"（桌面 WebView）/ 在白名单
+ *         内都放行进入下一步；出现且非 null 且不在白名单 → FORBIDDEN_ORIGIN。
+ *      2. 携带与本次启动一致的 capability token（timing-safe）→ 否则
+ *         FORBIDDEN_LOCAL_API。
+ *
+ * 设计要点（spec §9 / #9 / #10）：
+ *  - token 是首要且充分的防线；Origin 仅作辅助 deny，绝不作唯一依据。
+ *  - null origin 不能单独放行：仍必须带 token（走第 2 步）。
+ *  - 未登记 endpoint 默认要求 token，避免新增状态改写路由漏过检查。
+ *  - 失败一律走统一 error envelope + 稳定 code（spec §9）。
+ */
+export function createSecurityMiddleware(
+	options: SecurityMiddlewareOptions,
+): MiddlewareHandler {
+	const { token, trustedOrigins } = options;
+	return async (c, next) => {
+		// read-only 白名单：豁免 token 与来源检查。
+		if (!requiresCapabilityToken(c.req.method, c.req.path)) {
+			return next();
+		}
+
+		// 1. 辅助来源 deny：出现且非 null 且不可信 → 拒绝。
+		//    （缺省 / null / 可信 → 放行进入 token 检查；token 才是首要依据）
+		const origin = c.req.header("origin");
+		const originAllowed =
+			origin === undefined ||
+			origin === NULL_ORIGIN ||
+			trustedOrigins.has(origin);
+		if (!originAllowed) {
+			return jsonError(c, "FORBIDDEN_ORIGIN", "请求来源不是工作台可信来源");
+		}
+
+		// 2. 首要防线：capability token 必须匹配本次启动。
+		const provided = c.req.header(CAPABILITY_TOKEN_HEADER);
+		if (!provided || !tokenMatches(provided, token)) {
+			return jsonError(
+				c,
+				"FORBIDDEN_LOCAL_API",
+				"缺少或无效的本地 capability token",
+			);
+		}
+
+		return next();
+	};
+}

--- a/workbench/server/src/security/token.ts
+++ b/workbench/server/src/security/token.ts
@@ -1,0 +1,49 @@
+/**
+ * 本地 capability token（spec §9 / PRODUCT.md §6.8 运行时信任边界）。
+ *
+ * 每次 server 启动生成一个随机 token，作为本地 API 的能力凭证：所有会读写
+ * 文件、改配置、触发模型、启动 SSE、取消任务的 endpoint 必须带这个 token
+ * 才放行（见 ./middleware.ts）。
+ *
+ * token 是本次进程的运行期秘密，红线（spec §9）：
+ *   - 不进 URL、不进日志、不进仓库、不进 config.json。
+ *   - 只写一份临时运行期文件（~/.llm-wiki-agent/runtime/capability-token，
+ *     权限 0600），供同机可信 dev 代理 / 未来桌面壳读取后注入到请求头；下次
+ *     启动覆盖。它与 config.json 分开，不是“永久 config”。
+ *
+ * token 的交付路径（dev）：Vite dev 代理读取上面的运行期文件，在转发到后端的
+ * /api 请求上注入 CAPABILITY_TOKEN_HEADER。这样 token 永远不进入浏览器上下文
+ * （抗 XSS），且不改动任何前端业务调用。桌面安装版由桌面壳原生注入同一请求头。
+ */
+
+import { randomBytes } from "node:crypto";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { CAPABILITY_TOKEN_HEADER } from "@llm-wiki/workbench-contracts";
+
+import { APP_DIR } from "../config.js";
+
+export { CAPABILITY_TOKEN_HEADER };
+
+/**
+ * 运行期 token 文件路径。同机可信客户端据此读取本次启动的 token。
+ * 注意：与 config.json 完全分开，只存本次进程秘密。
+ */
+export const CAPABILITY_TOKEN_FILE = join(APP_DIR, "runtime", "capability-token");
+
+/** 生成 256-bit URL-safe 随机 token，足够抵抗穷举。 */
+export function generateCapabilityToken(): string {
+	return randomBytes(32).toString("base64url");
+}
+
+/**
+ * 把本次启动的 token 原子写入运行期文件（权限 0600）。
+ * 原子写（先 .tmp 再 rename）避免可信客户端读到半截内容。
+ */
+export async function writeCapabilityToken(token: string): Promise<void> {
+	await mkdir(dirname(CAPABILITY_TOKEN_FILE), { recursive: true, mode: 0o700 });
+	const tmp = `${CAPABILITY_TOKEN_FILE}.tmp`;
+	await writeFile(tmp, token, { mode: 0o600 });
+	await rename(tmp, CAPABILITY_TOKEN_FILE);
+}

--- a/workbench/web/vite.config.ts
+++ b/workbench/web/vite.config.ts
@@ -1,10 +1,49 @@
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import { resolve } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+import { CAPABILITY_TOKEN_HEADER } from "@llm-wiki/workbench-contracts";
+
 const apiOrigin = process.env.LLM_WIKI_AGENT_API_ORIGIN || "http://localhost:8787";
 const disableHmr = process.env.LLM_WIKI_AGENT_DISABLE_HMR === "1";
+
+// ============= 本地 capability token（#166） =============
+//
+// dev 期由 Vite 代理把后端生成的 capability token 注入到转发请求头，这样：
+//   - token 永远不进入浏览器上下文（抗 XSS：前端业务代码、JS 都拿不到它）；
+//   - 前端业务调用零改动（legacy api.ts 与新 api/client.ts 都照常走 /api 代理）；
+//   - token 不进 URL / 不进日志 / 不进仓库 / 不进 config（只存在后端内存 + 这份
+//     运行期文件里，由同机可信的 dev 代理读取后注入）。
+//
+// 路径与后端 workbench/server/src/security/token.ts 的 CAPABILITY_TOKEN_FILE 对齐
+// （~/.llm-wiki-agent/runtime/capability-token）；请求头名取自 @llm-wiki/workbench-contracts
+// 单一来源（与后端中间件共享同一常量，避免双端漂移）。
+const CAPABILITY_TOKEN_FILE = resolve(
+	homedir(),
+	".llm-wiki-agent",
+	"runtime",
+	"capability-token",
+);
+
+// 同步缓存：proxyReq 回调必须同步注入 header（异步 setHeader 会晚于请求发出）。
+// 按 mtime 失效重读，自动适配 tsx watch 重启后端换发的新 token。后端尚未写文件时
+// 返回 undefined（本次不注入），下一笔请求后端起来后自动补上。
+let cachedToken: string | undefined;
+let cachedMtimeMs: number | undefined;
+function readCapabilityTokenSync(): string | undefined {
+	try {
+		const mtimeMs = statSync(CAPABILITY_TOKEN_FILE).mtimeMs;
+		if (mtimeMs === cachedMtimeMs) return cachedToken;
+		cachedToken = readFileSync(CAPABILITY_TOKEN_FILE, "utf8").trim();
+		cachedMtimeMs = mtimeMs;
+		return cachedToken;
+	} catch {
+		return undefined;
+	}
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -24,6 +63,13 @@ export default defineConfig({
 			"/api": {
 				target: apiOrigin,
 				changeOrigin: true,
+				configure: (proxy) => {
+					// 把 capability token 注入到每个转发到后端的 /api 请求头。
+					proxy.on("proxyReq", (proxyReq) => {
+						const token = readCapabilityTokenSync();
+						if (token) proxyReq.setHeader(CAPABILITY_TOKEN_HEADER, token);
+					});
+				},
 			},
 		},
 	},


### PR DESCRIPTION
Closes #166. 父 issue #158。为工作台本地 API 建立统一安全入口，为未来 Mac/Windows 桌面安装版打基础（PRODUCT.md §6.8 / 设计稿 spec §9）。

## 改了什么

按 #167 endpoint contract registry 的 `safety` 元数据（单一来源）实现本地 API 信任边界，分三层 commit：

- **contracts**（`packages/workbench-contracts/src/endpoints.ts`）：从 registry 派生安全边界查询 —— `findEndpoint(method, path)`（Hono `:param` 动态段匹配）、`requiresCapabilityToken(method, path)`（read-only 豁免 / state-changing 需要 / 未登记 fail closed），以及共享常量 `CAPABILITY_TOKEN_HEADER`。
- **server**（`workbench/server/src/security/`）：`localHostOnly`（非 loopback 降级回 127.0.0.1，可测）、`generateCapabilityToken` + 运行期文件（0600，与 config.json 分开）、`createSecurityMiddleware`（read-only 白名单豁免；state-changing 要求 timing-safe token + 可信来源，Origin 仅作辅助 deny，null origin 不单独放行仍需 token）。经 `createApp({ security })` 挂在所有 `/api/*` 之前。
- **web**（`workbench/web/vite.config.ts`）：dev 代理在 `proxyReq` 上注入 token 头。

## 验收对照

| #166 要求 | 落地 |
|---|---|
| 后端默认只绑定 loopback | `localHostOnly` + 路由测试 + 实测绑定 127.0.0.1 |
| 每次启动生成 capability token，不进 URL/日志/仓库/永久 config | `crypto.randomBytes(32)` → base64url，写 `~/.llm-wiki-agent/runtime/capability-token`（0600）；运行期文件，非 config.json；测试断言 token 不进 URL query / console / envelope |
| 会改状态的 endpoint 必须过 token + 可信来源 | middleware，含未登记 fail closed |
| health / 只读 graph events / 文件下载显式白名单 | 全部 `read-only` 豁免 |
| 白名单/安全分类消费 #167 metadata | `requiresCapabilityToken` 只读 `ENDPOINT_REGISTRY`，无第二份分类表 |
| 禁止 GET 产生副作用 | registry 不变量测试：无 GET 标记为 state-changing |
| 非可信来源 / token 错误 → 统一 envelope + 稳定 code | `FORBIDDEN_ORIGIN` / `FORBIDDEN_LOCAL_API` |
| 桌面 WebView null origin 仍需 token（#9） | null origin 进入 token 检查，测试覆盖 |
| Origin / Fetch Metadata 仅辅助（#10） | token 是首要且充分防线，origin 是辅助 deny |

## 完成汇报（按 issue 要求）

**token 如何生成和传递**
- 生成：server 启动时 `crypto.randomBytes(32).toString("base64url")`，256-bit。
- 传递：后端原子写入运行期文件 `~/.llm-wiki-agent/runtime/capability-token`（0600）；**dev 由 Vite 代理读取该文件并在 `proxyReq` 上注入 `X-LLM-Wiki-Workbench-Token` 头**，token 永不进入浏览器上下文（抗 XSS），前端业务调用（legacy `api.ts` 与新 `api/client.ts`）零改动；桌面安装版未来由桌面壳原生注入同一请求头。

**哪些 endpoint 暂时白名单**
所有 `safety: read-only` 的 endpoint：`GET /api/health`、`GET /api/events`（只读 SSE EventSource）、`GET /api/artifacts/:id/files/:filename`（文件下载）、`POST /api/echo`，以及各 `GET` list/read（knowledge-bases、graph、refs、page、commands、config、models、artifacts、auth/status、conversations 等）。白名单=豁免 token 与来源检查（spec §9：无副作用端点）。

**如何消费 #167 metadata**
`requiresCapabilityToken(method, path)` 派生自 `ENDPOINT_REGISTRY` 的 `safety` 字段（经 `findEndpoint` 做动态段匹配），是中间件判定 token 要求的唯一依据。不另建分类表；路由迁移时改 registry entry 的 `safety`，调用路径与安全边界随之收敛。

**下一批可并行 issue：#168 和 #171**
本 PR 的安全地基已就位：route 拆分 / 迁移可独立推进，新 route 只要登记进 registry 即自动获得 token + 可信来源检查（无法绕过），`createApp({ security })` 是统一入口。

## 设计说明（review 期间澄清）

- **取消任务**：验收提到“取消任务”endpoint，但当前实现里取消走客户端断连（`stream.onAbort → session.abort`），无独立 cancel endpoint，故无项可登记；待未来若新增显式 cancel route，登记为 state-changing 即自动纳入。
- **文件下载白名单**：spec §9 第 409 行明确把“文件下载”列入白名单（无副作用读）。跨域 JS 读取受后端不发 CORS 头限制（浏览器阻止读响应），故无 JS 可达的泄露面；artifact id 为 UUID 不可枚举。保持 spec 行为，未额外加来源检查。

## review 驱动的简化

- 移除未被消费的 `isReadOnlyEndpoint`（YAGNI，`requiresCapabilityToken` 已覆盖中间件需要）。
- `CAPABILITY_TOKEN_HEADER` 单一来源到 contracts，避免双端字面量漂移致安全检查静默失效。
- Vite 从 2s 轮询插件简化为 per-request 同步读取（mtime 缓存）：更少代码、无生命周期样板、对 tsx watch 重启即时自愈。
- 移除未要求的 `LLM_WIKI_AGENT_TRUSTED_ORIGINS` env 变量（YAGNI），桌面 origin 待桌面版落地时在此追加。

## 验证

- `npm run typecheck`（contracts + server + web）：通过
- contracts 20 / server 67 / web 126(unit) + 108(dom)：全绿
- `git diff --check`：clean；隐私自查无本机路径/真名
- 实测：后端绑 127.0.0.1、token 文件 0600、直发 state-changing 无 token→403 FORBIDDEN_LOCAL_API、带 token→200、不可信 origin→403 FORBIDDEN_ORIGIN、经 Vite 代理（不自带 token）state-changing→200（代理注入生效）、token 不进 server 日志

## 未迁移 endpoint 说明（spec PR 规则）

本 PR 不迁移任何业务路由。endpoint 分类（legacy / migrated-json / file-download / sse 与 read-only / state-changing）沿用 #167 registry，未变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)