### PR TITLE
feat(workbench): migrate knowledge base context routes (#171)

### DIFF
--- a/packages/workbench-contracts/src/endpoints.ts
+++ b/packages/workbench-contracts/src/endpoints.ts
@@ -141,28 +141,28 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "GET",
 		path: "/api/knowledge-bases",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "列出知识库",
 	},
 	{
 		method: "POST",
 		path: "/api/knowledge-bases/external",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "state-changing",
 		description: "登记外部库，写应用数据",
 	},
 	{
 		method: "POST",
 		path: "/api/knowledge-bases/inspect",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "读取路径信息",
 	},
 	{
 		method: "DELETE",
 		path: "/api/knowledge-bases/external",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "state-changing",
 		description: "取消登记，写应用数据",
 	},
@@ -183,21 +183,21 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "GET",
 		path: "/api/knowledge-base",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "当前活跃上下文",
 	},
 	{
 		method: "POST",
 		path: "/api/knowledge-base",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "state-changing",
 		description: "选择知识库，改 active context",
 	},
 	{
 		method: "DELETE",
 		path: "/api/knowledge-base",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "state-changing",
 		description: "清空 active context",
 	},
@@ -437,6 +437,6 @@ export function requiresCapabilityToken(method: string, path: string): boolean {
 // "Unused '@ts-expect-error' directive" → 强制更新本护栏。这样"新 client 误
 // 处理 legacy endpoint"在编译期即可被发现。
 //
-// @ts-expect-error /api/knowledge-bases 是 legacy，MigratedJsonPath 必须拒绝
-const _legacyPathRejectedByClient: MigratedJsonPath = "/api/knowledge-bases";
+// @ts-expect-error /api/graph 是 legacy，MigratedJsonPath 必须拒绝
+const _legacyPathRejectedByClient: MigratedJsonPath = "/api/graph";
 void _legacyPathRejectedByClient;

--- a/packages/workbench-contracts/src/index.ts
+++ b/packages/workbench-contracts/src/index.ts
@@ -15,4 +15,5 @@ export * from "./json.js";
 export * from "./health.js";
 export * from "./config.js";
 export * from "./auth.js";
+export * from "./knowledge-bases.js";
 export * from "./endpoints.js";

--- a/packages/workbench-contracts/src/knowledge-bases.ts
+++ b/packages/workbench-contracts/src/knowledge-bases.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+
+export const KnowledgeBaseInfoSchema = z.object({
+	path: z.string(),
+	name: z.string(),
+	origin: z.enum(["default", "external"]),
+	valid: z.boolean(),
+	reason: z.string().optional(),
+});
+export type KnowledgeBaseInfo = z.infer<typeof KnowledgeBaseInfoSchema>;
+
+export const KnowledgeBaseListDataSchema = z.array(KnowledgeBaseInfoSchema);
+export type KnowledgeBaseListData = z.infer<typeof KnowledgeBaseListDataSchema>;
+
+/** 管理候选目录（登记、检查、取消登记）的请求字段。 */
+export const KnowledgeBasePathBodySchema = z
+	.object({
+		path: z.string().trim().min(1),
+	})
+	.strict();
+export type KnowledgeBasePathBody = z.infer<typeof KnowledgeBasePathBodySchema>;
+
+/**
+ * 后续 pages / graph / conversations / prompt / rebuild 统一复用的知识库上下文输入。
+ * JSON body 固定使用 `kbPath`；GET query 固定使用 `kb`，两者不再各自兼容别名。
+ */
+export const KnowledgeBaseContextBodySchema = z
+	.object({
+		kbPath: z.string().trim().min(1),
+	})
+	.strict();
+export type KnowledgeBaseContextBody = z.infer<
+	typeof KnowledgeBaseContextBodySchema
+>;
+
+export const KnowledgeBaseContextQuerySchema = z
+	.object({
+		kb: z.string().trim().min(1).optional(),
+	})
+	.strict();
+export type KnowledgeBaseContextQuery = z.infer<
+	typeof KnowledgeBaseContextQuerySchema
+>;
+
+export const RegisterExternalKnowledgeBaseDataSchema = z.object({
+	registered: z.boolean(),
+	path: z.string(),
+	info: KnowledgeBaseInfoSchema,
+});
+export type RegisterExternalKnowledgeBaseData = z.infer<
+	typeof RegisterExternalKnowledgeBaseDataSchema
+>;
+
+export const UnregisterExternalKnowledgeBaseDataSchema = z.object({
+	removed: z.boolean(),
+	path: z.string(),
+});
+export type UnregisterExternalKnowledgeBaseData = z.infer<
+	typeof UnregisterExternalKnowledgeBaseDataSchema
+>;
+
+export const InspectKnowledgeBasePathDataSchema = z.object({
+	exists: z.boolean(),
+	isDirectory: z.boolean(),
+	hasWikiSchema: z.boolean(),
+	resolvedPath: z.string().optional(),
+	ingestibleFiles: z
+		.object({
+			scanId: z.string(),
+			count: z.number().int().nonnegative(),
+			samples: z.array(z.string()),
+			paths: z.array(z.string()),
+			truncated: z.boolean(),
+		})
+		.optional(),
+});
+export type InspectKnowledgeBasePathData = z.infer<
+	typeof InspectKnowledgeBasePathDataSchema
+>;
+
+export const CurrentKnowledgeBaseSchema = z.object({
+	path: z.string(),
+	name: z.string(),
+});
+export type CurrentKnowledgeBase = z.infer<typeof CurrentKnowledgeBaseSchema>;
+
+export const UIMessageSchema = z.object({
+	id: z.string(),
+	role: z.enum(["user", "assistant"]),
+	content: z.string(),
+	tools: z.array(
+		z.object({
+			name: z.string(),
+			status: z.literal("done"),
+		}),
+	),
+});
+export type UIMessage = z.infer<typeof UIMessageSchema>;
+
+export const ActiveContextSchema = z.object({
+	kb: CurrentKnowledgeBaseSchema,
+	conversation: z.object({
+		id: z.string(),
+		isNew: z.boolean().optional(),
+		messages: z.array(UIMessageSchema),
+	}),
+	model: z
+		.object({
+			provider: z.string(),
+			id: z.string(),
+		})
+		.nullable(),
+});
+export type ActiveContext = z.infer<typeof ActiveContextSchema>;
+
+export const ActiveKnowledgeBaseDataSchema = z.object({
+	active: ActiveContextSchema.nullable(),
+});
+export type ActiveKnowledgeBaseData = z.infer<
+	typeof ActiveKnowledgeBaseDataSchema
+>;

--- a/packages/workbench-contracts/test/contracts.test.ts
+++ b/packages/workbench-contracts/test/contracts.test.ts
@@ -12,6 +12,8 @@ import {
 	ForbiddenPathDetailsSchema,
 	HealthDataSchema,
 	InvalidRequestDetailsSchema,
+	KnowledgeBaseContextBodySchema,
+	KnowledgeBaseContextQuerySchema,
 	JsonEnvelopeSchema,
 	MissingFieldDetailsSchema,
 	ModelRefSchema,
@@ -211,6 +213,20 @@ test("config / models / auth status data schema 校验公开响应 shape", () =>
 			envKeys: [{ name: "ANTHROPIC_API_KEY", present: false }],
 		}).success,
 		true,
+	);
+});
+
+test("知识库上下文明确 GET query kb 与 JSON body kbPath", () => {
+	assert.deepEqual(KnowledgeBaseContextQuerySchema.parse({ kb: " /kb/query " }), {
+		kb: "/kb/query",
+	});
+	assert.deepEqual(
+		KnowledgeBaseContextBodySchema.parse({ kbPath: " /kb/body " }),
+		{ kbPath: "/kb/body" },
+	);
+	assert.equal(
+		KnowledgeBaseContextBodySchema.safeParse({ path: "/kb/legacy" }).success,
+		false,
 	);
 });
 

--- a/packages/workbench-contracts/test/endpoints.test.ts
+++ b/packages/workbench-contracts/test/endpoints.test.ts
@@ -98,8 +98,10 @@ test("health 与设置/模型/auth status 是 migrated-json endpoint", () => {
 
 test("isMigratedJsonPath 接受 migrated-json、拒绝 legacy path", () => {
 	assert.equal(isMigratedJsonPath("/api/health"), true);
-	// legacy endpoint 必须返回 false —— 这是"新 client 不误处理 legacy"的数据层防线
-	assert.equal(isMigratedJsonPath("/api/knowledge-bases"), false);
+	assert.equal(isMigratedJsonPath("/api/knowledge-bases"), true);
+	assert.equal(isMigratedJsonPath("/api/knowledge-base"), true);
+	// 尚未迁移的 endpoint 必须返回 false —— 这是"新 client 不误处理 legacy"的数据层防线
+	assert.equal(isMigratedJsonPath("/api/graph"), false);
 	assert.equal(isMigratedJsonPath("/api/prompt"), false); // sse，不是 migrated-json
 	assert.equal(
 		isMigratedJsonPath("/api/artifacts/x/files/y.md"),
@@ -113,6 +115,49 @@ test("config / models / auth status 已迁移为 migrated-json，并保持安全
 		{ method: "POST", path: "/api/config", safety: "state-changing" },
 		{ method: "GET", path: "/api/models", safety: "read-only" },
 		{ method: "GET", path: "/api/auth/status", safety: "read-only" },
+	] as const;
+	for (const item of cases) {
+		const entry = findEndpoint(item.method, item.path);
+		assert.equal(entry?.kind, "migrated-json", `${item.method} ${item.path}`);
+		assert.equal(entry?.safety, item.safety, `${item.method} ${item.path}`);
+		assert.equal(isMigratedJsonPath(item.path), true, item.path);
+		assert.equal(
+			requiresCapabilityToken(item.method, item.path),
+			item.safety === "state-changing",
+			`${item.method} ${item.path}`,
+		);
+	}
+});
+
+test("knowledge bases 与 active context 路由已迁移并保持安全分类", () => {
+	const cases = [
+		{ method: "GET", path: "/api/knowledge-bases", safety: "read-only" },
+		{
+			method: "POST",
+			path: "/api/knowledge-bases/external",
+			safety: "state-changing",
+		},
+		{
+			method: "POST",
+			path: "/api/knowledge-bases/inspect",
+			safety: "read-only",
+		},
+		{
+			method: "DELETE",
+			path: "/api/knowledge-bases/external",
+			safety: "state-changing",
+		},
+		{ method: "GET", path: "/api/knowledge-base", safety: "read-only" },
+		{
+			method: "POST",
+			path: "/api/knowledge-base",
+			safety: "state-changing",
+		},
+		{
+			method: "DELETE",
+			path: "/api/knowledge-base",
+			safety: "state-changing",
+		},
 	] as const;
 	for (const item of cases) {
 		const entry = findEndpoint(item.method, item.path);

--- a/packages/workbench-contracts/test/knowledge-bases.test.ts
+++ b/packages/workbench-contracts/test/knowledge-bases.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	ActiveKnowledgeBaseDataSchema,
+	InspectKnowledgeBasePathDataSchema,
+	KnowledgeBaseContextBodySchema,
+	KnowledgeBaseInfoSchema,
+	KnowledgeBaseListDataSchema,
+	KnowledgeBasePathBodySchema,
+	RegisterExternalKnowledgeBaseDataSchema,
+	UnregisterExternalKnowledgeBaseDataSchema,
+} from "../src/index.js";
+
+const knowledgeBase = {
+	path: "/kb/registered",
+	name: "registered",
+	origin: "external" as const,
+	valid: true,
+};
+
+const active = {
+	kb: { path: knowledgeBase.path, name: knowledgeBase.name },
+	conversation: {
+		id: "conversation-1",
+		isNew: false,
+		messages: [
+			{
+				id: "u-0",
+				role: "user" as const,
+				content: "你好",
+				tools: [],
+			},
+		],
+	},
+	model: { provider: "anthropic", id: "claude-sonnet" },
+};
+
+test("知识库契约校验列表、登记、检查与 active context 的公开 data", () => {
+	assert.deepEqual(KnowledgeBaseInfoSchema.parse(knowledgeBase), knowledgeBase);
+	assert.deepEqual(KnowledgeBaseListDataSchema.parse([knowledgeBase]), [knowledgeBase]);
+	assert.deepEqual(
+		RegisterExternalKnowledgeBaseDataSchema.parse({
+			registered: true,
+			path: knowledgeBase.path,
+			info: knowledgeBase,
+		}),
+		{ registered: true, path: knowledgeBase.path, info: knowledgeBase },
+	);
+	assert.deepEqual(
+		UnregisterExternalKnowledgeBaseDataSchema.parse({
+			removed: true,
+			path: knowledgeBase.path,
+		}),
+		{ removed: true, path: knowledgeBase.path },
+	);
+	assert.equal(
+		InspectKnowledgeBasePathDataSchema.safeParse({
+			exists: true,
+			isDirectory: true,
+			hasWikiSchema: true,
+			resolvedPath: knowledgeBase.path,
+			ingestibleFiles: {
+				scanId: "scan-1",
+				count: 1,
+				samples: ["raw/note.md"],
+				paths: [`${knowledgeBase.path}/raw/note.md`],
+				truncated: false,
+			},
+		}).success,
+		true,
+	);
+	assert.deepEqual(ActiveKnowledgeBaseDataSchema.parse({ active }), { active });
+	assert.deepEqual(ActiveKnowledgeBaseDataSchema.parse({ active: null }), {
+		active: null,
+	});
+});
+
+test("知识库管理 path 与上下文 kbPath 是两种明确语义，不接受旧选择字段", () => {
+	assert.deepEqual(KnowledgeBasePathBodySchema.parse({ path: " /kb/candidate " }), {
+		path: "/kb/candidate",
+	});
+	assert.deepEqual(
+		KnowledgeBaseContextBodySchema.parse({ kbPath: " /kb/registered " }),
+		{ kbPath: "/kb/registered" },
+	);
+	assert.equal(
+		KnowledgeBaseContextBodySchema.safeParse({ path: "/kb/registered" }).success,
+		false,
+	);
+	assert.equal(
+		KnowledgeBaseContextBodySchema.safeParse({
+			kbPath: "/kb/registered",
+			path: "/kb/legacy",
+		}).success,
+		false,
+	);
+});

--- a/tests/browser/graph-workbench-interactions.mjs
+++ b/tests/browser/graph-workbench-interactions.mjs
@@ -2011,7 +2011,7 @@ async function reloadPinDiagnostics(page, nodeId) {
     const currentGraphLayoutUrl = async () => {
       const response = await fetch("/api/knowledge-base");
       const payload = await response.json();
-      const kbPath = payload?.active?.kb?.path || "";
+      const kbPath = payload?.data?.active?.kb?.path || "";
       return kbPath ? `/api/graph/layout?kb=${encodeURIComponent(kbPath)}` : "/api/graph/layout";
     };
     const target = document.querySelector(`.sigma-global-node-hit-target[data-node-id="${CSS.escape(nodeId)}"]`);
@@ -2046,7 +2046,7 @@ async function waitForPersistedGraphPin(page, pinKey) {
       const currentGraphLayoutUrl = async () => {
         const response = await fetch("/api/knowledge-base");
         const payload = await response.json();
-        const kbPath = payload?.active?.kb?.path || "";
+        const kbPath = payload?.data?.active?.kb?.path || "";
         return kbPath ? `/api/graph/layout?kb=${encodeURIComponent(kbPath)}` : "/api/graph/layout";
       };
       const layoutUrl = await currentGraphLayoutUrl();
@@ -2060,7 +2060,7 @@ async function waitForPersistedGraphPin(page, pinKey) {
       const currentGraphLayoutUrl = async () => {
         const response = await fetch("/api/knowledge-base");
         const payload = await response.json();
-        const kbPath = payload?.active?.kb?.path || "";
+        const kbPath = payload?.data?.active?.kb?.path || "";
         return kbPath ? `/api/graph/layout?kb=${encodeURIComponent(kbPath)}` : "/api/graph/layout";
       };
       const layoutUrl = await currentGraphLayoutUrl();

--- a/workbench/server/src/agent.ts
+++ b/workbench/server/src/agent.ts
@@ -37,7 +37,10 @@ import { ensureKbSessionDir, listConversations } from "./conversations.js";
 import { scanAndRebuildArtifactIndex } from "./artifacts.js";
 import { createArtifactsExtension } from "./extensions/artifacts.js";
 import knowledgeBaseExtension from "./extensions/knowledge-base.js";
-import { setCurrentKnowledgeBase } from "./extensions/knowledge-base.js";
+import {
+	clearCurrentKnowledgeBase,
+	setCurrentKnowledgeBase,
+} from "./extensions/knowledge-base.js";
 import { createNewWikiExtension } from "./extensions/new-wiki.js";
 import { createSynthesisExtension } from "./extensions/synthesis.js";
 
@@ -436,6 +439,7 @@ export async function createNewConversation(kbPath: string): Promise<ActiveConte
  */
 export async function clearActive(): Promise<void> {
 	await disposeActive();
+	clearCurrentKnowledgeBase();
 }
 
 /**

--- a/workbench/server/src/agent.ts
+++ b/workbench/server/src/agent.ts
@@ -99,7 +99,21 @@ let resourceLoaderState: {
 	promise: Promise<DefaultResourceLoader>;
 } | null = null;
 let active: ActiveContext | null = null;
-let selectKbQueue: Promise<void> = Promise.resolve();
+let activeMutationQueue: Promise<void> = Promise.resolve();
+
+async function runActiveMutation<T>(operation: () => Promise<T>): Promise<T> {
+	const previous = activeMutationQueue;
+	let release!: () => void;
+	activeMutationQueue = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	await previous;
+	try {
+		return await operation();
+	} finally {
+		release();
+	}
+}
 
 export async function getResourceLoader(): Promise<DefaultResourceLoader> {
 	const includeUserGlobal = (await loadConfig()).showUserGlobalSkills === true;
@@ -340,17 +354,7 @@ export function getConfiguredModel(ref: ModelRef): Model<any> | undefined {
  *   - 该 KB 无对话：creates a new one
  */
 export async function selectKb(kbPath: string): Promise<ActiveContext> {
-	const previous = selectKbQueue;
-	let release!: () => void;
-	selectKbQueue = new Promise<void>((resolve) => {
-		release = resolve;
-	});
-	await previous;
-	try {
-		return await selectKbSerial(kbPath);
-	} finally {
-		release();
-	}
+	return runActiveMutation(() => selectKbSerial(kbPath));
 }
 
 async function selectKbSerial(kbPath: string): Promise<ActiveContext> {
@@ -409,6 +413,13 @@ export async function selectConversation(
 	kbPath: string,
 	conversationId: string,
 ): Promise<ActiveContext> {
+	return runActiveMutation(() => selectConversationSerial(kbPath, conversationId));
+}
+
+async function selectConversationSerial(
+	kbPath: string,
+	conversationId: string,
+): Promise<ActiveContext> {
 	const list = await listConversations(kbPath);
 	const target = list.find((c) => c.id === conversationId);
 	if (!target) {
@@ -441,6 +452,10 @@ export async function selectConversation(
  * 在该 KB 下新建一个空白对话，并设为活跃。
  */
 export async function createNewConversation(kbPath: string): Promise<ActiveContext> {
+	return runActiveMutation(() => createNewConversationSerial(kbPath));
+}
+
+async function createNewConversationSerial(kbPath: string): Promise<ActiveContext> {
 	await disposeActive();
 	const kb = await setCurrentKnowledgeBase(kbPath);
 	const dir = await ensureKbSessionDir(kbPath);
@@ -466,8 +481,10 @@ export async function createNewConversation(kbPath: string): Promise<ActiveConte
  * 完全清空活跃上下文（不删除磁盘上的会话文件）。
  */
 export async function clearActive(): Promise<void> {
-	await disposeActive();
-	clearCurrentKnowledgeBase();
+	await runActiveMutation(async () => {
+		await disposeActive();
+		clearCurrentKnowledgeBase();
+	});
 }
 
 /**

--- a/workbench/server/src/agent.ts
+++ b/workbench/server/src/agent.ts
@@ -99,6 +99,7 @@ let resourceLoaderState: {
 	promise: Promise<DefaultResourceLoader>;
 } | null = null;
 let active: ActiveContext | null = null;
+let selectKbQueue: Promise<void> = Promise.resolve();
 
 export async function getResourceLoader(): Promise<DefaultResourceLoader> {
 	const includeUserGlobal = (await loadConfig()).showUserGlobalSkills === true;
@@ -339,6 +340,20 @@ export function getConfiguredModel(ref: ModelRef): Model<any> | undefined {
  *   - 该 KB 无对话：creates a new one
  */
 export async function selectKb(kbPath: string): Promise<ActiveContext> {
+	const previous = selectKbQueue;
+	let release!: () => void;
+	selectKbQueue = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	await previous;
+	try {
+		return await selectKbSerial(kbPath);
+	} finally {
+		release();
+	}
+}
+
+async function selectKbSerial(kbPath: string): Promise<ActiveContext> {
 	const dir = await ensureKbSessionDir(kbPath);
 	const loader = await getResourceLoader();
 

--- a/workbench/server/src/agent.ts
+++ b/workbench/server/src/agent.ts
@@ -334,13 +334,11 @@ export function getConfiguredModel(ref: ModelRef): Model<any> | undefined {
 }
 
 /**
- * 选择/进入一个知识库：dispose 老 session，加载/新建该库下的活跃对话。
+ * 选择/进入一个知识库：先完整创建新 session，成功后才替换并 dispose 老 session。
  *   - 该 KB 有对话：opens most recent
  *   - 该 KB 无对话：creates a new one
  */
 export async function selectKb(kbPath: string): Promise<ActiveContext> {
-	await disposeActive();
-	const kb = await setCurrentKnowledgeBase(kbPath);
 	const dir = await ensureKbSessionDir(kbPath);
 	const loader = await getResourceLoader();
 
@@ -366,7 +364,22 @@ export async function selectKb(kbPath: string): Promise<ActiveContext> {
 	});
 	if (modelFallbackMessage) console.log(`[agent] ${modelFallbackMessage}`);
 
+	let kb: ActiveContext["kb"];
+	try {
+		kb = await setCurrentKnowledgeBase(kbPath);
+	} catch (err) {
+		session.dispose();
+		throw err;
+	}
+	const previous = active;
 	active = { kb, session, conversationId: session.sessionId, isNew };
+	if (previous) {
+		try {
+			previous.session.dispose();
+		} catch {
+			// noop
+		}
+	}
 	await rememberLastUsedKb(kbPath);
 	console.log(
 		`[agent] selectKb ${kb.name} → conversation ${active.conversationId.slice(0, 8)} (${isNew ? "new" : "resumed"})`,

--- a/workbench/server/src/app.ts
+++ b/workbench/server/src/app.ts
@@ -10,6 +10,7 @@ import { HttpContractError } from "./http/request.js";
 import { createAuthRoutes, defaultAuthRouteService, type AuthRouteService } from "./routes/auth.js";
 import { createConfigRoutes, createModelRoutes, defaultConfigRouteService, type ConfigRouteService } from "./routes/config.js";
 import { createHealthRoutes } from "./routes/health.js";
+import { createKnowledgeBaseRoutes, defaultKnowledgeBaseRouteService, type KnowledgeBaseRouteService } from "./routes/knowledge-bases.js";
 
 export type WorkbenchAppMode = "test" | "dev" | "desktop";
 
@@ -34,6 +35,8 @@ export interface WorkbenchAppDeps {
 	configService?: ConfigRouteService;
 	/** 认证状态 route 依赖；测试可注入 fake，真实启动用默认实现。 */
 	authService?: AuthRouteService;
+	/** 知识库 / active context route 依赖；route 测试必须注入 fake。 */
+	knowledgeBaseService?: KnowledgeBaseRouteService;
 }
 
 /**
@@ -75,6 +78,12 @@ export function createApp(deps: WorkbenchAppDeps = {}): Hono {
 	app.route("/api/config", createConfigRoutes(deps.configService ?? defaultConfigRouteService));
 	app.route("/api/models", createModelRoutes(deps.configService ?? defaultConfigRouteService));
 	app.route("/api/auth", createAuthRoutes(deps.authService ?? defaultAuthRouteService));
+	app.route(
+		"/api",
+		createKnowledgeBaseRoutes(
+			deps.knowledgeBaseService ?? defaultKnowledgeBaseRouteService,
+		),
+	);
 
 	return app;
 }

--- a/workbench/server/src/http/knowledge-base-context.test.ts
+++ b/workbench/server/src/http/knowledge-base-context.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { HttpContractError } from "./request.js";
+import { resolveKnowledgeBaseContext } from "./knowledge-base-context.js";
+
+const deps = {
+	getActiveKnowledgeBasePath: () => "/kb/active",
+	assertRegisteredKnowledgeBase: async (kbPath: string) => {
+		if (kbPath === "/kb/missing") {
+			throw new HttpContractError(
+				"KB_NOT_REGISTERED",
+				"知识库未登记或已失效",
+			);
+		}
+		return kbPath;
+	},
+};
+
+test("知识库上下文 query kb 优先于 body kbPath，二者缺省时回退 active", async () => {
+	assert.equal(
+		await resolveKnowledgeBaseContext(
+			{ queryKb: " /kb/query ", body: { kbPath: "/kb/body" } },
+			deps,
+		),
+		"/kb/query",
+	);
+	assert.equal(
+		await resolveKnowledgeBaseContext({ body: { kbPath: " /kb/body " } }, deps),
+		"/kb/body",
+	);
+	assert.equal(await resolveKnowledgeBaseContext({}, deps), "/kb/active");
+});
+
+test("知识库上下文拒绝旧 body path 字段", async () => {
+	await assert.rejects(
+		() => resolveKnowledgeBaseContext({ body: { path: "/kb/legacy" } }, deps),
+		(err) => err instanceof HttpContractError && err.code === "INVALID_REQUEST",
+	);
+});
+
+test("知识库上下文无 active 与未登记路径返回稳定 code", async () => {
+	await assert.rejects(
+		() =>
+			resolveKnowledgeBaseContext(
+				{},
+				{ ...deps, getActiveKnowledgeBasePath: () => null },
+			),
+		(err) => err instanceof HttpContractError && err.code === "NO_ACTIVE_KB",
+	);
+	await assert.rejects(
+		() => resolveKnowledgeBaseContext({ queryKb: "/kb/missing" }, deps),
+		(err) => err instanceof HttpContractError && err.code === "KB_NOT_REGISTERED",
+	);
+});

--- a/workbench/server/src/http/knowledge-base-context.test.ts
+++ b/workbench/server/src/http/knowledge-base-context.test.ts
@@ -8,10 +8,10 @@ const deps = {
 	getActiveKnowledgeBasePath: () => "/kb/active",
 	assertRegisteredKnowledgeBase: async (kbPath: string) => {
 		if (kbPath === "/kb/missing") {
-			throw new HttpContractError(
-				"KB_NOT_REGISTERED",
-				"知识库未登记或已失效",
-			);
+			throw Object.assign(new Error("not registered"), {
+				code: "KB_NOT_REGISTERED",
+				statusCode: 403,
+			});
 		}
 		return kbPath;
 	},

--- a/workbench/server/src/http/knowledge-base-context.ts
+++ b/workbench/server/src/http/knowledge-base-context.ts
@@ -1,0 +1,125 @@
+import {
+	KnowledgeBaseContextBodySchema,
+	KnowledgeBaseContextQuerySchema,
+} from "@llm-wiki/workbench-contracts";
+
+import { HttpContractError } from "./request.js";
+
+export interface KnowledgeBaseContextRequest {
+	queryKb?: string;
+	body?: unknown;
+}
+
+export interface KnowledgeBaseContextResolverDeps {
+	getActiveKnowledgeBasePath: () => string | null;
+	assertRegisteredKnowledgeBase: (kbPath: string) => Promise<string>;
+}
+
+/**
+ * 知识库上下文唯一解析入口：GET query 用 `kb`，JSON body 用 `kbPath`，显式输入
+ * 优先于 active context；显式或 active 路径都必须通过同一个登记校验。
+ */
+export async function resolveKnowledgeBaseContext(
+	request: KnowledgeBaseContextRequest,
+	deps: KnowledgeBaseContextResolverDeps,
+): Promise<string> {
+	const parsedQuery = KnowledgeBaseContextQuerySchema.safeParse({
+		...(request.queryKb === undefined ? {} : { kb: request.queryKb }),
+	});
+	if (!parsedQuery.success) {
+		throw invalidContextRequest(parsedQuery.error.issues);
+	}
+
+	let bodyKbPath: string | undefined;
+	if (request.body !== undefined) {
+		const parsedBody = KnowledgeBaseContextBodySchema.safeParse(request.body);
+		if (!parsedBody.success) {
+			throw invalidContextRequest(parsedBody.error.issues);
+		}
+		bodyKbPath = parsedBody.data.kbPath;
+	}
+
+	const requestedPath = parsedQuery.data.kb ?? bodyKbPath;
+	const kbPath = requestedPath ?? deps.getActiveKnowledgeBasePath();
+	if (!kbPath) {
+		throw new HttpContractError("NO_ACTIVE_KB", "当前没有选择知识库");
+	}
+
+	try {
+		return await deps.assertRegisteredKnowledgeBase(kbPath);
+	} catch (err) {
+		throw mapKnowledgeBaseError(err);
+	}
+}
+
+export function mapKnowledgeBaseError(err: unknown): HttpContractError {
+	if (err instanceof HttpContractError) {
+		if (err.code === "NO_ACTIVE_KB") {
+			return new HttpContractError("NO_ACTIVE_KB", "当前没有选择知识库");
+		}
+		if (err.code === "KB_NOT_REGISTERED") {
+			return new HttpContractError(
+				"KB_NOT_REGISTERED",
+				"知识库未登记或已失效",
+			);
+		}
+		if (err.code === "FORBIDDEN_PATH") {
+			return new HttpContractError(
+				"FORBIDDEN_PATH",
+				"路径不在允许的知识库边界内",
+				{ reason: forbiddenPathReason(err.details) },
+			);
+		}
+		return err;
+	}
+	const source = err as {
+		code?: unknown;
+		statusCode?: unknown;
+		details?: unknown;
+	};
+	if (source.code === "NO_ACTIVE_KB") {
+		return new HttpContractError("NO_ACTIVE_KB", "当前没有选择知识库");
+	}
+	if (source.code === "KB_NOT_REGISTERED") {
+		return new HttpContractError(
+			"KB_NOT_REGISTERED",
+			"知识库未登记或已失效",
+		);
+	}
+	if (source.code === "FORBIDDEN_PATH" || source.statusCode === 403) {
+		const reason = forbiddenPathReason(source.details);
+		return new HttpContractError(
+			"FORBIDDEN_PATH",
+			"路径不在允许的知识库边界内",
+			{ reason },
+		);
+	}
+	return new HttpContractError("INTERNAL_ERROR", "服务器内部错误");
+}
+
+function forbiddenPathReason(
+	details: unknown,
+): "outside-root" | "not-registered" | "symlink-escape" {
+	if (details && typeof details === "object") {
+		const reason = (details as { reason?: unknown }).reason;
+		if (
+			reason === "outside-root" ||
+			reason === "not-registered" ||
+			reason === "symlink-escape"
+		) {
+			return reason;
+		}
+	}
+	return "outside-root";
+}
+
+function invalidContextRequest(
+	issues: Array<{ path: PropertyKey[]; message: string }>,
+): HttpContractError {
+	return new HttpContractError("INVALID_REQUEST", "请求字段不符合 schema", {
+		issues: issues.map((issue) => ({
+			path: issue.path.join("."),
+			message: issue.message,
+		})),
+	});
+}

--- a/workbench/server/src/index.ts
+++ b/workbench/server/src/index.ts
@@ -38,13 +38,11 @@ import {
 } from "./artifacts.js";
 import {
 	bootstrapFromConfig,
-	clearActive,
 	createNewConversation,
 	getActive,
 	getActiveSession,
 	listLoadedSkills,
 	selectConversation,
-	selectKb,
 } from "./agent.js";
 import { setAuthKey, testAuthConnection } from "./auth.js";
 import { loadConfig } from "./config.js";
@@ -59,18 +57,13 @@ import {
 	readGraphLayout,
 	resumeGraphWatcher,
 	subscribeGraphEvents,
-	stopKnowledgeBaseGraphWatcher,
 	suspendGraphWatcher,
 	triggerGraphRebuild,
 	watchKnowledgeBaseGraph,
 	writeGraphLayout,
 } from "./graph.js";
 import {
-	inspectPath,
 	assertRegisteredKnowledgeBase,
-	listKnowledgeBases,
-	registerExternalKnowledgeBase,
-	unregisterExternalKnowledgeBase,
 } from "./knowledge-bases.js";
 import { listPageRefs, readWikiPage } from "./pages.js";
 import { localHostOnly } from "./security/host.js";
@@ -191,75 +184,7 @@ app.post("/api/echo", async (c) => {
 	return c.json({ ok: true, received: body });
 });
 
-// ============= 知识库列表（库的管理） =============
-
-app.get("/api/knowledge-bases", async (c) => {
-	try {
-		const items = await listKnowledgeBases();
-		return c.json({ ok: true, items });
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			500,
-		);
-	}
-});
-
-app.post("/api/knowledge-bases/external", async (c) => {
-	let body: { path?: unknown };
-	try {
-		body = await c.req.json();
-	} catch {
-		return c.json({ ok: false, error: "Invalid JSON body" }, 400);
-	}
-	if (typeof body.path !== "string" || !body.path.trim()) {
-		return c.json({ ok: false, error: "Missing or empty 'path'" }, 400);
-	}
-	try {
-		const result = await registerExternalKnowledgeBase(body.path);
-		return c.json({ ok: true, ...result });
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			400,
-		);
-	}
-});
-
-app.post("/api/knowledge-bases/inspect", async (c) => {
-	let body: { path?: unknown };
-	try {
-		body = await c.req.json();
-	} catch {
-		return c.json({ ok: false, error: "Invalid JSON body" }, 400);
-	}
-	if (typeof body.path !== "string" || !body.path.trim()) {
-		return c.json({ ok: false, error: "Missing or empty 'path'" }, 400);
-	}
-	try {
-		return c.json({ ok: true, result: await inspectPath(body.path) });
-	} catch (err) {
-		const statusCode = (err as { statusCode?: number }).statusCode ?? 500;
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			statusCode === 403 ? 403 : 500,
-		);
-	}
-});
-
-app.delete("/api/knowledge-bases/external", async (c) => {
-	let body: { path?: unknown };
-	try {
-		body = await c.req.json();
-	} catch {
-		return c.json({ ok: false, error: "Invalid JSON body" }, 400);
-	}
-	if (typeof body.path !== "string" || !body.path.trim()) {
-		return c.json({ ok: false, error: "Missing or empty 'path'" }, 400);
-	}
-	const result = await unregisterExternalKnowledgeBase(body.path);
-	return c.json({ ok: true, ...result });
-});
+// ============= 知识库初始化（仍为 legacy；列表/登记/active context 已迁入 routes） =============
 
 app.post("/api/knowledge-bases/new", async (c) => {
 	let body: { name?: unknown; purpose?: unknown };
@@ -325,63 +250,6 @@ app.post("/api/knowledge-bases/init-existing", async (c) => {
 			400,
 		);
 	}
-});
-
-// ============= 活跃上下文（当前选中的 KB + 对话） =============
-
-app.get("/api/knowledge-base", async (c) => {
-	const ctx = getActive();
-	if (!ctx) return c.json({ ok: true, active: null });
-	return c.json({
-		ok: true,
-		active: {
-			kb: ctx.kb,
-			conversation: {
-				id: ctx.conversationId,
-				messages: piMessagesToUIMessages(ctx.session.state.messages),
-			},
-			model: extractModelInfo(ctx.session),
-		},
-	});
-});
-
-app.post("/api/knowledge-base", async (c) => {
-	let body: { path?: unknown };
-	try {
-		body = await c.req.json();
-	} catch {
-		return c.json({ ok: false, error: "Invalid JSON body" }, 400);
-	}
-	if (typeof body.path !== "string" || !body.path.trim()) {
-		return c.json({ ok: false, error: "Missing or empty 'path'" }, 400);
-	}
-	try {
-		const ctx = await selectKb(body.path);
-		watchKnowledgeBaseGraph(ctx.kb.path);
-		return c.json({
-			ok: true,
-			active: {
-				kb: ctx.kb,
-				conversation: {
-					id: ctx.conversationId,
-					isNew: ctx.isNew,
-					messages: piMessagesToUIMessages(ctx.session.state.messages),
-				},
-				model: extractModelInfo(ctx.session),
-			},
-		});
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			400,
-		);
-	}
-});
-
-app.delete("/api/knowledge-base", async (c) => {
-	await clearActive();
-	stopKnowledgeBaseGraphWatcher();
-	return c.json({ ok: true });
 });
 
 // ============= 图谱（指定知识库；未传时回退当前知识库） =============

--- a/workbench/server/src/knowledge-base-routes.test.ts
+++ b/workbench/server/src/knowledge-base-routes.test.ts
@@ -1,0 +1,347 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+	ActiveKnowledgeBaseData,
+	InspectKnowledgeBasePathData,
+	KnowledgeBaseInfo,
+	RegisterExternalKnowledgeBaseData,
+	UnregisterExternalKnowledgeBaseData,
+} from "@llm-wiki/workbench-contracts";
+
+import { createApp } from "./app.js";
+import { resolveKnowledgeBaseContext } from "./http/knowledge-base-context.js";
+import type { KnowledgeBaseRouteService } from "./routes/knowledge-bases.js";
+
+type EnvelopeJson = {
+	ok?: boolean;
+	code?: string;
+	message?: string;
+	details?: Record<string, unknown>;
+	data?: unknown;
+};
+
+const registeredKb: KnowledgeBaseInfo = {
+	path: "/fake/default/registered",
+	name: "registered",
+	origin: "default",
+	valid: true,
+};
+
+const externalKb: KnowledgeBaseInfo = {
+	path: "/fake/external/notes",
+	name: "notes",
+	origin: "external",
+	valid: true,
+};
+
+const activeData: ActiveKnowledgeBaseData = {
+	active: {
+		kb: { path: registeredKb.path, name: registeredKb.name },
+		conversation: {
+			id: "conversation-1",
+			isNew: false,
+			messages: [
+				{
+					id: "u-0",
+					role: "user",
+					content: "你好",
+					tools: [],
+				},
+			],
+		},
+		model: { provider: "anthropic", id: "claude-sonnet" },
+	},
+};
+
+interface FakeOptions {
+	active?: ActiveKnowledgeBaseData;
+	registered?: ReadonlySet<string>;
+	forbidden?: ReadonlySet<string>;
+}
+
+function createFakeService(options: FakeOptions = {}) {
+	let active = options.active ?? { active: null };
+	const registered = options.registered ?? new Set([registeredKb.path, externalKb.path]);
+	const forbidden = options.forbidden ?? new Set<string>();
+	const calls = {
+		selected: [] as string[],
+		watched: [] as string[],
+		cleared: 0,
+		stopped: 0,
+		registered: [] as string[],
+		unregistered: [] as string[],
+		inspected: [] as string[],
+	};
+
+	const assertSelectable = (kbPath: string) => {
+		if (forbidden.has(kbPath)) {
+			throw Object.assign(new Error("private path"), {
+				code: "FORBIDDEN_PATH",
+				details: { reason: "outside-root" },
+			});
+		}
+		if (!registered.has(kbPath)) {
+			throw Object.assign(new Error("not registered"), {
+				code: "KB_NOT_REGISTERED",
+			});
+		}
+	};
+
+	const service: KnowledgeBaseRouteService = {
+		listKnowledgeBases: async () => [registeredKb, externalKb],
+		registerExternalKnowledgeBase: async (
+			path: string,
+		): Promise<RegisterExternalKnowledgeBaseData> => {
+			calls.registered.push(path);
+			if (forbidden.has(path)) {
+				throw Object.assign(new Error(`/Users/private/${path}`), {
+					code: "FORBIDDEN_PATH",
+					details: { reason: "outside-root" },
+				});
+			}
+			return { registered: true, path: externalKb.path, info: externalKb };
+		},
+		unregisterExternalKnowledgeBase: async (
+			path: string,
+		): Promise<UnregisterExternalKnowledgeBaseData> => {
+			calls.unregistered.push(path);
+			return { removed: true, path };
+		},
+		inspectKnowledgeBasePath: async (
+			path: string,
+		): Promise<InspectKnowledgeBasePathData> => {
+			calls.inspected.push(path);
+			if (forbidden.has(path)) {
+				throw Object.assign(new Error(`/Users/private/${path}`), {
+					code: "FORBIDDEN_PATH",
+					details: { reason: "symlink-escape" },
+				});
+			}
+			return {
+				exists: true,
+				isDirectory: true,
+				hasWikiSchema: true,
+				resolvedPath: path,
+			};
+		},
+		getActiveKnowledgeBase: () => active,
+		assertRegisteredKnowledgeBase: async (kbPath: string) => {
+			assertSelectable(kbPath);
+			return kbPath;
+		},
+		selectKnowledgeBase: async (kbPath: string) => {
+			assertSelectable(kbPath);
+			calls.selected.push(kbPath);
+			active = activeData;
+			return activeData;
+		},
+		clearActiveKnowledgeBase: async () => {
+			calls.cleared += 1;
+			active = { active: null };
+		},
+		watchKnowledgeBaseGraph: (kbPath: string) => {
+			calls.watched.push(kbPath);
+		},
+		stopKnowledgeBaseGraphWatcher: () => {
+			calls.stopped += 1;
+		},
+	};
+	return { service, calls };
+}
+
+async function json(res: Response): Promise<EnvelopeJson> {
+	return (await res.json()) as EnvelopeJson;
+}
+
+test("知识库 route 使用 fake service 返回统一列表、active 与管理 envelope", async () => {
+	const { service, calls } = createFakeService({ active: activeData });
+	const app = createApp({ knowledgeBaseService: service });
+
+	const listRes = await app.request("/api/knowledge-bases");
+	assert.equal(listRes.status, 200);
+	assert.deepEqual((await json(listRes)).data, [registeredKb, externalKb]);
+
+	const activeRes = await app.request("/api/knowledge-base");
+	assert.equal(activeRes.status, 200);
+	assert.deepEqual((await json(activeRes)).data, activeData);
+
+	const registerRes = await app.request("/api/knowledge-bases/external", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ path: " /fake/external/notes " }),
+	});
+	assert.equal(registerRes.status, 200);
+	assert.deepEqual(calls.registered, [externalKb.path]);
+	assert.deepEqual((await json(registerRes)).data, {
+		registered: true,
+		path: externalKb.path,
+		info: externalKb,
+	});
+
+	const inspectRes = await app.request("/api/knowledge-bases/inspect", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ path: externalKb.path }),
+	});
+	assert.equal(inspectRes.status, 200);
+	assert.equal((await json(inspectRes)).ok, true);
+	assert.deepEqual(calls.inspected, [externalKb.path]);
+
+	const unregisterRes = await app.request("/api/knowledge-bases/external", {
+		method: "DELETE",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ path: externalKb.path }),
+	});
+	assert.equal(unregisterRes.status, 200);
+	assert.deepEqual(calls.unregistered, [externalKb.path]);
+});
+
+test("读取 active context 在未选库时返回统一的 null active", async () => {
+	const { service } = createFakeService();
+	const app = createApp({ knowledgeBaseService: service });
+	const res = await app.request("/api/knowledge-base");
+	assert.equal(res.status, 200);
+	assert.deepEqual(await json(res), {
+		ok: true,
+		data: { active: null },
+	});
+});
+
+test("共享上下文 resolver 在未选库时返回 NO_ACTIVE_KB", async () => {
+	await assert.rejects(
+		() =>
+			resolveKnowledgeBaseContext(
+				{},
+				{
+					getActiveKnowledgeBasePath: () => null,
+					assertRegisteredKnowledgeBase: async (kbPath) => kbPath,
+				},
+			),
+		(err) =>
+			err instanceof Error &&
+			(err as Error & { code?: string }).code === "NO_ACTIVE_KB",
+	);
+});
+
+test("选择 active KB 只接受 kbPath，验证登记后切换并启动 watcher", async () => {
+	const { service, calls } = createFakeService();
+	const app = createApp({ knowledgeBaseService: service });
+	const res = await app.request("/api/knowledge-base", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ kbPath: registeredKb.path }),
+	});
+	assert.equal(res.status, 200);
+	assert.deepEqual((await json(res)).data, activeData);
+	assert.deepEqual(calls.selected, [registeredKb.path]);
+	assert.deepEqual(calls.watched, [registeredKb.path]);
+
+	const oldField = await app.request("/api/knowledge-base", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ path: registeredKb.path }),
+	});
+	assert.equal(oldField.status, 400);
+	assert.equal((await json(oldField)).code, "INVALID_REQUEST");
+});
+
+test("选择未登记 KB 返回 KB_NOT_REGISTERED，且不改变 active 或 watcher", async () => {
+	const { service, calls } = createFakeService({ active: activeData });
+	const app = createApp({ knowledgeBaseService: service });
+	const res = await app.request("/api/knowledge-base", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ kbPath: "/fake/unregistered" }),
+	});
+	assert.equal(res.status, 404);
+	assert.deepEqual(await json(res), {
+		ok: false,
+		code: "KB_NOT_REGISTERED",
+		message: "知识库未登记或已失效",
+	});
+	assert.deepEqual(calls.selected, []);
+	assert.deepEqual(calls.watched, []);
+	assert.deepEqual(service.getActiveKnowledgeBase(), activeData);
+});
+
+test("forbidden path 返回脱敏 FORBIDDEN_PATH，不泄露本地绝对路径", async () => {
+	const privatePath = "/fake/private";
+	const { service } = createFakeService({ forbidden: new Set([privatePath]) });
+	const app = createApp({ knowledgeBaseService: service });
+	for (const [url, method, body] of [
+		["/api/knowledge-bases/inspect", "POST", { path: privatePath }],
+		["/api/knowledge-bases/external", "POST", { path: privatePath }],
+		["/api/knowledge-base", "POST", { kbPath: privatePath }],
+	] as const) {
+		const res = await app.request(url, {
+			method,
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+		assert.equal(res.status, 403);
+		const payload = await json(res);
+		assert.equal(payload.ok, false);
+		assert.equal(payload.code, "FORBIDDEN_PATH");
+		assert.equal(payload.message, "路径不在允许的知识库边界内");
+		assert.equal(
+			["outside-root", "symlink-escape"].includes(
+				String(payload.details?.reason),
+			),
+			true,
+		);
+		assert.equal(JSON.stringify(payload).includes("/Users/"), false);
+		assert.equal(JSON.stringify(payload).includes(privatePath), false);
+	}
+});
+
+test("清除 active context 同时清理会话与 graph watcher", async () => {
+	const { service, calls } = createFakeService({ active: activeData });
+	const app = createApp({ knowledgeBaseService: service });
+	const res = await app.request("/api/knowledge-base", { method: "DELETE" });
+	assert.equal(res.status, 200);
+	assert.deepEqual(await json(res), { ok: true, data: { active: null } });
+	assert.equal(calls.cleared, 1);
+	assert.equal(calls.stopped, 1);
+});
+
+test("未知知识库服务错误返回脱敏 INTERNAL_ERROR", async () => {
+	const { service } = createFakeService();
+	service.registerExternalKnowledgeBase = async (
+		_path: string,
+	): Promise<RegisterExternalKnowledgeBaseData> => {
+		throw new Error("/Users/private/config.json api_key=sk-do-not-leak");
+	};
+	const app = createApp({ knowledgeBaseService: service });
+	const res = await app.request("/api/knowledge-bases/external", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ path: "/fake/external" }),
+	});
+	assert.equal(res.status, 500);
+	assert.deepEqual(await json(res), {
+		ok: false,
+		code: "INTERNAL_ERROR",
+		message: "服务器内部错误",
+	});
+});
+
+test("知识库 body 使用统一 JSON/schema 校验且不回显原始 body", async () => {
+	const { service } = createFakeService();
+	const app = createApp({ knowledgeBaseService: service });
+	const invalidJson = await app.request("/api/knowledge-base", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: "{bad",
+	});
+	assert.equal((await json(invalidJson)).code, "INVALID_JSON");
+
+	const invalidRequest = await app.request("/api/knowledge-bases/external", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ path: "", secret: "sk-do-not-echo" }),
+	});
+	const payload = await json(invalidRequest);
+	assert.equal(payload.code, "INVALID_REQUEST");
+	assert.equal(JSON.stringify(payload).includes("sk-do-not-echo"), false);
+});

--- a/workbench/server/src/knowledge-bases.ts
+++ b/workbench/server/src/knowledge-bases.ts
@@ -109,7 +109,9 @@ export async function findRegisteredKnowledgeBase(
 export async function assertRegisteredKnowledgeBase(rawPath: string): Promise<string> {
 	const match = await findRegisteredKnowledgeBase(rawPath, await listKnowledgeBases());
 	if (!match) {
-		throw Object.assign(new Error("knowledge base is not registered"), { statusCode: 403 });
+		throw Object.assign(new Error("knowledge base is not registered"), {
+			code: "KB_NOT_REGISTERED",
+		});
 	}
 	return match.path;
 }
@@ -120,7 +122,10 @@ export async function inspectPath(rawPath: string): Promise<InspectPathResult> {
 	const absolutePath = resolve(expanded);
 	const info = await stat(absolutePath).catch((err: NodeJS.ErrnoException) => {
 		if (err.code === "EACCES" || err.code === "EPERM") {
-			throw Object.assign(new Error(`没有权限访问：${absolutePath}`), { statusCode: 403 });
+			throw Object.assign(new Error("path is not accessible"), {
+				code: "FORBIDDEN_PATH",
+				details: { reason: "outside-root" },
+			});
 		}
 		return null;
 	});
@@ -274,7 +279,9 @@ export async function registerExternalKnowledgeBase(rawPath: string): Promise<{
 
 	const check = await inspectKnowledgeBasePath(absolutePath);
 	if (!check.valid) {
-		throw new Error(`不是合法知识库（${check.reason}）：${absolutePath}`);
+		throw Object.assign(new Error("path is not a valid knowledge base"), {
+			code: "KB_NOT_REGISTERED",
+		});
 	}
 
 	const config = await loadConfig();

--- a/workbench/server/src/knowledge-bases.ts
+++ b/workbench/server/src/knowledge-bases.ts
@@ -111,6 +111,7 @@ export async function assertRegisteredKnowledgeBase(rawPath: string): Promise<st
 	if (!match) {
 		throw Object.assign(new Error("knowledge base is not registered"), {
 			code: "KB_NOT_REGISTERED",
+			statusCode: 403,
 		});
 	}
 	return match.path;

--- a/workbench/server/src/routes/knowledge-bases.ts
+++ b/workbench/server/src/routes/knowledge-bases.ts
@@ -1,0 +1,218 @@
+import { Hono } from "hono";
+
+import {
+	ActiveKnowledgeBaseDataSchema,
+	InspectKnowledgeBasePathDataSchema,
+	KnowledgeBaseContextBodySchema,
+	KnowledgeBaseListDataSchema,
+	KnowledgeBasePathBodySchema,
+	RegisterExternalKnowledgeBaseDataSchema,
+	UnregisterExternalKnowledgeBaseDataSchema,
+	type ActiveKnowledgeBaseData,
+	type InspectKnowledgeBasePathData,
+	type KnowledgeBaseInfo,
+	type RegisterExternalKnowledgeBaseData,
+	type UnregisterExternalKnowledgeBaseData,
+} from "@llm-wiki/workbench-contracts";
+
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+
+import {
+	clearActive,
+	getActive,
+	selectKb,
+	type ActiveContext as AgentActiveContext,
+} from "../agent.js";
+import { piMessagesToUIMessages } from "../conversations.js";
+import {
+	mapKnowledgeBaseError,
+	resolveKnowledgeBaseContext,
+} from "../http/knowledge-base-context.js";
+import {
+	HttpContractError,
+	parseValidatedBody,
+} from "../http/request.js";
+import { jsonOk } from "../http/response.js";
+import {
+	assertRegisteredKnowledgeBase,
+	inspectPath,
+	listKnowledgeBases,
+	registerExternalKnowledgeBase,
+	unregisterExternalKnowledgeBase,
+} from "../knowledge-bases.js";
+import {
+	stopKnowledgeBaseGraphWatcher,
+	watchKnowledgeBaseGraph,
+} from "../graph.js";
+
+export interface KnowledgeBaseRouteService {
+	listKnowledgeBases: () => Promise<KnowledgeBaseInfo[]>;
+	registerExternalKnowledgeBase: (
+		path: string,
+	) => Promise<RegisterExternalKnowledgeBaseData>;
+	unregisterExternalKnowledgeBase: (
+		path: string,
+	) => Promise<UnregisterExternalKnowledgeBaseData>;
+	inspectKnowledgeBasePath: (
+		path: string,
+	) => Promise<InspectKnowledgeBasePathData>;
+	getActiveKnowledgeBase: () => ActiveKnowledgeBaseData;
+	assertRegisteredKnowledgeBase: (kbPath: string) => Promise<string>;
+	selectKnowledgeBase: (kbPath: string) => Promise<ActiveKnowledgeBaseData>;
+	clearActiveKnowledgeBase: () => Promise<void>;
+	watchKnowledgeBaseGraph: (kbPath: string) => void;
+	stopKnowledgeBaseGraphWatcher: () => void;
+}
+
+export const defaultKnowledgeBaseRouteService: KnowledgeBaseRouteService = {
+	listKnowledgeBases: async () =>
+		KnowledgeBaseListDataSchema.parse(await listKnowledgeBases()),
+	registerExternalKnowledgeBase: async (path) =>
+		RegisterExternalKnowledgeBaseDataSchema.parse(
+			await registerExternalKnowledgeBase(path),
+		),
+	unregisterExternalKnowledgeBase: async (path) =>
+		UnregisterExternalKnowledgeBaseDataSchema.parse(
+			await unregisterExternalKnowledgeBase(path),
+		),
+	inspectKnowledgeBasePath: async (path) =>
+		InspectKnowledgeBasePathDataSchema.parse(await inspectPath(path)),
+	getActiveKnowledgeBase: () => serializeActiveContext(getActive()),
+	assertRegisteredKnowledgeBase,
+	selectKnowledgeBase: async (kbPath) => {
+		const registeredPath = await assertRegisteredKnowledgeBase(kbPath);
+		return serializeActiveContext(await selectKb(registeredPath));
+	},
+	clearActiveKnowledgeBase: clearActive,
+	watchKnowledgeBaseGraph,
+	stopKnowledgeBaseGraphWatcher,
+};
+
+export function createKnowledgeBaseRoutes(
+	service: KnowledgeBaseRouteService,
+): Hono {
+	const router = new Hono();
+
+	router.get("/knowledge-bases", async (c) => {
+		const items = KnowledgeBaseListDataSchema.parse(
+			await service.listKnowledgeBases(),
+		);
+		return jsonOk(c, items);
+	});
+
+	router.post("/knowledge-bases/external", async (c) => {
+		const { path } = await parseValidatedBody(c, KnowledgeBasePathBodySchema);
+		try {
+			return jsonOk(
+				c,
+				RegisterExternalKnowledgeBaseDataSchema.parse(
+					await service.registerExternalKnowledgeBase(path),
+				),
+			);
+		} catch (err) {
+			throw mapKnowledgeBaseError(err);
+		}
+	});
+
+	router.post("/knowledge-bases/inspect", async (c) => {
+		const { path } = await parseValidatedBody(c, KnowledgeBasePathBodySchema);
+		try {
+			return jsonOk(
+				c,
+				InspectKnowledgeBasePathDataSchema.parse(
+					await service.inspectKnowledgeBasePath(path),
+				),
+			);
+		} catch (err) {
+			throw mapKnowledgeBaseError(err);
+		}
+	});
+
+	router.delete("/knowledge-bases/external", async (c) => {
+		const { path } = await parseValidatedBody(c, KnowledgeBasePathBodySchema);
+		try {
+			return jsonOk(
+				c,
+				UnregisterExternalKnowledgeBaseDataSchema.parse(
+					await service.unregisterExternalKnowledgeBase(path),
+				),
+			);
+		} catch (err) {
+			throw mapKnowledgeBaseError(err);
+		}
+	});
+
+	router.get("/knowledge-base", (c) => {
+		const data = ActiveKnowledgeBaseDataSchema.parse(
+			service.getActiveKnowledgeBase(),
+		);
+		return jsonOk(c, data);
+	});
+
+	router.post("/knowledge-base", async (c) => {
+		const body = await parseValidatedBody(c, KnowledgeBaseContextBodySchema);
+		const kbPath = await resolveKnowledgeBaseContext(
+			{ body },
+			{
+				getActiveKnowledgeBasePath: () =>
+					service.getActiveKnowledgeBase().active?.kb.path ?? null,
+				assertRegisteredKnowledgeBase:
+					service.assertRegisteredKnowledgeBase,
+			},
+		);
+		try {
+			const data = ActiveKnowledgeBaseDataSchema.parse(
+				await service.selectKnowledgeBase(kbPath),
+			);
+			if (!data.active) {
+				throw new Error("selectKnowledgeBase returned no active context");
+			}
+			service.watchKnowledgeBaseGraph(data.active.kb.path);
+			return jsonOk(c, data);
+		} catch (err) {
+			if (err instanceof HttpContractError) throw err;
+			throw mapKnowledgeBaseError(err);
+		}
+	});
+
+	router.delete("/knowledge-base", async (c) => {
+		await service.clearActiveKnowledgeBase();
+		service.stopKnowledgeBaseGraphWatcher();
+		return jsonOk(c, ActiveKnowledgeBaseDataSchema.parse({ active: null }));
+	});
+
+	return router;
+}
+
+function serializeActiveContext(
+	ctx: AgentActiveContext | null,
+): ActiveKnowledgeBaseData {
+	if (!ctx) return { active: null };
+	return ActiveKnowledgeBaseDataSchema.parse({
+		active: {
+			kb: ctx.kb,
+			conversation: {
+				id: ctx.conversationId,
+				isNew: ctx.isNew,
+				messages: piMessagesToUIMessages(ctx.session.state.messages),
+			},
+			model: extractModelInfo(ctx.session),
+		},
+	});
+}
+
+function extractModelInfo(
+	session: AgentSession,
+): { provider: string; id: string } | null {
+	const model = (session.state as {
+		model?: { provider?: unknown; id?: unknown };
+	}).model;
+	if (
+		model &&
+		typeof model.provider === "string" &&
+		typeof model.id === "string"
+	) {
+		return { provider: model.provider, id: model.id };
+	}
+	return null;
+}

--- a/workbench/web/src/lib/api.ts
+++ b/workbench/web/src/lib/api.ts
@@ -8,29 +8,35 @@ import { parseSSE, type SSEMessage } from "./sse";
 import { getConfig as getConfigMigrated, setConfig as setConfigMigrated, fetchAvailableModels as fetchAvailableModelsMigrated } from "./api/config";
 import { getAuthStatus as getAuthStatusMigrated } from "./api/auth";
 import {
+	clearActiveContext as clearActiveContextMigrated,
+	getActiveContext as getActiveContextMigrated,
+	inspectKnowledgeBasePath as inspectKnowledgeBasePathMigrated,
+	listKnowledgeBases as listKnowledgeBasesMigrated,
+	registerExternalKnowledgeBase as registerExternalKnowledgeBaseMigrated,
+	selectKnowledgeBase as selectKnowledgeBaseMigrated,
+	unregisterExternalKnowledgeBase as unregisterExternalKnowledgeBaseMigrated,
+} from "./api/knowledge-bases";
+import {
+	type ActiveContext,
 	type AppConfig,
 	type AuthStatusData,
 	type AvailableModelInfo,
+	type InspectKnowledgeBasePathData,
+	type KnowledgeBaseInfo,
 	type ModelRef,
 } from "@llm-wiki/workbench-contracts";
 import type { GraphData, GraphDiff, GraphLayoutFile, PinMap } from "@llm-wiki/graph-engine";
 
-export type { AppConfig, AvailableModelInfo, ModelRef } from "@llm-wiki/workbench-contracts";
+export type {
+	ActiveContext,
+	AppConfig,
+	AvailableModelInfo,
+	KnowledgeBaseInfo,
+	ModelRef,
+	UIMessage,
+} from "@llm-wiki/workbench-contracts";
 
 // ============= 类型 =============
-
-export interface KnowledgeBaseInfo {
-	path: string;
-	name: string;
-	origin: "default" | "external";
-	valid: boolean;
-	reason?: string;
-}
-
-export interface CurrentKnowledgeBase {
-	path: string;
-	name: string;
-}
 
 export interface ConversationInfo {
 	id: string;
@@ -39,29 +45,7 @@ export interface ConversationInfo {
 	modifiedAt: number;
 }
 
-export interface UIMessage {
-	id: string;
-	role: "user" | "assistant";
-	content: string;
-	tools: { name: string; status: "done" }[];
-}
-
-export interface ModelInfo {
-	provider: string;
-	id: string;
-}
-
 export type AuthStatus = AuthStatusData;
-
-export interface ActiveContext {
-	kb: CurrentKnowledgeBase;
-	conversation: {
-		id: string;
-		isNew?: boolean;
-		messages: UIMessage[];
-	};
-	model: ModelInfo | null;
-}
 
 export interface CommandItem {
 	slug: string;
@@ -100,19 +84,10 @@ export interface ArtifactManifest {
 
 export type ExportKind = "pdf" | "docx" | "pptx" | "xlsx" | "html";
 
-export interface InspectPathResult {
-	exists: boolean;
-	isDirectory: boolean;
-	hasWikiSchema: boolean;
-	resolvedPath?: string;
-	ingestibleFiles?: {
-		scanId: string;
-		count: number;
-		samples: string[];
-		paths: string[];
-		truncated: boolean;
-	};
-}
+export type InspectPathResult = InspectKnowledgeBasePathData;
+export type ModelInfo = ActiveContext["model"] extends infer Model
+	? Exclude<Model, null>
+	: never;
 
 export type BatchDigestEvent =
 	| { type: "start"; total: number; concurrency: number; outputDir: string }
@@ -224,75 +199,35 @@ export type ToolStatusContractEvent =
 	| AssistantErrorEvent;
 
 // ============= API =============
-// health 已迁移到统一契约路径 ./api/health（createApp + workbench-contracts）。
-// 其余函数仍是 legacy，等待按 issue 逐个迁移到 ./api/<domain>。
+// health、config/auth 和 knowledge-bases/active context 已迁移到 ./api/<domain>。
+// 其余函数仍是 legacy，等待按 issue 逐个迁移。
 
-export async function listKnowledgeBases(): Promise<KnowledgeBaseInfo[]> {
-	const res = await fetch("/api/knowledge-bases");
-	if (!res.ok) throw new Error(`HTTP ${res.status}`);
-	const json = (await res.json()) as { ok: boolean; items?: KnowledgeBaseInfo[]; error?: string };
-	if (!json.ok) throw new Error(json.error ?? "未知错误");
-	return json.items ?? [];
+export function listKnowledgeBases(): Promise<KnowledgeBaseInfo[]> {
+	return listKnowledgeBasesMigrated();
 }
 
-export async function getActiveContext(): Promise<ActiveContext | null> {
-	const res = await fetch("/api/knowledge-base");
-	if (!res.ok) throw new Error(`HTTP ${res.status}`);
-	const json = (await res.json()) as { ok: boolean; active: ActiveContext | null };
-	return json.active;
+export function getActiveContext(): Promise<ActiveContext | null> {
+	return getActiveContextMigrated();
 }
 
-export async function selectKnowledgeBase(path: string): Promise<ActiveContext> {
-	const res = await fetch("/api/knowledge-base", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ path }),
-	});
-	const json = (await res.json()) as {
-		ok: boolean;
-		active?: ActiveContext;
-		error?: string;
-	};
-	if (!res.ok || !json.ok || !json.active) {
-		throw new Error(json.error ?? `HTTP ${res.status}`);
-	}
-	return json.active;
+export function selectKnowledgeBase(path: string): Promise<ActiveContext> {
+	return selectKnowledgeBaseMigrated(path);
 }
 
-export async function clearActiveContext(): Promise<void> {
-	await fetch("/api/knowledge-base", { method: "DELETE" });
+export function clearActiveContext(): Promise<void> {
+	return clearActiveContextMigrated();
 }
 
-export async function registerExternalKnowledgeBase(path: string): Promise<{
-	registered: boolean;
-	info: KnowledgeBaseInfo;
-}> {
-	const res = await fetch("/api/knowledge-bases/external", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ path }),
-	});
-	const json = (await res.json()) as {
-		ok: boolean;
-		registered?: boolean;
-		info?: KnowledgeBaseInfo;
-		error?: string;
-	};
-	if (!res.ok || !json.ok || !json.info) {
-		throw new Error(json.error ?? `HTTP ${res.status}`);
-	}
-	return { registered: json.registered ?? false, info: json.info };
+export function registerExternalKnowledgeBase(
+	path: string,
+): Promise<{ registered: boolean; info: KnowledgeBaseInfo }> {
+	return registerExternalKnowledgeBaseMigrated(path);
 }
 
-export async function inspectKnowledgeBasePath(path: string): Promise<InspectPathResult> {
-	const res = await fetch("/api/knowledge-bases/inspect", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ path }),
-	});
-	const json = (await res.json()) as { ok: boolean; result?: InspectPathResult; error?: string };
-	if (!res.ok || !json.ok || !json.result) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return json.result;
+export function inspectKnowledgeBasePath(
+	path: string,
+): Promise<InspectPathResult> {
+	return inspectKnowledgeBasePathMigrated(path);
 }
 
 export async function chooseDirectory(): Promise<string | null> {
@@ -346,15 +281,10 @@ export async function createKnowledgeBase(name: string, purpose: string): Promis
 	return json.info;
 }
 
-export async function unregisterExternalKnowledgeBase(path: string): Promise<{ removed: boolean }> {
-	const res = await fetch("/api/knowledge-bases/external", {
-		method: "DELETE",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ path }),
-	});
-	const json = (await res.json()) as { ok: boolean; removed?: boolean; error?: string };
-	if (!res.ok || !json.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return { removed: json.removed ?? false };
+export function unregisterExternalKnowledgeBase(
+	path: string,
+): Promise<{ removed: boolean }> {
+	return unregisterExternalKnowledgeBaseMigrated(path);
 }
 
 // ============= 对话 =============

--- a/workbench/web/src/lib/api/knowledge-bases.ts
+++ b/workbench/web/src/lib/api/knowledge-bases.ts
@@ -1,0 +1,89 @@
+import {
+	ActiveKnowledgeBaseDataSchema,
+	InspectKnowledgeBasePathDataSchema,
+	KnowledgeBaseContextBodySchema,
+	KnowledgeBaseListDataSchema,
+	KnowledgeBasePathBodySchema,
+	RegisterExternalKnowledgeBaseDataSchema,
+	UnregisterExternalKnowledgeBaseDataSchema,
+	type ActiveContext,
+	type InspectKnowledgeBasePathData,
+	type KnowledgeBaseInfo,
+} from "@llm-wiki/workbench-contracts";
+
+import { request } from "./client";
+
+export type {
+	ActiveContext,
+	CurrentKnowledgeBase,
+	InspectKnowledgeBasePathData as InspectPathResult,
+	KnowledgeBaseInfo,
+	UIMessage,
+} from "@llm-wiki/workbench-contracts";
+
+export function listKnowledgeBases(): Promise<KnowledgeBaseInfo[]> {
+	return request("/api/knowledge-bases", {
+		responseSchema: KnowledgeBaseListDataSchema,
+	});
+}
+
+export async function getActiveContext(): Promise<ActiveContext | null> {
+	const { active } = await request("/api/knowledge-base", {
+		responseSchema: ActiveKnowledgeBaseDataSchema,
+	});
+	return active;
+}
+
+export async function selectKnowledgeBase(
+	kbPath: string,
+): Promise<ActiveContext> {
+	const body = KnowledgeBaseContextBodySchema.parse({ kbPath });
+	const { active } = await request("/api/knowledge-base", {
+		method: "POST",
+		body,
+		responseSchema: ActiveKnowledgeBaseDataSchema,
+	});
+	if (!active) {
+		throw new Error("选择知识库后未返回 active context");
+	}
+	return active;
+}
+
+export async function clearActiveContext(): Promise<void> {
+	await request("/api/knowledge-base", {
+		method: "DELETE",
+		responseSchema: ActiveKnowledgeBaseDataSchema,
+	});
+}
+
+export async function registerExternalKnowledgeBase(
+	path: string,
+): Promise<{ registered: boolean; info: KnowledgeBaseInfo }> {
+	const data = await request("/api/knowledge-bases/external", {
+		method: "POST",
+		body: KnowledgeBasePathBodySchema.parse({ path }),
+		responseSchema: RegisterExternalKnowledgeBaseDataSchema,
+	});
+	return { registered: data.registered, info: data.info };
+}
+
+export function inspectKnowledgeBasePath(
+	path: string,
+): Promise<InspectKnowledgeBasePathData> {
+	return request("/api/knowledge-bases/inspect", {
+		method: "POST",
+		body: KnowledgeBasePathBodySchema.parse({ path }),
+		responseSchema: InspectKnowledgeBasePathDataSchema,
+	});
+}
+
+export async function unregisterExternalKnowledgeBase(
+	path: string,
+): Promise<{ removed: boolean }> {
+	const data = await request("/api/knowledge-bases/external", {
+		method: "DELETE",
+		body: KnowledgeBasePathBodySchema.parse({ path }),
+		responseSchema: UnregisterExternalKnowledgeBaseDataSchema,
+	});
+	return { removed: data.removed };
+}

--- a/workbench/web/test/knowledge-bases-api.test.ts
+++ b/workbench/web/test/knowledge-bases-api.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { ApiError, ContractMismatchError } from "../src/lib/api/client";
+import {
+	clearActiveContext,
+	getActiveContext,
+	inspectKnowledgeBasePath,
+	listKnowledgeBases,
+	registerExternalKnowledgeBase,
+	selectKnowledgeBase,
+	unregisterExternalKnowledgeBase,
+} from "../src/lib/api/knowledge-bases";
+
+const knowledgeBase = {
+	path: "/kb/registered",
+	name: "registered",
+	origin: "external" as const,
+	valid: true,
+};
+
+const active = {
+	kb: { path: knowledgeBase.path, name: knowledgeBase.name },
+	conversation: { id: "conversation-1", isNew: false, messages: [] },
+	model: null,
+};
+
+function stubFetch(body: unknown, status = 200) {
+	const calls: Array<{ url: string; init?: RequestInit }> = [];
+	globalThis.fetch = ((input: URL | string, init?: RequestInit) => {
+		calls.push({ url: String(input), init });
+		return Promise.resolve(
+			new Response(JSON.stringify(body), {
+				status,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	}) as typeof globalThis.fetch;
+	return calls;
+}
+
+function requestBody(calls: Array<{ url: string; init?: RequestInit }>): unknown {
+	return JSON.parse(String(calls[0]?.init?.body));
+}
+
+describe("knowledge bases / active context API module", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("列表与 active context 只接受统一 envelope data", async () => {
+		let calls = stubFetch({ ok: true, data: [knowledgeBase] });
+		assert.deepEqual(await listKnowledgeBases(), [knowledgeBase]);
+		assert.equal(calls[0]?.url, "/api/knowledge-bases");
+		assert.equal(calls[0]?.init?.method, "GET");
+
+		calls = stubFetch({ ok: true, data: { active } });
+		assert.deepEqual(await getActiveContext(), active);
+		assert.equal(calls[0]?.url, "/api/knowledge-base");
+	});
+
+	it("selectKnowledgeBase 用 kbPath body 表达统一上下文入口", async () => {
+		const calls = stubFetch({ ok: true, data: { active } });
+		assert.deepEqual(await selectKnowledgeBase(knowledgeBase.path), active);
+		assert.equal(calls[0]?.url, "/api/knowledge-base");
+		assert.equal(calls[0]?.init?.method, "POST");
+		assert.deepEqual(requestBody(calls), { kbPath: knowledgeBase.path });
+	});
+
+	it("登记、检查、取消登记继续用 path body，并统一解析 data", async () => {
+		let calls = stubFetch({
+			ok: true,
+			data: { registered: true, path: knowledgeBase.path, info: knowledgeBase },
+		});
+		assert.deepEqual(await registerExternalKnowledgeBase(knowledgeBase.path), {
+			registered: true,
+			info: knowledgeBase,
+		});
+		assert.equal(calls[0]?.url, "/api/knowledge-bases/external");
+		assert.equal(calls[0]?.init?.method, "POST");
+		assert.deepEqual(requestBody(calls), { path: knowledgeBase.path });
+
+		calls = stubFetch({
+			ok: true,
+			data: {
+				exists: true,
+				isDirectory: true,
+				hasWikiSchema: true,
+				resolvedPath: knowledgeBase.path,
+			},
+		});
+		assert.equal((await inspectKnowledgeBasePath(knowledgeBase.path)).hasWikiSchema, true);
+		assert.equal(calls[0]?.url, "/api/knowledge-bases/inspect");
+		assert.deepEqual(requestBody(calls), { path: knowledgeBase.path });
+
+		calls = stubFetch({
+			ok: true,
+			data: { removed: true, path: knowledgeBase.path },
+		});
+		assert.deepEqual(await unregisterExternalKnowledgeBase(knowledgeBase.path), {
+			removed: true,
+		});
+		assert.equal(calls[0]?.init?.method, "DELETE");
+		assert.deepEqual(requestBody(calls), { path: knowledgeBase.path });
+	});
+
+	it("clearActiveContext 校验响应，不再吞掉失败", async () => {
+		const calls = stubFetch({ ok: true, data: { active: null } });
+		await clearActiveContext();
+		assert.equal(calls[0]?.url, "/api/knowledge-base");
+		assert.equal(calls[0]?.init?.method, "DELETE");
+
+		stubFetch(
+			{ ok: false, code: "FORBIDDEN_LOCAL_API", message: "缺少 capability token" },
+			403,
+		);
+		await assert.rejects(
+			() => clearActiveContext(),
+			(err) => err instanceof ApiError && err.code === "FORBIDDEN_LOCAL_API",
+		);
+	});
+
+	it("no active 返回 null；not registered / forbidden path 透出稳定 code 与 typed details", async () => {
+		stubFetch({ ok: true, data: { active: null } });
+		assert.equal(await getActiveContext(), null);
+
+		stubFetch(
+			{ ok: false, code: "KB_NOT_REGISTERED", message: "知识库未登记或已失效" },
+			404,
+		);
+		await assert.rejects(
+			() => selectKnowledgeBase("/kb/missing"),
+			(err) => err instanceof ApiError && err.code === "KB_NOT_REGISTERED",
+		);
+
+		stubFetch(
+			{
+				ok: false,
+				code: "FORBIDDEN_PATH",
+				message: "路径不在允许的知识库边界内",
+				details: { reason: "outside-root" },
+			},
+			403,
+		);
+		await assert.rejects(
+			() => inspectKnowledgeBasePath("/private"),
+			(err) =>
+				err instanceof ApiError &&
+				err.code === "FORBIDDEN_PATH" &&
+				(err.details as { reason?: string })?.reason === "outside-root",
+		);
+	});
+
+	it("拒绝旧 top-level items / active 响应", async () => {
+		stubFetch({ ok: true, items: [knowledgeBase] });
+		await assert.rejects(
+			() => listKnowledgeBases(),
+			(err) => err instanceof ContractMismatchError,
+		);
+
+		stubFetch({ ok: true, active });
+		await assert.rejects(
+			() => getActiveContext(),
+			(err) => err instanceof ContractMismatchError,
+		);
+	});
+});

--- a/workbench/web/test/visual/paper-ui.ts
+++ b/workbench/web/test/visual/paper-ui.ts
@@ -502,7 +502,7 @@ async function fulfillMockApi(route: Route, url: URL, method: string) {
 	if (pathname === "/api/knowledge-bases") {
 		await json({
 			ok: true,
-			items: [
+			data: [
 				{ path: visualKbPath, name: "AI 学习知识库", origin: "default", valid: true },
 				{ path: "/visual/design", name: "设计灵感库", origin: "external", valid: true },
 			],
@@ -510,7 +510,7 @@ async function fulfillMockApi(route: Route, url: URL, method: string) {
 		return;
 	}
 	if (pathname === "/api/knowledge-base") {
-		await json({ ok: true, active: visualActiveContext() });
+		await json({ ok: true, data: { active: visualActiveContext() } });
 		return;
 	}
 	if (pathname === "/api/conversations") {


### PR DESCRIPTION
## Summary

- migrate knowledge-base list, external registration/removal/inspection, and active-context routes to the shared JSON envelope
- add shared Zod contracts, injectable Hono route dependencies, and a frontend knowledge-base API module backed by `client.ts`
- define the shared context input rule: GET uses `kb`, JSON bodies use `kbPath`, explicit input falls back to active context, and every resolved path passes registered-KB validation
- preserve active context when a replacement fails and serialize active-context mutations to keep agent/session/extension state aligned

## Migrated endpoints

- `GET /api/knowledge-bases` — read-only
- `POST /api/knowledge-bases/external` — state-changing
- `POST /api/knowledge-bases/inspect` — read-only
- `DELETE /api/knowledge-bases/external` — state-changing
- `GET /api/knowledge-base` — read-only
- `POST /api/knowledge-base` — state-changing
- `DELETE /api/knowledge-base` — state-changing

## Active context contract

- success: `{ ok: true, data: { active: ActiveContext | null } }`
- no selection is a valid read state and returns `active: null`
- routes that require a KB use the shared resolver and return `NO_ACTIVE_KB` when neither explicit nor active context exists
- unregistered and forbidden paths return `KB_NOT_REGISTERED` / `FORBIDDEN_PATH` with Chinese messages and redacted typed details

## Follow-up reuse

- pages, graph, rebuild, conversations, and prompt remain legacy in this PR
- their later migrations should reuse `KnowledgeBaseContextBodySchema`, `KnowledgeBaseContextQuerySchema`, and `resolveKnowledgeBaseContext()` rather than interpreting path fields independently

## Verification

- `npm run typecheck`
- `npm run test -w @llm-wiki/workbench-contracts`
- `node --import tsx --test "workbench/server/src/**/*.test.ts"`
- `npm run test -w @llm-wiki-agent/web`
- `npm run lint -w @llm-wiki-agent/web`
- `git diff origin/main...HEAD --check`
- manual temporary-HOME run: list, empty active, valid selection, active reread, unregistered 404, clear active
- browser smoke: app loaded without page errors and selecting the temporary `demo` KB opened its conversation state

## Scope

- does not migrate pages, graph, prompt, rebuild, or conversation business routes
- does not change knowledge-base layout, Skill behavior, credentials, CHANGELOG, README, or version

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
