### PR TITLE
feat(workbench): migrate config/models/auth status routes (#168)

### DIFF
--- a/packages/workbench-contracts/src/auth.ts
+++ b/packages/workbench-contracts/src/auth.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const AuthProviderStatusSchema = z.object({
+	id: z.string(),
+	type: z.string(),
+	configured: z.boolean(),
+});
+export type AuthProviderStatus = z.infer<typeof AuthProviderStatusSchema>;
+
+export const AuthEnvKeyStatusSchema = z.object({
+	name: z.string(),
+	present: z.boolean(),
+});
+export type AuthEnvKeyStatus = z.infer<typeof AuthEnvKeyStatusSchema>;
+
+export const AuthStatusDataSchema = z.object({
+	authFileExists: z.boolean(),
+	providers: z.array(AuthProviderStatusSchema),
+	envKeys: z.array(AuthEnvKeyStatusSchema),
+});
+export type AuthStatusData = z.infer<typeof AuthStatusDataSchema>;

--- a/packages/workbench-contracts/src/config.ts
+++ b/packages/workbench-contracts/src/config.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+export const ModelRefSchema = z.object({
+	provider: z.string().trim().min(1),
+	modelId: z.string().trim().min(1),
+});
+export type ModelRef = z.infer<typeof ModelRefSchema>;
+
+export const AppConfigSchema = z.object({
+	version: z.literal(1),
+	externalKnowledgeBases: z.array(z.string()),
+	lastUsedKbPath: z.string().optional(),
+	showUserGlobalSkills: z.boolean().optional(),
+	modelRoles: z
+		.object({
+			main: ModelRefSchema.nullable().optional(),
+			digest: ModelRefSchema.nullable().optional(),
+		})
+		.optional(),
+	uiPrefs: z
+		.object({
+			sidebarExpandedKbs: z.array(z.string()).optional(),
+		})
+		.optional(),
+});
+export type AppConfig = z.infer<typeof AppConfigSchema>;
+
+export const ConfigPatchSchema = z.object({
+	showUserGlobalSkills: z.boolean().optional(),
+	modelRoles: z
+		.object({
+			main: ModelRefSchema.nullable().optional(),
+			digest: ModelRefSchema.nullable().optional(),
+		})
+		.optional(),
+	uiPrefs: z
+		.object({
+			sidebarExpandedKbs: z.array(z.string()).optional(),
+		})
+		.optional(),
+});
+export type ConfigPatch = z.infer<typeof ConfigPatchSchema>;
+
+export const AvailableModelInfoSchema = z.object({
+	provider: z.string(),
+	modelId: z.string(),
+	name: z.string(),
+	reasoning: z.boolean(),
+	contextWindow: z.number().int().nonnegative(),
+	cost: z.object({ input: z.number(), output: z.number() }),
+	hasAuth: z.boolean(),
+});
+export type AvailableModelInfo = z.infer<typeof AvailableModelInfoSchema>;
+
+export const AvailableModelsDataSchema = z.array(AvailableModelInfoSchema);
+export type AvailableModelsData = z.infer<typeof AvailableModelsDataSchema>;

--- a/packages/workbench-contracts/src/endpoints.ts
+++ b/packages/workbench-contracts/src/endpoints.ts
@@ -253,21 +253,21 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "GET",
 		path: "/api/config",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "读配置",
 	},
 	{
 		method: "POST",
 		path: "/api/config",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "state-changing",
 		description: "写配置",
 	},
 	{
 		method: "GET",
 		path: "/api/models",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "可用模型列表",
 	},
@@ -295,7 +295,7 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "GET",
 		path: "/api/auth/status",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "认证状态",
 	},

--- a/packages/workbench-contracts/src/index.ts
+++ b/packages/workbench-contracts/src/index.ts
@@ -13,4 +13,6 @@
 export * from "./errors.js";
 export * from "./json.js";
 export * from "./health.js";
+export * from "./config.js";
+export * from "./auth.js";
 export * from "./endpoints.js";

--- a/packages/workbench-contracts/test/contracts.test.ts
+++ b/packages/workbench-contracts/test/contracts.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+	AppConfigSchema,
+	AuthStatusDataSchema,
+	AvailableModelsDataSchema,
 	ConflictDetailsSchema,
 	errorCodeToHttpStatus,
 	FailureEnvelopeSchema,
@@ -11,6 +14,7 @@ import {
 	InvalidRequestDetailsSchema,
 	JsonEnvelopeSchema,
 	MissingFieldDetailsSchema,
+	ModelRefSchema,
 	NotFoundDetailsSchema,
 	SuccessEnvelopeSchema,
 	success,
@@ -156,6 +160,56 @@ test("typed details schema 校验结构化形状", () => {
 	);
 	assert.equal(
 		ConflictDetailsSchema.safeParse({ conflicts: ["purpose.md"] }).success,
+		true,
+	);
+});
+
+test("ModelRef schema trim provider/modelId 且拒绝空字符串", () => {
+	assert.deepEqual(
+		ModelRefSchema.parse({ provider: " anthropic ", modelId: " claude-sonnet " }),
+		{ provider: "anthropic", modelId: "claude-sonnet" },
+	);
+	assert.equal(
+		ModelRefSchema.safeParse({ provider: " ", modelId: "claude-sonnet" }).success,
+		false,
+	);
+	assert.equal(
+		ModelRefSchema.safeParse({ provider: "anthropic", modelId: "" }).success,
+		false,
+	);
+});
+
+test("config / models / auth status data schema 校验公开响应 shape", () => {
+	assert.equal(
+		AppConfigSchema.safeParse({
+			version: 1,
+			externalKnowledgeBases: [],
+			showUserGlobalSkills: true,
+			modelRoles: { main: { provider: "anthropic", modelId: "claude-sonnet" }, digest: null },
+			uiPrefs: { sidebarExpandedKbs: ["/kb/demo"] },
+		}).success,
+		true,
+	);
+	assert.equal(
+		AvailableModelsDataSchema.safeParse([
+			{
+				provider: "anthropic",
+				modelId: "claude-sonnet",
+				name: "Claude Sonnet",
+				reasoning: false,
+				contextWindow: 200000,
+				cost: { input: 3, output: 15 },
+				hasAuth: true,
+			},
+		]).success,
+		true,
+	);
+	assert.equal(
+		AuthStatusDataSchema.safeParse({
+			authFileExists: true,
+			providers: [{ id: "anthropic", type: "api_key", configured: true }],
+			envKeys: [{ name: "ANTHROPIC_API_KEY", present: false }],
+		}).success,
 		true,
 	);
 });

--- a/packages/workbench-contracts/test/endpoints.test.ts
+++ b/packages/workbench-contracts/test/endpoints.test.ts
@@ -76,12 +76,19 @@ test("MIGRATED_JSON_PATHS 与 registry 的 migrated-json 子集严格一致（�
 	assert.deepEqual([...MIGRATED_JSON_PATHS], expected);
 });
 
-test("health 是当前唯一 migrated-json endpoint 且只读", () => {
-	const migrated = ENDPOINT_REGISTRY.filter((e) => e.kind === "migrated-json");
-	assert.deepEqual(
-		migrated.map((e) => e.path),
-		["/api/health"],
+test("health 与设置/模型/auth status 是 migrated-json endpoint", () => {
+	const migrated = ENDPOINT_REGISTRY.filter((e) => e.kind === "migrated-json").map(
+		(e) => `${e.method} ${e.path}`,
 	);
+	for (const expected of [
+		"GET /api/health",
+		"GET /api/config",
+		"POST /api/config",
+		"GET /api/models",
+		"GET /api/auth/status",
+	]) {
+		assert.ok(migrated.includes(expected), `missing migrated endpoint ${expected}`);
+	}
 	const health = ENDPOINT_REGISTRY.find(
 		(e) => e.method === "GET" && e.path === "/api/health",
 	);
@@ -98,6 +105,26 @@ test("isMigratedJsonPath 接受 migrated-json、拒绝 legacy path", () => {
 		isMigratedJsonPath("/api/artifacts/x/files/y.md"),
 		false, // file-download，不是 migrated-json
 	);
+});
+
+test("config / models / auth status 已迁移为 migrated-json，并保持安全分类", () => {
+	const cases = [
+		{ method: "GET", path: "/api/config", safety: "read-only" },
+		{ method: "POST", path: "/api/config", safety: "state-changing" },
+		{ method: "GET", path: "/api/models", safety: "read-only" },
+		{ method: "GET", path: "/api/auth/status", safety: "read-only" },
+	] as const;
+	for (const item of cases) {
+		const entry = findEndpoint(item.method, item.path);
+		assert.equal(entry?.kind, "migrated-json", `${item.method} ${item.path}`);
+		assert.equal(entry?.safety, item.safety, `${item.method} ${item.path}`);
+		assert.equal(isMigratedJsonPath(item.path), true, item.path);
+		assert.equal(
+			requiresCapabilityToken(item.method, item.path),
+			item.safety === "state-changing",
+			`${item.method} ${item.path}`,
+		);
+	}
 });
 
 // ============= #166 安全边界查询 =============

--- a/workbench/server/src/app.test.ts
+++ b/workbench/server/src/app.test.ts
@@ -10,8 +10,8 @@ type EnvelopeJson = {
 	ok?: boolean;
 	code?: string;
 	message?: string;
-	details?: { diagnosticId?: string; field?: string } | null;
-	data?: { status?: string; service?: string; timestamp?: number };
+	details?: { diagnosticId?: string; field?: string; issues?: Array<{ path: string; message: string }> } | null;
+	data?: any;
 };
 
 test("GET /api/health 返回统一成功 envelope", async () => {
@@ -79,6 +79,201 @@ test("dev 模式 INTERNAL_ERROR 默认不带 details", async () => {
 	const res = await app.request("/api/throw");
 	const json = (await res.json()) as EnvelopeJson;
 	assert.equal(json.details, undefined);
+});
+
+test("GET /api/config 返回统一成功 envelope，且 route seam 不读写真实用户目录", async () => {
+	const app = createApp({
+		configService: {
+			loadConfig: async () => ({
+				version: 1,
+				externalKnowledgeBases: [],
+				showUserGlobalSkills: true,
+				modelRoles: { main: { provider: "anthropic", modelId: "claude-sonnet" } },
+			}),
+			saveConfig: async () => {
+				throw new Error("GET 不应写配置");
+			},
+			listAvailableModels: () => [],
+			reloadActiveResources: async () => {
+				throw new Error("GET 不应 reload");
+			},
+		},
+	});
+	const res = await app.request("/api/config");
+	assert.equal(res.status, 200);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, true);
+	assert.equal((json.data as { version?: number })?.version, 1);
+	assert.equal((json.data as { showUserGlobalSkills?: boolean })?.showUserGlobalSkills, true);
+});
+
+test("POST /api/config 校验 JSON body，写入后返回统一成功 envelope", async () => {
+	let saved: unknown;
+	let reloaded = 0;
+	const app = createApp({
+		configService: {
+			loadConfig: async () => ({ version: 1, externalKnowledgeBases: [] }),
+			saveConfig: async (next) => {
+				saved = next;
+			},
+			listAvailableModels: () => [],
+			reloadActiveResources: async () => {
+				reloaded += 1;
+			},
+		},
+	});
+	const res = await app.request("/api/config", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ showUserGlobalSkills: true, modelRoles: { main: null } }),
+	});
+	assert.equal(res.status, 200);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, true);
+	assert.deepEqual(saved, {
+		version: 1,
+		externalKnowledgeBases: [],
+		showUserGlobalSkills: true,
+		modelRoles: { main: null },
+	});
+	assert.equal(reloaded, 1);
+	assert.equal((json.data as { showUserGlobalSkills?: boolean })?.showUserGlobalSkills, true);
+});
+
+test("POST /api/config 对模型引用 trim 后保存，并拒绝空模型字段", async () => {
+	let saved: unknown;
+	const app = createApp({
+		configService: {
+			loadConfig: async () => ({ version: 1, externalKnowledgeBases: [] }),
+			saveConfig: async (next) => {
+				saved = next;
+			},
+			listAvailableModels: () => [],
+			reloadActiveResources: async () => {},
+		},
+	});
+	const ok = await app.request("/api/config", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			modelRoles: { main: { provider: " anthropic ", modelId: " claude-sonnet " } },
+		}),
+	});
+	assert.equal(ok.status, 200);
+	assert.deepEqual(saved, {
+		version: 1,
+		externalKnowledgeBases: [],
+		modelRoles: { main: { provider: "anthropic", modelId: "claude-sonnet" } },
+	});
+
+	const invalid = await app.request("/api/config", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ modelRoles: { main: { provider: " ", modelId: "claude-sonnet" } } }),
+	});
+	assert.equal(invalid.status, 400);
+	const json = (await invalid.json()) as EnvelopeJson;
+	assert.equal(json.ok, false);
+	assert.equal(json.code, "INVALID_REQUEST");
+});
+
+test("POST /api/config invalid JSON 返回 INVALID_JSON envelope", async () => {
+	const app = createApp();
+	const res = await app.request("/api/config", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: "{bad",
+	});
+	assert.equal(res.status, 400);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, false);
+	assert.equal(json.code, "INVALID_JSON");
+	assert.equal(json.message, "请求体不是有效的 JSON");
+});
+
+test("POST /api/config invalid request 返回 typed details 且不包含原始 body", async () => {
+	const app = createApp();
+	const res = await app.request("/api/config", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ showUserGlobalSkills: "yes", secret: "sk-should-not-echo" }),
+	});
+	assert.equal(res.status, 400);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, false);
+	assert.equal(json.code, "INVALID_REQUEST");
+	assert.equal(Array.isArray(json.details?.issues), true);
+	assert.equal(JSON.stringify(json).includes("sk-should-not-echo"), false);
+});
+
+test("GET /api/models 返回统一成功 envelope", async () => {
+	const app = createApp({
+		configService: {
+			loadConfig: async () => ({ version: 1, externalKnowledgeBases: [] }),
+			saveConfig: async () => {},
+			listAvailableModels: () => [
+				{
+					provider: "anthropic",
+					modelId: "claude-sonnet",
+					name: "Claude Sonnet",
+					reasoning: false,
+					contextWindow: 200000,
+					cost: { input: 3, output: 15 },
+					hasAuth: true,
+				},
+			],
+			reloadActiveResources: async () => {},
+		},
+	});
+	const res = await app.request("/api/models");
+	assert.equal(res.status, 200);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, true);
+	assert.equal(Array.isArray(json.data), true);
+	assert.equal((json.data as Array<{ provider?: string }>)[0]?.provider, "anthropic");
+});
+
+test("GET /api/auth/status 返回脱敏认证状态，不泄露 key、auth 路径、环境变量值或 raw provider error", async () => {
+	const app = createApp({
+		authService: {
+			getAuthStatus: async () => ({
+				authFileExists: true,
+				providers: [{ id: "anthropic", type: "api_key", configured: true }],
+				envKeys: [{ name: "ANTHROPIC_API_KEY", present: true }],
+			}),
+		},
+	});
+	const res = await app.request("/api/auth/status");
+	assert.equal(res.status, 200);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, true);
+	const body = JSON.stringify(json);
+	assert.equal(body.includes("sk-"), false);
+	assert.equal(body.includes("/Users/"), false);
+	assert.equal(body.includes(".pi/agent/auth.json"), false);
+	assert.equal(body.includes(String(process.env.ANTHROPIC_API_KEY ?? "__absent__")), false);
+});
+
+test("GET /api/auth/status 服务异常返回统一失败 envelope，且不泄露敏感细节", async () => {
+	const app = createApp({
+		authService: {
+			getAuthStatus: async () => {
+				throw new Error("/Users/demo/.pi/agent/auth.json raw provider error api_key=sk-should-not-leak");
+			},
+		},
+		mode: "test",
+	});
+	const res = await app.request("/api/auth/status");
+	assert.equal(res.status, 500);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, false);
+	assert.equal(json.code, "INTERNAL_ERROR");
+	assert.equal(json.message, "服务器内部错误");
+	const body = JSON.stringify(json);
+	assert.equal(body.includes("/Users/"), false);
+	assert.equal(body.includes(".pi/agent/auth.json"), false);
+	assert.equal(body.includes("raw provider error"), false);
+	assert.equal(body.includes("sk-should-not-leak"), false);
 });
 
 test("注入 deps.security 后作用于 /api/* 请求（#166 接入点预留）", async () => {

--- a/workbench/server/src/app.ts
+++ b/workbench/server/src/app.ts
@@ -7,6 +7,8 @@ import type { MiddlewareHandler } from "hono";
 import { failure } from "@llm-wiki/workbench-contracts";
 
 import { HttpContractError } from "./http/request.js";
+import { createAuthRoutes, defaultAuthRouteService, type AuthRouteService } from "./routes/auth.js";
+import { createConfigRoutes, createModelRoutes, defaultConfigRouteService, type ConfigRouteService } from "./routes/config.js";
 import { createHealthRoutes } from "./routes/health.js";
 
 export type WorkbenchAppMode = "test" | "dev" | "desktop";
@@ -28,6 +30,10 @@ export interface WorkbenchAppDeps {
 	 * ENDPOINT_REGISTRY（每 endpoint 的 safety 字段）为单一来源（spec §7 / §9，#167）。
 	 */
 	security?: MiddlewareHandler;
+	/** 设置 / 模型 route 依赖；测试可注入 fake，真实启动用默认实现。 */
+	configService?: ConfigRouteService;
+	/** 认证状态 route 依赖；测试可注入 fake，真实启动用默认实现。 */
+	authService?: AuthRouteService;
 }
 
 /**
@@ -66,6 +72,9 @@ export function createApp(deps: WorkbenchAppDeps = {}): Hono {
 
 	// 3. 已迁移 route module：统一经过 request / response / security 接入点。
 	app.route("/api/health", createHealthRoutes());
+	app.route("/api/config", createConfigRoutes(deps.configService ?? defaultConfigRouteService));
+	app.route("/api/models", createModelRoutes(deps.configService ?? defaultConfigRouteService));
+	app.route("/api/auth", createAuthRoutes(deps.authService ?? defaultAuthRouteService));
 
 	return app;
 }

--- a/workbench/server/src/index.ts
+++ b/workbench/server/src/index.ts
@@ -42,14 +42,12 @@ import {
 	createNewConversation,
 	getActive,
 	getActiveSession,
-	listAvailableModels,
 	listLoadedSkills,
-	reloadActiveResources,
 	selectConversation,
 	selectKb,
 } from "./agent.js";
-import { getAuthStatus, setAuthKey, testAuthConnection } from "./auth.js";
-import { type AppConfig, loadConfig, saveConfig } from "./config.js";
+import { setAuthKey, testAuthConnection } from "./auth.js";
+import { loadConfig } from "./config.js";
 import { listConversations, piMessagesToUIMessages } from "./conversations.js";
 import { runBatchDigest } from "./digest/batch.js";
 import {
@@ -115,28 +113,6 @@ function extractModelInfo(session: AgentSession): { provider: string; id: string
 function extractContextWindow(session: AgentSession): number | undefined {
 	const model = (session.state as { model?: { contextWindow?: unknown } }).model;
 	return typeof model?.contextWindow === "number" ? model.contextWindow : undefined;
-}
-
-function normalizeRoleModelRef(raw: unknown): AppConfig["modelRoles"] extends infer Roles
-	? Roles extends { main?: infer Ref }
-		? Ref | undefined
-		: never
-	: never {
-	if (raw === null) return null;
-	if (typeof raw !== "object" || raw === undefined) return undefined;
-	const obj = raw as Record<string, unknown>;
-	if (typeof obj.provider !== "string" || typeof obj.modelId !== "string") return undefined;
-	if (!obj.provider.trim() || !obj.modelId.trim()) return undefined;
-	return { provider: obj.provider.trim(), modelId: obj.modelId.trim() };
-}
-
-function sameModelRef(a: unknown, b: unknown): boolean {
-	const left = normalizeRoleModelRef(a);
-	const right = normalizeRoleModelRef(b);
-	if (left === undefined && right === undefined) return true;
-	if (left === null || right === null) return left === right;
-	if (left === undefined || right === undefined) return false;
-	return left.provider === right.provider && left.modelId === right.modelId;
 }
 
 function requestedKnowledgeBasePath(queryValue: string | undefined, body?: unknown): string | null {
@@ -553,89 +529,6 @@ app.get("/api/commands", async (c) => {
 	}
 });
 
-app.get("/api/config", async (c) => {
-	try {
-		return c.json({ ok: true, config: await loadConfig() });
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			500,
-		);
-	}
-});
-
-app.post("/api/config", async (c) => {
-	let body: {
-		showUserGlobalSkills?: unknown;
-		modelRoles?: unknown;
-		uiPrefs?: unknown;
-	};
-	try {
-		body = await c.req.json();
-	} catch {
-		return c.json({ ok: false, error: "Invalid JSON body" }, 400);
-	}
-	try {
-		const current = await loadConfig();
-		const next: AppConfig = {
-			...current,
-			...(typeof body.showUserGlobalSkills === "boolean"
-				? { showUserGlobalSkills: body.showUserGlobalSkills }
-				: {}),
-		};
-		let mainRoleChanged = false;
-		if (typeof body.modelRoles === "object" && body.modelRoles !== null) {
-			const roles = body.modelRoles as Record<string, unknown>;
-			const nextMain = normalizeRoleModelRef(roles.main);
-			const nextDigest = normalizeRoleModelRef(roles.digest);
-			mainRoleChanged = nextMain !== undefined && !sameModelRef(current.modelRoles?.main, nextMain);
-			next.modelRoles = {
-				...(current.modelRoles ?? {}),
-				...(nextMain !== undefined ? { main: nextMain } : {}),
-				...(nextDigest !== undefined ? { digest: nextDigest } : {}),
-			};
-		}
-		if (typeof body.uiPrefs === "object" && body.uiPrefs !== null) {
-			const prefs = body.uiPrefs as Record<string, unknown>;
-			next.uiPrefs = {
-				...(current.uiPrefs ?? {}),
-				...(Array.isArray(prefs.sidebarExpandedKbs)
-					? {
-							sidebarExpandedKbs: prefs.sidebarExpandedKbs.filter(
-								(value): value is string => typeof value === "string",
-							),
-						}
-					: {}),
-			};
-		}
-		await saveConfig(next);
-		if (
-			(typeof body.showUserGlobalSkills === "boolean" &&
-				body.showUserGlobalSkills !== current.showUserGlobalSkills) ||
-			mainRoleChanged
-		) {
-			await reloadActiveResources();
-		}
-		return c.json({ ok: true, config: next });
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			500,
-		);
-	}
-});
-
-app.get("/api/models", async (c) => {
-	try {
-		return c.json({ ok: true, items: listAvailableModels() });
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			500,
-		);
-	}
-});
-
 app.post("/api/system/choose-directory", async (c) => {
 	if (process.platform !== "darwin") {
 		return c.json({ ok: false, error: "当前系统暂不支持文件夹选择器" }, 501);
@@ -764,17 +657,6 @@ app.get("/api/artifacts/:id/files/:filename", async (c) => {
 });
 
 // ============= 模型认证 =============
-
-app.get("/api/auth/status", async (c) => {
-	try {
-		return c.json({ ok: true, ...(await getAuthStatus()) });
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			500,
-		);
-	}
-});
 
 app.post("/api/auth/set", async (c) => {
 	let body: { provider?: unknown; type?: unknown; key?: unknown };

--- a/workbench/server/src/routes/auth.ts
+++ b/workbench/server/src/routes/auth.ts
@@ -1,0 +1,24 @@
+import { Hono } from "hono";
+import { AuthStatusDataSchema, type AuthStatusData } from "@llm-wiki/workbench-contracts";
+
+import { getAuthStatus } from "../auth.js";
+import { jsonOk } from "../http/response.js";
+
+export interface AuthRouteService {
+	getAuthStatus: () => Promise<unknown>;
+}
+
+export const defaultAuthRouteService: AuthRouteService = {
+	getAuthStatus,
+};
+
+export function createAuthRoutes(service: AuthRouteService): Hono {
+	const router = new Hono();
+
+	router.get("/status", async (c) => {
+		const status: AuthStatusData = AuthStatusDataSchema.parse(await service.getAuthStatus());
+		return jsonOk(c, status);
+	});
+
+	return router;
+}

--- a/workbench/server/src/routes/config.ts
+++ b/workbench/server/src/routes/config.ts
@@ -1,0 +1,106 @@
+import { Hono } from "hono";
+import {
+	AppConfigSchema,
+	AvailableModelsDataSchema,
+	ConfigPatchSchema,
+	ModelRefSchema,
+	type AppConfig,
+	type ConfigPatch,
+} from "@llm-wiki/workbench-contracts";
+
+import { listAvailableModels, reloadActiveResources } from "../agent.js";
+import { loadConfig, saveConfig } from "../config.js";
+import { parseValidatedBody } from "../http/request.js";
+import { jsonOk } from "../http/response.js";
+
+export interface ConfigRouteService {
+	loadConfig: () => Promise<AppConfig>;
+	saveConfig: (config: AppConfig) => Promise<void>;
+	listAvailableModels: () => unknown;
+	reloadActiveResources: () => Promise<void>;
+}
+
+export const defaultConfigRouteService: ConfigRouteService = {
+	loadConfig: async () => AppConfigSchema.parse(await loadConfig()),
+	saveConfig: async (config) => saveConfig(config),
+	listAvailableModels,
+	reloadActiveResources: async () => {
+		await reloadActiveResources();
+	},
+};
+
+export function createConfigRoutes(service: ConfigRouteService): Hono {
+	const router = new Hono();
+
+	router.get("/", async (c) => {
+		const config = AppConfigSchema.parse(await service.loadConfig());
+		return jsonOk(c, config);
+	});
+
+	router.post("/", async (c) => {
+		const patch = await parseValidatedBody(c, ConfigPatchSchema);
+		const current = AppConfigSchema.parse(await service.loadConfig());
+		const next = applyConfigPatch(current, patch);
+		await service.saveConfig(next);
+		if (shouldReloadResources(current, patch)) {
+			await service.reloadActiveResources();
+		}
+		return jsonOk(c, AppConfigSchema.parse(next));
+	});
+
+	return router;
+}
+
+export function createModelRoutes(service: ConfigRouteService): Hono {
+	const router = new Hono();
+	router.get("/", (c) => {
+		return jsonOk(c, AvailableModelsDataSchema.parse(service.listAvailableModels()));
+	});
+	return router;
+}
+
+function applyConfigPatch(current: AppConfig, patch: ConfigPatch): AppConfig {
+	const next: AppConfig = { ...current };
+	if (patch.showUserGlobalSkills !== undefined) {
+		next.showUserGlobalSkills = patch.showUserGlobalSkills;
+	}
+	if (patch.modelRoles !== undefined) {
+		next.modelRoles = {
+			...(current.modelRoles ?? {}),
+			...(patch.modelRoles.main !== undefined ? { main: patch.modelRoles.main } : {}),
+			...(patch.modelRoles.digest !== undefined ? { digest: patch.modelRoles.digest } : {}),
+		};
+	}
+	if (patch.uiPrefs !== undefined) {
+		next.uiPrefs = {
+			...(current.uiPrefs ?? {}),
+			...(patch.uiPrefs.sidebarExpandedKbs !== undefined
+				? { sidebarExpandedKbs: patch.uiPrefs.sidebarExpandedKbs }
+				: {}),
+		};
+	}
+	return next;
+}
+
+function shouldReloadResources(current: AppConfig, patch: ConfigPatch): boolean {
+	if (
+		patch.showUserGlobalSkills !== undefined &&
+		patch.showUserGlobalSkills !== current.showUserGlobalSkills
+	) {
+		return true;
+	}
+	if (patch.modelRoles?.main !== undefined) {
+		return !sameModelRef(current.modelRoles?.main, patch.modelRoles.main);
+	}
+	return false;
+}
+
+function sameModelRef(a: unknown, b: unknown): boolean {
+	const schema = ModelRefSchema.nullable();
+	const left = schema.safeParse(a);
+	const right = schema.safeParse(b);
+	if (!left.success && !right.success) return true;
+	if (!left.success || !right.success) return false;
+	if (left.data === null || right.data === null) return left.data === right.data;
+	return left.data.provider === right.data.provider && left.data.modelId === right.data.modelId;
+}

--- a/workbench/server/src/security/middleware.test.ts
+++ b/workbench/server/src/security/middleware.test.ts
@@ -18,6 +18,10 @@ type EnvelopeJson = {
 /**
  * 搭一个带真实 security 中间件 + 若干 registry 路径的测试 app：
  *  - GET /api/health                         read-only（createApp 自带）
+ *  - GET /api/config                         read-only（#168 migrated-json）
+ *  - POST /api/config                        state-changing（#168 migrated-json）
+ *  - GET /api/models                         read-only（#168 migrated-json）
+ *  - GET /api/auth/status                    read-only（#168 migrated-json）
  *  - POST /api/echo                          read-only（POST 不等于要 token）
  *  - GET /api/artifacts/:id/files/:filename  file-download read-only
  *  - POST /api/knowledge-bases/new           state-changing
@@ -29,6 +33,15 @@ function buildApp(
 ) {
 	const app = createApp({
 		security: createSecurityMiddleware({ token, trustedOrigins }),
+		configService: {
+			loadConfig: async () => ({ version: 1, externalKnowledgeBases: [] }),
+			saveConfig: async () => {},
+			listAvailableModels: () => [],
+			reloadActiveResources: async () => {},
+		},
+		authService: {
+			getAuthStatus: async () => ({ authFileExists: false, providers: [], envKeys: [] }),
+		},
 	});
 	app.post("/api/echo", (c) => c.json({ ok: true }));
 	app.get("/api/artifacts/:id/files/:filename", (c) => c.json({ ok: true }));
@@ -69,6 +82,41 @@ test("POST 不等于需要 token：read-only 的 POST /api/echo 无 token 放行
 test("文件下载 GET 无 token / 来源即放行", async () => {
 	const app = buildApp();
 	const res = await app.request("/api/artifacts/abc/files/report.md");
+	assert.equal(res.status, 200);
+});
+
+test("#168 migrated-json read-only GET 无 token 放行", async () => {
+	const app = buildApp();
+	for (const path of ["/api/config", "/api/models", "/api/auth/status"]) {
+		const res = await app.request(path);
+		assert.equal(res.status, 200, path);
+	}
+});
+
+test("#168 migrated-json state-changing POST /api/config 缺 token -> 403 FORBIDDEN_LOCAL_API", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/config", {
+		method: "POST",
+		headers: headers({ origin: TRUSTED_ORIGIN, "Content-Type": "application/json" }),
+		body: JSON.stringify({ showUserGlobalSkills: true }),
+	});
+	assert.equal(res.status, 403);
+	const json = (await res.json()) as EnvelopeJson;
+	assert.equal(json.ok, false);
+	assert.equal(json.code, "FORBIDDEN_LOCAL_API");
+});
+
+test("#168 migrated-json state-changing POST /api/config 带正确 token + 可信来源 -> 200", async () => {
+	const app = buildApp();
+	const res = await app.request("/api/config", {
+		method: "POST",
+		headers: headers({
+			origin: TRUSTED_ORIGIN,
+			"Content-Type": "application/json",
+			[CAPABILITY_TOKEN_HEADER]: TOKEN,
+		}),
+		body: JSON.stringify({ showUserGlobalSkills: true }),
+	});
 	assert.equal(res.status, 200);
 });
 

--- a/workbench/web/src/lib/api.ts
+++ b/workbench/web/src/lib/api.ts
@@ -5,7 +5,17 @@
  */
 
 import { parseSSE, type SSEMessage } from "./sse";
+import { getConfig as getConfigMigrated, setConfig as setConfigMigrated, fetchAvailableModels as fetchAvailableModelsMigrated } from "./api/config";
+import { getAuthStatus as getAuthStatusMigrated } from "./api/auth";
+import {
+	type AppConfig,
+	type AuthStatusData,
+	type AvailableModelInfo,
+	type ModelRef,
+} from "@llm-wiki/workbench-contracts";
 import type { GraphData, GraphDiff, GraphLayoutFile, PinMap } from "@llm-wiki/graph-engine";
+
+export type { AppConfig, AvailableModelInfo, ModelRef } from "@llm-wiki/workbench-contracts";
 
 // ============= 类型 =============
 
@@ -41,20 +51,7 @@ export interface ModelInfo {
 	id: string;
 }
 
-export interface ModelRef {
-	provider: string;
-	modelId: string;
-}
-
-export interface AvailableModelInfo {
-	provider: string;
-	modelId: string;
-	name: string;
-	reasoning: boolean;
-	contextWindow: number;
-	cost: { input: number; output: number };
-	hasAuth: boolean;
-}
+export type AuthStatus = AuthStatusData;
 
 export interface ActiveContext {
 	kb: CurrentKnowledgeBase;
@@ -81,12 +78,6 @@ export interface PageRef {
 	title: string;
 }
 
-export interface AuthStatus {
-	authFileExists: boolean;
-	providers: { id: string; type: string; configured: boolean }[];
-	envKeys: { name: string; present: boolean }[];
-}
-
 export interface ArtifactManifest {
 	id: string;
 	kind: "html" | "pdf" | "docx" | "pptx" | "xlsx";
@@ -108,20 +99,6 @@ export interface ArtifactManifest {
 }
 
 export type ExportKind = "pdf" | "docx" | "pptx" | "xlsx" | "html";
-
-export interface AppConfig {
-	version: 1;
-	externalKnowledgeBases: string[];
-	lastUsedKbPath?: string;
-	showUserGlobalSkills?: boolean;
-	modelRoles?: {
-		main?: ModelRef | null;
-		digest?: ModelRef | null;
-	};
-	uiPrefs?: {
-		sidebarExpandedKbs?: string[];
-	};
-}
 
 export interface InspectPathResult {
 	exists: boolean;
@@ -457,32 +434,15 @@ export async function listCommands(includeUserGlobal = false): Promise<CommandIt
 }
 
 export async function getConfig(): Promise<AppConfig> {
-	const res = await fetch("/api/config");
-	const json = (await res.json()) as { ok: boolean; config?: AppConfig; error?: string };
-	if (!res.ok || !json.ok || !json.config) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return json.config;
+	return getConfigMigrated();
 }
 
 export async function setConfig(partial: Partial<AppConfig>): Promise<AppConfig> {
-	const res = await fetch("/api/config", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(partial),
-	});
-	const json = (await res.json()) as { ok: boolean; config?: AppConfig; error?: string };
-	if (!res.ok || !json.ok || !json.config) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return json.config;
+	return setConfigMigrated(partial);
 }
 
 export async function fetchAvailableModels(): Promise<AvailableModelInfo[]> {
-	const res = await fetch("/api/models");
-	const json = (await res.json()) as {
-		ok: boolean;
-		items?: AvailableModelInfo[];
-		error?: string;
-	};
-	if (!res.ok || !json.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return json.items ?? [];
+	return fetchAvailableModelsMigrated();
 }
 
 export async function streamBatchDigest(
@@ -612,10 +572,7 @@ export function buildExportPrompt(kind: ExportKind, titleSource: string): string
 }
 
 export async function getAuthStatus(): Promise<AuthStatus> {
-	const res = await fetch("/api/auth/status");
-	const json = (await res.json()) as ({ ok: true } & AuthStatus) | { ok: false; error?: string };
-	if (!res.ok || !json.ok) throw new Error(("error" in json && json.error) || `HTTP ${res.status}`);
-	return json;
+	return getAuthStatusMigrated();
 }
 
 export async function setAuthKey(provider: string, key: string): Promise<void> {

--- a/workbench/web/src/lib/api/auth.ts
+++ b/workbench/web/src/lib/api/auth.ts
@@ -1,0 +1,7 @@
+import { AuthStatusDataSchema, type AuthStatusData } from "@llm-wiki/workbench-contracts";
+
+import { request } from "./client";
+
+export function getAuthStatus(): Promise<AuthStatusData> {
+	return request("/api/auth/status", { responseSchema: AuthStatusDataSchema });
+}

--- a/workbench/web/src/lib/api/config.ts
+++ b/workbench/web/src/lib/api/config.ts
@@ -1,0 +1,26 @@
+import {
+	AppConfigSchema,
+	AvailableModelsDataSchema,
+	ConfigPatchSchema,
+	type AppConfig,
+	type AvailableModelsData,
+	type ConfigPatch,
+} from "@llm-wiki/workbench-contracts";
+
+import { request } from "./client";
+
+export function getConfig(): Promise<AppConfig> {
+	return request("/api/config", { responseSchema: AppConfigSchema });
+}
+
+export function setConfig(partial: ConfigPatch): Promise<AppConfig> {
+	return request("/api/config", {
+		method: "POST",
+		body: ConfigPatchSchema.parse(partial),
+		responseSchema: AppConfigSchema,
+	});
+}
+
+export function fetchAvailableModels(): Promise<AvailableModelsData> {
+	return request("/api/models", { responseSchema: AvailableModelsDataSchema });
+}

--- a/workbench/web/test/config-auth-api.test.ts
+++ b/workbench/web/test/config-auth-api.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { ApiError, ContractMismatchError } from "../src/lib/api/client";
+import { fetchAvailableModels, getConfig, setConfig } from "../src/lib/api/config";
+import { getAuthStatus } from "../src/lib/api/auth";
+
+function stubFetch(body: unknown, status = 200) {
+	const calls: Array<{ url: string; init?: RequestInit }> = [];
+	globalThis.fetch = ((input: URL | string, init?: RequestInit) => {
+		calls.push({ url: String(input), init });
+		return Promise.resolve(
+			new Response(JSON.stringify(body), {
+				status,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	}) as typeof globalThis.fetch;
+	return calls;
+}
+
+describe("config / auth API modules", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("getConfig 通过统一 client 读取 /api/config 的 data", async () => {
+		const calls = stubFetch({
+			ok: true,
+			data: {
+				version: 1,
+				externalKnowledgeBases: [],
+				showUserGlobalSkills: true,
+			},
+		});
+		const config = await getConfig();
+		assert.equal(calls[0]?.url, "/api/config");
+		assert.equal(calls[0]?.init?.method, "GET");
+		assert.equal(config.showUserGlobalSkills, true);
+	});
+
+	it("setConfig 用 POST JSON body，并返回统一 envelope data", async () => {
+		const calls = stubFetch({
+			ok: true,
+			data: {
+				version: 1,
+				externalKnowledgeBases: [],
+				modelRoles: { main: null },
+			},
+		});
+		const config = await setConfig({ modelRoles: { main: null } });
+		assert.equal(calls[0]?.url, "/api/config");
+		assert.equal(calls[0]?.init?.method, "POST");
+		assert.deepEqual(JSON.parse(String(calls[0]?.init?.body)), { modelRoles: { main: null } });
+		assert.deepEqual(config.modelRoles, { main: null });
+	});
+
+	it("fetchAvailableModels 读取 /api/models 的统一 data 数组", async () => {
+		stubFetch({
+			ok: true,
+			data: [
+				{
+					provider: "anthropic",
+					modelId: "claude-sonnet",
+					name: "Claude Sonnet",
+					reasoning: false,
+					contextWindow: 200000,
+					cost: { input: 3, output: 15 },
+					hasAuth: true,
+				},
+			],
+		});
+		const models = await fetchAvailableModels();
+		assert.equal(models[0]?.provider, "anthropic");
+	});
+
+	it("getAuthStatus 读取脱敏认证状态，不接受旧的 spread 响应", async () => {
+		stubFetch({
+			ok: true,
+			authFileExists: true,
+			providers: [{ id: "anthropic", type: "api_key", configured: true }],
+			envKeys: [],
+		});
+		await assert.rejects(() => getAuthStatus(), (err) => err instanceof ContractMismatchError);
+	});
+
+	it("getAuthStatus 返回统一 envelope data 且不暴露认证细节", async () => {
+		stubFetch({
+			ok: true,
+			data: {
+				authFileExists: true,
+				providers: [{ id: "anthropic", type: "api_key", configured: true }],
+				envKeys: [{ name: "ANTHROPIC_API_KEY", present: true }],
+			},
+		});
+		const status = await getAuthStatus();
+		assert.equal(status.authFileExists, true);
+		const body = JSON.stringify(status);
+		assert.equal(body.includes("sk-"), false);
+		assert.equal(body.includes("/Users/"), false);
+		assert.equal(body.includes(".pi/agent/auth.json"), false);
+	});
+
+	it("失败 envelope 由领域 module 透出 ApiError code", async () => {
+		stubFetch({ ok: false, code: "INTERNAL_ERROR", message: "服务器内部错误" }, 500);
+		await assert.rejects(
+			() => getConfig(),
+			(err) => err instanceof ApiError && err.code === "INTERNAL_ERROR",
+		);
+	});
+});

--- a/workbench/web/test/topbar.test.tsx
+++ b/workbench/web/test/topbar.test.tsx
@@ -118,7 +118,7 @@ describe("TopBar", () => {
 			if (url === "/api/config" && method === "GET") {
 				return json({
 					ok: true,
-					config: {
+					data: {
 						version: 1,
 						externalKnowledgeBases: [],
 						modelRoles: { main: { provider: "deepseek", modelId: "deepseek-v4-flash" } },
@@ -128,7 +128,7 @@ describe("TopBar", () => {
 			if (url === "/api/models") {
 				return json({
 					ok: true,
-					items: [
+					data: [
 						{
 							provider: "deepseek",
 							modelId: "deepseek-v4-flash",
@@ -153,7 +153,7 @@ describe("TopBar", () => {
 			if (url === "/api/config" && method === "POST") {
 				return json({
 					ok: true,
-					config: {
+					data: {
 						version: 1,
 						externalKnowledgeBases: [],
 						modelRoles: { main: { provider: "openai", modelId: "gpt-5" } },


### PR DESCRIPTION
## Summary
- Migrates `GET /api/config`, `POST /api/config`, `GET /api/models`, and `GET /api/auth/status` to shared workbench contracts and unified JSON envelopes.
- Moves settings/models/auth status handling into domain route modules and web domain API modules using the migrated-json client.
- Updates endpoint registry safety so read-only routes remain token-exempt while `POST /api/config` requires the local capability token.

## Test plan
- [x] `npm run test -w @llm-wiki/workbench-contracts`
- [x] `node --import tsx --test "workbench/server/src/**/*.test.ts"`
- [x] `npm run test -w @llm-wiki-agent/web`
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `/review` specialist + adversarial review; no unresolved findings
- [x] Manual dev API validation for migrated envelopes and `POST /api/config` token guard

## Notes
- `POST /api/auth/set` and `POST /api/auth/test` remain legacy by scope.
- Auth status responses are constrained to public fields only and must not return API keys, auth file paths, environment variable values, or raw provider errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)