### PR TITLE
feat(workbench): migrate page and artifact routes (#169)

### DIFF
--- a/packages/workbench-contracts/src/artifacts.ts
+++ b/packages/workbench-contracts/src/artifacts.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+export const ArtifactKindSchema = z.enum(["html", "pdf", "docx", "pptx", "xlsx"]);
+export type ArtifactKind = z.infer<typeof ArtifactKindSchema>;
+
+export const ArtifactRendererSchema = z.enum(["iframe", "download-only"]);
+export type ArtifactRenderer = z.infer<typeof ArtifactRendererSchema>;
+
+export const ArtifactFileSchema = z.object({
+	name: z.string(),
+	sizeBytes: z.number().int().nonnegative(),
+	mimeType: z.string(),
+});
+export type ArtifactFile = z.infer<typeof ArtifactFileSchema>;
+
+export const ArtifactManifestSchema = z.object({
+	id: z.string().uuid(),
+	kind: ArtifactKindSchema,
+	renderer: ArtifactRendererSchema,
+	metadata: z.object({
+		title: z.string(),
+		createdAt: z.string(),
+		sourceConversationId: z.string(),
+		sourceKbPath: z.string(),
+		sourceSkill: z.string(),
+		sizeBytes: z.number().int().nonnegative(),
+	}),
+	files: z.array(ArtifactFileSchema),
+	primaryFile: z.string(),
+});
+export type ArtifactManifest = z.infer<typeof ArtifactManifestSchema>;
+
+export const ArtifactListQuerySchema = z.object({
+	conversation: z.string().trim().min(1).optional(),
+}).strict();
+export type ArtifactListQuery = z.infer<typeof ArtifactListQuerySchema>;
+
+export const ArtifactListDataSchema = z.array(ArtifactManifestSchema);
+export type ArtifactListData = z.infer<typeof ArtifactListDataSchema>;
+
+export const ArtifactManifestDataSchema = ArtifactManifestSchema;
+export type ArtifactManifestData = ArtifactManifest;

--- a/packages/workbench-contracts/src/endpoints.ts
+++ b/packages/workbench-contracts/src/endpoints.ts
@@ -232,14 +232,14 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "GET",
 		path: "/api/refs",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "页面引用候选",
 	},
 	{
 		method: "GET",
 		path: "/api/page",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "读 wiki 页面",
 	},
@@ -281,14 +281,14 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "GET",
 		path: "/api/artifacts",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "列出产物",
 	},
 	{
 		method: "GET",
 		path: "/api/artifacts/:id",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "产物 manifest",
 	},

--- a/packages/workbench-contracts/src/index.ts
+++ b/packages/workbench-contracts/src/index.ts
@@ -16,4 +16,6 @@ export * from "./health.js";
 export * from "./config.js";
 export * from "./auth.js";
 export * from "./knowledge-bases.js";
+export * from "./pages.js";
+export * from "./artifacts.js";
 export * from "./endpoints.js";

--- a/packages/workbench-contracts/src/pages.ts
+++ b/packages/workbench-contracts/src/pages.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const PageRefSchema = z.object({
+	path: z.string(),
+	name: z.string(),
+	category: z.string(),
+	title: z.string(),
+});
+export type PageRef = z.infer<typeof PageRefSchema>;
+
+const OptionalKnowledgeBaseQuerySchema = z.object({
+	kb: z.string().trim().min(1).optional(),
+});
+
+export const PageRefsQuerySchema = OptionalKnowledgeBaseQuerySchema.extend({
+	q: z.string().optional().default(""),
+	limit: z.coerce.number().int().min(1).max(5000).optional().default(20),
+}).strict();
+export type PageRefsQuery = z.infer<typeof PageRefsQuerySchema>;
+
+export const PageRefsDataSchema = z.array(PageRefSchema);
+export type PageRefsData = z.infer<typeof PageRefsDataSchema>;
+
+export const PageReadQuerySchema = OptionalKnowledgeBaseQuerySchema.extend({
+	path: z.string().trim().min(1),
+}).strict();
+export type PageReadQuery = z.infer<typeof PageReadQuerySchema>;
+
+export const PageReadDataSchema = z.object({
+	content: z.string(),
+});
+export type PageReadData = z.infer<typeof PageReadDataSchema>;

--- a/packages/workbench-contracts/test/pages-artifacts.test.ts
+++ b/packages/workbench-contracts/test/pages-artifacts.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	ArtifactListDataSchema,
+	ArtifactManifestDataSchema,
+	ArtifactManifestSchema,
+	PageReadDataSchema,
+	PageRefsDataSchema,
+	PageRefsQuerySchema,
+	findEndpoint,
+	isMigratedJsonPath,
+} from "../src/index.js";
+
+const manifest = {
+	id: "11111111-1111-4111-8111-111111111111",
+	kind: "html" as const,
+	renderer: "iframe" as const,
+	metadata: {
+		title: "研究报告",
+		createdAt: "2026-07-10T00:00:00.000Z",
+		sourceConversationId: "conversation-1",
+		sourceKbPath: "/kb/registered",
+		sourceSkill: "html",
+		sizeBytes: 12,
+	},
+	files: [{ name: "report.html", sizeBytes: 12, mimeType: "text/html; charset=utf-8" }],
+	primaryFile: "report.html",
+};
+
+test("页面读取与引用候选共享 schema 只接受统一 data 形状", () => {
+	assert.deepEqual(PageReadDataSchema.parse({ content: "# 页面" }), { content: "# 页面" });
+	assert.deepEqual(PageRefsDataSchema.parse([{ path: "wiki/topics/a.md", name: "a", category: "topics", title: "A" }])[0]?.title, "A");
+	assert.deepEqual(PageRefsQuerySchema.parse({ kb: "/kb/registered", q: "A", limit: "20" }), {
+		kb: "/kb/registered",
+		q: "A",
+		limit: 20,
+	});
+	assert.equal(PageRefsQuerySchema.safeParse({ limit: "not-a-number" }).success, false);
+});
+
+test("artifact list 与 manifest 共享同一个 manifest schema", () => {
+	assert.deepEqual(ArtifactManifestSchema.parse(manifest), manifest);
+	assert.deepEqual(ArtifactListDataSchema.parse([manifest]), [manifest]);
+	assert.deepEqual(ArtifactManifestDataSchema.parse(manifest), manifest);
+});
+
+test("#169 JSON endpoints 已迁移，文件下载保持 file-download 例外", () => {
+	for (const path of ["/api/refs", "/api/page", "/api/artifacts", "/api/artifacts/:id"] as const) {
+		assert.equal(findEndpoint("GET", path)?.kind, "migrated-json", path);
+		assert.equal(isMigratedJsonPath(path), true, path);
+	}
+	const download = findEndpoint("GET", "/api/artifacts/id/files/report.html");
+	assert.equal(download?.kind, "file-download");
+	assert.equal(isMigratedJsonPath("/api/artifacts/id/files/report.html"), false);
+});

--- a/workbench/server/src/app.ts
+++ b/workbench/server/src/app.ts
@@ -7,10 +7,12 @@ import type { MiddlewareHandler } from "hono";
 import { failure } from "@llm-wiki/workbench-contracts";
 
 import { HttpContractError } from "./http/request.js";
+import { createArtifactRoutes, defaultArtifactRouteService, type ArtifactRouteService } from "./routes/artifacts.js";
 import { createAuthRoutes, defaultAuthRouteService, type AuthRouteService } from "./routes/auth.js";
 import { createConfigRoutes, createModelRoutes, defaultConfigRouteService, type ConfigRouteService } from "./routes/config.js";
 import { createHealthRoutes } from "./routes/health.js";
 import { createKnowledgeBaseRoutes, defaultKnowledgeBaseRouteService, type KnowledgeBaseRouteService } from "./routes/knowledge-bases.js";
+import { createPageRoutes, defaultPageRouteService, type PageRouteService } from "./routes/pages.js";
 
 export type WorkbenchAppMode = "test" | "dev" | "desktop";
 
@@ -37,6 +39,10 @@ export interface WorkbenchAppDeps {
 	authService?: AuthRouteService;
 	/** 知识库 / active context route 依赖；route 测试必须注入 fake。 */
 	knowledgeBaseService?: KnowledgeBaseRouteService;
+	/** wiki 页面读取 / 引用候选 route 依赖。 */
+	pageService?: PageRouteService;
+	/** artifact manifest/list/file route 依赖。 */
+	artifactService?: ArtifactRouteService;
 }
 
 /**
@@ -83,6 +89,14 @@ export function createApp(deps: WorkbenchAppDeps = {}): Hono {
 		createKnowledgeBaseRoutes(
 			deps.knowledgeBaseService ?? defaultKnowledgeBaseRouteService,
 		),
+	);
+	app.route(
+		"/api",
+		createPageRoutes(deps.pageService ?? defaultPageRouteService),
+	);
+	app.route(
+		"/api",
+		createArtifactRoutes(deps.artifactService ?? defaultArtifactRouteService),
 	);
 
 	return app;

--- a/workbench/server/src/artifacts.ts
+++ b/workbench/server/src/artifacts.ts
@@ -4,30 +4,14 @@ import { mkdir, readdir, readFile, rename, stat, writeFile } from "node:fs/promi
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
+import type {
+	ArtifactKind,
+	ArtifactManifest,
+} from "@llm-wiki/workbench-contracts";
+
 import { APP_DIR } from "./config.js";
 
-export type ArtifactKind = "html" | "pdf" | "docx" | "pptx" | "xlsx";
-export type ArtifactRenderer = "iframe" | "download-only";
-
-export interface ArtifactManifest {
-	id: string;
-	kind: ArtifactKind;
-	renderer: ArtifactRenderer;
-	metadata: {
-		title: string;
-		createdAt: string;
-		sourceConversationId: string;
-		sourceKbPath: string;
-		sourceSkill: string;
-		sizeBytes: number;
-	};
-	files: Array<{
-		name: string;
-		sizeBytes: number;
-		mimeType: string;
-	}>;
-	primaryFile: string;
-}
+export type { ArtifactKind, ArtifactManifest } from "@llm-wiki/workbench-contracts";
 
 interface PendingArtifact {
 	id: string;

--- a/workbench/server/src/http/request.ts
+++ b/workbench/server/src/http/request.ts
@@ -35,16 +35,11 @@ export async function parseJsonBody(c: Context): Promise<unknown> {
 	}
 }
 
-/**
- * 解析并按 schema 校验 JSON body。校验失败抛 INVALID_REQUEST，details 只含
- * 字段级 issues（path + message），不含原始 body。
- */
-export async function parseValidatedBody<T>(
-	c: Context,
+export function parseValidatedInput<T>(
 	schema: ZodType<T>,
-): Promise<T> {
-	const raw = await parseJsonBody(c);
-	const result = schema.safeParse(raw);
+	input: unknown,
+): T {
+	const result = schema.safeParse(input);
 	if (!result.success) {
 		throw new HttpContractError("INVALID_REQUEST", "请求字段不符合 schema", {
 			issues: result.error.issues.map((issue) => ({
@@ -54,4 +49,15 @@ export async function parseValidatedBody<T>(
 		});
 	}
 	return result.data;
+}
+
+/**
+ * 解析并按 schema 校验 JSON body。校验失败抛 INVALID_REQUEST，details 只含
+ * 字段级 issues（path + message），不含原始 body。
+ */
+export async function parseValidatedBody<T>(
+	c: Context,
+	schema: ZodType<T>,
+): Promise<T> {
+	return parseValidatedInput(schema, await parseJsonBody(c));
 }

--- a/workbench/server/src/index.ts
+++ b/workbench/server/src/index.ts
@@ -22,7 +22,6 @@
 import { serve } from "@hono/node-server";
 import { streamSSE } from "hono/streaming";
 import { execFile } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
@@ -30,10 +29,6 @@ import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { createApp } from "./app.js";
 import {
 	artifactEvents,
-	getArtifact,
-	isValidArtifactId,
-	listArtifacts,
-	resolveArtifactFile,
 	type ArtifactCreatedEvent,
 } from "./artifacts.js";
 import {
@@ -65,7 +60,6 @@ import {
 import {
 	assertRegisteredKnowledgeBase,
 } from "./knowledge-bases.js";
-import { listPageRefs, readWikiPage } from "./pages.js";
 import { localHostOnly } from "./security/host.js";
 import { createSecurityMiddleware } from "./security/middleware.js";
 import {
@@ -312,42 +306,6 @@ app.put("/api/graph/layout", async (c) => {
 	}
 });
 
-// ============= Wiki 页面引用候选 =============
-
-app.get("/api/refs", async (c) => {
-	const kbPath = c.req.query("kb");
-	if (!kbPath) return c.json({ ok: false, error: "Missing query param 'kb'" }, 400);
-	const q = c.req.query("q") ?? "";
-	const rawLimit = Number(c.req.query("limit") ?? 20);
-	const limit = Number.isFinite(rawLimit) ? rawLimit : 20;
-	try {
-		const items = await listPageRefs(kbPath, q, limit);
-		return c.json({ ok: true, items });
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			400,
-		);
-	}
-});
-
-app.get("/api/page", async (c) => {
-	const kbPath = c.req.query("kb");
-	const relPath = c.req.query("path");
-	if (!kbPath || !relPath) {
-		return c.json({ ok: false, error: "Missing query params 'kb' or 'path'" }, 400);
-	}
-	try {
-		const content = await readWikiPage(kbPath, relPath);
-		return c.json({ ok: true, content });
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			400,
-		);
-	}
-});
-
 // ============= Slash 命令列表 =============
 
 app.get("/api/commands", async (c) => {
@@ -482,46 +440,6 @@ app.post("/api/knowledge-bases/batch-digest", async (c) => {
 			resumeGraphWatcher(body.kbPath as string, { trigger: completed });
 		}
 	});
-});
-
-// ============= 产物 Artifacts =============
-
-app.get("/api/artifacts", (c) => {
-	const conversationId = c.req.query("conversation");
-	return c.json({ ok: true, items: listArtifacts(conversationId) });
-});
-
-app.get("/api/artifacts/:id", (c) => {
-	const id = c.req.param("id");
-	if (!isValidArtifactId(id)) {
-		return c.json({ ok: false, error: "Invalid artifact id" }, 400);
-	}
-	const manifest = getArtifact(id);
-	if (!manifest) return c.json({ ok: false, error: "Artifact not found" }, 404);
-	return c.json({ ok: true, manifest });
-});
-
-app.get("/api/artifacts/:id/files/:filename", async (c) => {
-	const id = c.req.param("id");
-	const filename = c.req.param("filename");
-	if (!isValidArtifactId(id)) {
-		return c.json({ ok: false, error: "Invalid artifact id" }, 400);
-	}
-	try {
-		const file = resolveArtifactFile(id, filename);
-		const body = await readFile(file.path);
-		return new Response(body, {
-			headers: {
-				"Content-Type": file.mimeType,
-				"Content-Length": String(file.sizeBytes),
-				"Content-Disposition": `attachment; filename="${encodeURIComponent(filename)}"`,
-			},
-		});
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		const status = message.includes("不存在") || message.includes("不在 manifest") ? 404 : 400;
-		return c.json({ ok: false, error: message }, status);
-	}
 });
 
 // ============= 模型认证 =============

--- a/workbench/server/src/pages-artifacts-routes.test.ts
+++ b/workbench/server/src/pages-artifacts-routes.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ArtifactManifest, PageRef } from "@llm-wiki/workbench-contracts";
+
+import { createApp } from "./app.js";
+import type { ArtifactRouteService } from "./routes/artifacts.js";
+import type { PageRouteService } from "./routes/pages.js";
+
+const kbPath = "/fake/registered";
+const artifactId = "11111111-1111-4111-8111-111111111111";
+const refs: PageRef[] = [
+	{ path: "wiki/topics/a.md", name: "a", category: "topics", title: "A" },
+];
+const manifest: ArtifactManifest = {
+	id: artifactId,
+	kind: "html",
+	renderer: "iframe",
+	metadata: {
+		title: "研究报告",
+		createdAt: "2026-07-10T00:00:00.000Z",
+		sourceConversationId: "conversation-1",
+		sourceKbPath: kbPath,
+		sourceSkill: "html",
+		sizeBytes: 12,
+	},
+	files: [{ name: "report.html", sizeBytes: 12, mimeType: "text/html; charset=utf-8" }],
+	primaryFile: "report.html",
+};
+
+function createPageService(overrides: Partial<PageRouteService> = {}): PageRouteService {
+	return {
+		getActiveKnowledgeBasePath: () => kbPath,
+		assertRegisteredKnowledgeBase: async (requested) => {
+			if (requested === "/fake/private") {
+				throw Object.assign(new Error("/Users/private/secret"), {
+					code: "FORBIDDEN_PATH",
+					details: { reason: "outside-root" },
+				});
+			}
+			if (requested !== kbPath) {
+				throw Object.assign(new Error("missing"), { code: "KB_NOT_REGISTERED" });
+			}
+			return requested;
+		},
+		listPageRefs: async () => refs,
+		readWikiPage: async (_kb, path) => {
+			if (path === "wiki/topics/missing.md") {
+				throw Object.assign(new Error("ENOENT /Users/private/kb/wiki/topics/missing.md"), {
+					code: "ENOENT",
+				});
+			}
+			if (path.includes("..")) throw new Error("path must be inside wiki /Users/private");
+			return "# 页面";
+		},
+		...overrides,
+	};
+}
+
+function createArtifactService(overrides: Partial<ArtifactRouteService> = {}): ArtifactRouteService {
+	return {
+		listArtifacts: () => [manifest],
+		getArtifact: (id) => (id === artifactId ? manifest : null),
+		readArtifactFile: async (id, filename) => {
+			if (id !== artifactId || filename !== "report.html") return null;
+			return {
+				body: new TextEncoder().encode("<h1>报告</h1>"),
+				mimeType: "text/html; charset=utf-8",
+				sizeBytes: 15,
+			};
+		},
+		...overrides,
+	};
+}
+
+async function json(res: Response): Promise<Record<string, unknown>> {
+	return (await res.json()) as Record<string, unknown>;
+}
+
+test("页面读取与引用候选通过 active context 返回统一 success envelope", async () => {
+	const pageService = createPageService();
+	const app = createApp({ pageService, artifactService: createArtifactService() });
+
+	const page = await app.request("/api/page?path=wiki%2Ftopics%2Fa.md");
+	assert.equal(page.status, 200);
+	assert.deepEqual(await json(page), { ok: true, data: { content: "# 页面" } });
+
+	const reference = await app.request("/api/refs?q=A&limit=20");
+	assert.equal(reference.status, 200);
+	assert.deepEqual(await json(reference), { ok: true, data: refs });
+});
+
+test("页面 route 返回稳定 not found、forbidden path 与 invalid request", async () => {
+	const app = createApp({ pageService: createPageService(), artifactService: createArtifactService() });
+
+	const missing = await app.request("/api/page?path=wiki%2Ftopics%2Fmissing.md");
+	assert.equal(missing.status, 404);
+	assert.deepEqual(await json(missing), {
+		ok: false,
+		code: "NOT_FOUND",
+		message: "wiki 页面不存在",
+	});
+
+	const forbidden = await app.request("/api/page?kb=%2Ffake%2Fprivate&path=wiki%2Ftopics%2Fa.md");
+	assert.equal(forbidden.status, 403);
+	const forbiddenPayload = await json(forbidden);
+	assert.deepEqual(forbiddenPayload, {
+		ok: false,
+		code: "FORBIDDEN_PATH",
+		message: "路径不在允许的知识库边界内",
+		details: { reason: "outside-root" },
+	});
+	assert.equal(JSON.stringify(forbiddenPayload).includes("/Users/"), false);
+
+	const invalid = await app.request("/api/page?path=");
+	assert.equal(invalid.status, 400);
+	assert.equal((await json(invalid)).code, "INVALID_REQUEST");
+
+	const invalidLimit = await app.request("/api/refs?limit=bad");
+	assert.equal(invalidLimit.status, 400);
+	assert.equal((await json(invalidLimit)).code, "INVALID_REQUEST");
+});
+
+test("页面 route 复用 active context 的 no active 与 registered KB 错误语义", async () => {
+	let app = createApp({
+		pageService: createPageService({ getActiveKnowledgeBasePath: () => null }),
+		artifactService: createArtifactService(),
+	});
+	let res = await app.request("/api/page?path=wiki%2Ftopics%2Fa.md");
+	assert.equal(res.status, 400);
+	assert.equal((await json(res)).code, "NO_ACTIVE_KB");
+
+	app = createApp({ pageService: createPageService(), artifactService: createArtifactService() });
+	res = await app.request("/api/refs?kb=%2Ffake%2Funregistered");
+	assert.equal(res.status, 404);
+	assert.equal((await json(res)).code, "KB_NOT_REGISTERED");
+});
+
+test("artifact list 与 manifest 返回统一 success/failure envelope", async () => {
+	const app = createApp({ pageService: createPageService(), artifactService: createArtifactService() });
+	const list = await app.request("/api/artifacts?conversation=conversation-1");
+	assert.deepEqual(await json(list), { ok: true, data: [manifest] });
+
+	const found = await app.request(`/api/artifacts/${artifactId}`);
+	assert.deepEqual(await json(found), { ok: true, data: manifest });
+
+	const invalid = await app.request("/api/artifacts/not-an-id");
+	assert.equal(invalid.status, 400);
+	assert.equal((await json(invalid)).code, "INVALID_REQUEST");
+
+	const missingId = "22222222-2222-4222-8222-222222222222";
+	const missing = await app.request(`/api/artifacts/${missingId}`);
+	assert.equal(missing.status, 404);
+	assert.deepEqual(await json(missing), {
+		ok: false,
+		code: "NOT_FOUND",
+		message: "产物不存在",
+	});
+});
+
+test("manifest 中的产物文件已从磁盘消失时返回统一 NOT_FOUND envelope", async () => {
+	const artifactService = createArtifactService({
+		readArtifactFile: async () => {
+			throw Object.assign(
+				new Error("ENOENT /Users/private/artifacts/report.html"),
+				{ code: "ENOENT" },
+			);
+		},
+	});
+	const app = createApp({ pageService: createPageService(), artifactService });
+	const res = await app.request(`/api/artifacts/${artifactId}/files/report.html`);
+	assert.equal(res.status, 404);
+	const payload = await json(res);
+	assert.deepEqual(payload, {
+		ok: false,
+		code: "NOT_FOUND",
+		message: "产物文件不存在",
+	});
+	assert.equal(JSON.stringify(payload).includes("/Users/"), false);
+});
+
+test("文件下载成功返回文件 Response，失败返回统一 error envelope", async () => {
+	const app = createApp({ pageService: createPageService(), artifactService: createArtifactService() });
+	const success = await app.request(`/api/artifacts/${artifactId}/files/report.html`);
+	assert.equal(success.status, 200);
+	assert.equal(success.headers.get("content-type"), "text/html; charset=utf-8");
+	assert.equal(success.headers.get("content-disposition"), 'attachment; filename="report.html"');
+	assert.equal(await success.text(), "<h1>报告</h1>");
+
+	const missing = await app.request(`/api/artifacts/${artifactId}/files/missing.html`);
+	assert.equal(missing.status, 404);
+	assert.deepEqual(await json(missing), {
+		ok: false,
+		code: "NOT_FOUND",
+		message: "产物文件不存在",
+	});
+
+	const invalid = await app.request("/api/artifacts/not-an-id/files/report.html");
+	assert.equal(invalid.status, 400);
+	assert.equal((await json(invalid)).code, "INVALID_REQUEST");
+});

--- a/workbench/server/src/pages.ts
+++ b/workbench/server/src/pages.ts
@@ -1,14 +1,11 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 
+import type { PageRef } from "@llm-wiki/workbench-contracts";
+
 import { assertRegisteredKnowledgeBase } from "./knowledge-bases.js";
 
-export interface PageRef {
-	path: string;
-	name: string;
-	category: string;
-	title: string;
-}
+export type { PageRef } from "@llm-wiki/workbench-contracts";
 
 const PAGE_DIRS = ["entities", "topics", "sources", "comparisons", "synthesis"];
 const IGNORE_NAMES = new Set([".obsidian", ".DS_Store", ".wiki-tmp", ".git", "node_modules"]);

--- a/workbench/server/src/routes/artifacts.ts
+++ b/workbench/server/src/routes/artifacts.ts
@@ -1,0 +1,115 @@
+import { readFile } from "node:fs/promises";
+
+import { Hono } from "hono";
+import { z } from "zod";
+
+import {
+	ArtifactListDataSchema,
+	ArtifactListQuerySchema,
+	ArtifactManifestDataSchema,
+	type ArtifactManifest,
+} from "@llm-wiki/workbench-contracts";
+
+import {
+	getArtifact,
+	listArtifacts,
+	resolveArtifactFile,
+} from "../artifacts.js";
+import { HttpContractError, parseValidatedInput } from "../http/request.js";
+import { jsonOk } from "../http/response.js";
+
+export interface ArtifactFileData {
+	body: Uint8Array;
+	mimeType: string;
+	sizeBytes: number;
+}
+
+export interface ArtifactRouteService {
+	listArtifacts: (conversationId?: string) => ArtifactManifest[];
+	getArtifact: (id: string) => ArtifactManifest | null;
+	readArtifactFile: (
+		id: string,
+		filename: string,
+	) => Promise<ArtifactFileData | null>;
+}
+
+export const defaultArtifactRouteService: ArtifactRouteService = {
+	listArtifacts,
+	getArtifact,
+	readArtifactFile: async (id, filename) => {
+		const manifest = getArtifact(id);
+		if (!manifest || !manifest.files.some((file) => file.name === filename)) {
+			return null;
+		}
+		const file = resolveArtifactFile(id, filename);
+		return {
+			body: await readFile(file.path),
+			mimeType: file.mimeType,
+			sizeBytes: file.sizeBytes,
+		};
+	},
+};
+
+const ArtifactIdSchema = z.string().uuid();
+const ArtifactFilenameSchema = z
+	.string()
+	.min(1)
+	.refine(
+		(filename) =>
+			!filename.includes("/") &&
+			!filename.includes("\\") &&
+			!filename.includes(".."),
+		{ message: "文件名不安全" },
+	);
+
+export function createArtifactRoutes(service: ArtifactRouteService): Hono {
+	const router = new Hono();
+
+	router.get("/artifacts", (c) => {
+		const query = parseValidatedInput(ArtifactListQuerySchema, {
+			conversation: c.req.query("conversation"),
+		});
+		return jsonOk(
+			c,
+			ArtifactListDataSchema.parse(service.listArtifacts(query.conversation)),
+		);
+	});
+
+	router.get("/artifacts/:id", (c) => {
+		const id = parseValidatedInput(ArtifactIdSchema, c.req.param("id"));
+		const manifest = service.getArtifact(id);
+		if (!manifest) {
+			throw new HttpContractError("NOT_FOUND", "产物不存在");
+		}
+		return jsonOk(c, ArtifactManifestDataSchema.parse(manifest));
+	});
+
+	router.get("/artifacts/:id/files/:filename", async (c) => {
+		const id = parseValidatedInput(ArtifactIdSchema, c.req.param("id"));
+		const filename = parseValidatedInput(
+			ArtifactFilenameSchema,
+			c.req.param("filename"),
+		);
+		let file: ArtifactFileData | null;
+		try {
+			file = await service.readArtifactFile(id, filename);
+		} catch (err) {
+			if ((err as { code?: unknown }).code === "ENOENT") {
+				throw new HttpContractError("NOT_FOUND", "产物文件不存在");
+			}
+			throw err;
+		}
+		if (!file) {
+			throw new HttpContractError("NOT_FOUND", "产物文件不存在");
+		}
+		return new Response(file.body, {
+			headers: {
+				"Content-Type": file.mimeType,
+				"Content-Length": String(file.sizeBytes),
+				"Content-Disposition": `attachment; filename="${encodeURIComponent(filename)}"`,
+			},
+		});
+	});
+
+	return router;
+}

--- a/workbench/server/src/routes/pages.ts
+++ b/workbench/server/src/routes/pages.ts
@@ -1,0 +1,114 @@
+import { Hono } from "hono";
+
+import {
+	PageReadDataSchema,
+	PageReadQuerySchema,
+	PageRefsDataSchema,
+	PageRefsQuerySchema,
+	type PageRef,
+} from "@llm-wiki/workbench-contracts";
+
+import { getActive } from "../agent.js";
+import {
+	mapKnowledgeBaseError,
+	resolveKnowledgeBaseContext,
+} from "../http/knowledge-base-context.js";
+import {
+	HttpContractError,
+	parseValidatedInput,
+} from "../http/request.js";
+import { jsonOk } from "../http/response.js";
+import { assertRegisteredKnowledgeBase } from "../knowledge-bases.js";
+import { listPageRefs, readWikiPage } from "../pages.js";
+
+export interface PageRouteService {
+	getActiveKnowledgeBasePath: () => string | null;
+	assertRegisteredKnowledgeBase: (kbPath: string) => Promise<string>;
+	listPageRefs: (kbPath: string, query: string, limit: number) => Promise<PageRef[]>;
+	readWikiPage: (kbPath: string, relPath: string) => Promise<string>;
+}
+
+export const defaultPageRouteService: PageRouteService = {
+	getActiveKnowledgeBasePath: () => getActive()?.kb.path ?? null,
+	assertRegisteredKnowledgeBase,
+	listPageRefs,
+	readWikiPage,
+};
+
+export function createPageRoutes(service: PageRouteService): Hono {
+	const router = new Hono();
+
+	router.get("/refs", async (c) => {
+		const query = parseValidatedInput(PageRefsQuerySchema, {
+			kb: c.req.query("kb"),
+			q: c.req.query("q"),
+			limit: c.req.query("limit"),
+		});
+		const kbPath = await resolvePageKnowledgeBase(query.kb, service);
+		try {
+			return jsonOk(
+				c,
+				PageRefsDataSchema.parse(
+					await service.listPageRefs(kbPath, query.q, query.limit),
+				),
+			);
+		} catch (err) {
+			throw mapPageError(err);
+		}
+	});
+
+	router.get("/page", async (c) => {
+		const query = parseValidatedInput(PageReadQuerySchema, {
+			kb: c.req.query("kb"),
+			path: c.req.query("path"),
+		});
+		const kbPath = await resolvePageKnowledgeBase(query.kb, service);
+		try {
+			return jsonOk(
+				c,
+				PageReadDataSchema.parse({
+					content: await service.readWikiPage(kbPath, query.path),
+				}),
+			);
+		} catch (err) {
+			throw mapPageError(err);
+		}
+	});
+
+	return router;
+}
+
+async function resolvePageKnowledgeBase(
+	queryKb: string | undefined,
+	service: PageRouteService,
+): Promise<string> {
+	return resolveKnowledgeBaseContext(
+		{ queryKb },
+		{
+			getActiveKnowledgeBasePath: service.getActiveKnowledgeBasePath,
+			assertRegisteredKnowledgeBase: service.assertRegisteredKnowledgeBase,
+		},
+	);
+}
+
+function mapPageError(err: unknown): HttpContractError {
+	if (err instanceof HttpContractError) return err;
+	const source = err as { code?: unknown; statusCode?: unknown };
+	if (source.code === "ENOENT") {
+		return new HttpContractError("NOT_FOUND", "wiki 页面不存在");
+	}
+	if (source.code === "FORBIDDEN_PATH" || source.statusCode === 403) {
+		return mapKnowledgeBaseError(err);
+	}
+	if (
+		err instanceof Error &&
+		(err.message.includes("inside wiki") ||
+			err.message.includes("must be relative") ||
+			err.message.includes("markdown file"))
+	) {
+		return new HttpContractError("FORBIDDEN_PATH", "路径不在允许的知识库边界内", {
+			reason: "outside-root",
+		});
+	}
+	return new HttpContractError("INTERNAL_ERROR", "服务器内部错误");
+}

--- a/workbench/server/src/security/middleware.test.ts
+++ b/workbench/server/src/security/middleware.test.ts
@@ -42,9 +42,17 @@ function buildApp(
 		authService: {
 			getAuthStatus: async () => ({ authFileExists: false, providers: [], envKeys: [] }),
 		},
+		artifactService: {
+			listArtifacts: () => [],
+			getArtifact: () => null,
+			readArtifactFile: async () => ({
+				body: new TextEncoder().encode("report"),
+				mimeType: "text/markdown; charset=utf-8",
+				sizeBytes: 6,
+			}),
+		},
 	});
 	app.post("/api/echo", (c) => c.json({ ok: true }));
-	app.get("/api/artifacts/:id/files/:filename", (c) => c.json({ ok: true }));
 	app.post("/api/knowledge-bases/new", (c) => c.json({ ok: true }));
 	app.post("/api/prompt", (c) => c.json({ ok: true }));
 	return app;
@@ -81,7 +89,9 @@ test("POST 不等于需要 token：read-only 的 POST /api/echo 无 token 放行
 
 test("文件下载 GET 无 token / 来源即放行", async () => {
 	const app = buildApp();
-	const res = await app.request("/api/artifacts/abc/files/report.md");
+	const res = await app.request(
+		"/api/artifacts/11111111-1111-4111-8111-111111111111/files/report.md",
+	);
 	assert.equal(res.status, 200);
 });
 

--- a/workbench/web/src/lib/api.ts
+++ b/workbench/web/src/lib/api.ts
@@ -17,22 +17,35 @@ import {
 	unregisterExternalKnowledgeBase as unregisterExternalKnowledgeBaseMigrated,
 } from "./api/knowledge-bases";
 import {
+	getArtifactFileUrl as getArtifactFileUrlMigrated,
+	getArtifactManifest as getArtifactManifestMigrated,
+	listArtifacts as listArtifactsMigrated,
+} from "./api/artifacts";
+import {
+	listRefs as listRefsMigrated,
+	readPage as readPageMigrated,
+} from "./api/pages";
+import {
 	type ActiveContext,
 	type AppConfig,
+	type ArtifactManifest,
 	type AuthStatusData,
 	type AvailableModelInfo,
 	type InspectKnowledgeBasePathData,
 	type KnowledgeBaseInfo,
 	type ModelRef,
+	type PageRef,
 } from "@llm-wiki/workbench-contracts";
 import type { GraphData, GraphDiff, GraphLayoutFile, PinMap } from "@llm-wiki/graph-engine";
 
 export type {
 	ActiveContext,
 	AppConfig,
+	ArtifactManifest,
 	AvailableModelInfo,
 	KnowledgeBaseInfo,
 	ModelRef,
+	PageRef,
 	UIMessage,
 } from "@llm-wiki/workbench-contracts";
 
@@ -53,33 +66,6 @@ export interface CommandItem {
 	description: string;
 	source: "builtin" | "pi-default" | "user-global";
 	skillPath: string | null;
-}
-
-export interface PageRef {
-	path: string;
-	name: string;
-	category: string;
-	title: string;
-}
-
-export interface ArtifactManifest {
-	id: string;
-	kind: "html" | "pdf" | "docx" | "pptx" | "xlsx";
-	renderer: "iframe" | "download-only";
-	metadata: {
-		title: string;
-		createdAt: string;
-		sourceConversationId: string;
-		sourceKbPath: string;
-		sourceSkill: string;
-		sizeBytes: number;
-	};
-	files: Array<{
-		name: string;
-		sizeBytes: number;
-		mimeType: string;
-	}>;
-	primaryFile: string;
 }
 
 export type ExportKind = "pdf" | "docx" | "pptx" | "xlsx" | "html";
@@ -404,20 +390,12 @@ export async function streamBatchDigest(
 	return parseSSE(res.body);
 }
 
-export async function listRefs(kbPath: string, query: string, limit = 20): Promise<PageRef[]> {
-	const url = `/api/refs?kb=${encodeURIComponent(kbPath)}&q=${encodeURIComponent(query)}&limit=${limit}`;
-	const res = await fetch(url);
-	const json = (await res.json()) as { ok: boolean; items?: PageRef[]; error?: string };
-	if (!res.ok || !json.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return json.items ?? [];
+export function listRefs(kbPath: string, query: string, limit = 20): Promise<PageRef[]> {
+	return listRefsMigrated(kbPath, query, limit);
 }
 
-export async function readPage(kbPath: string, relPath: string): Promise<string> {
-	const url = `/api/page?kb=${encodeURIComponent(kbPath)}&path=${encodeURIComponent(relPath)}`;
-	const res = await fetch(url);
-	const json = (await res.json()) as { ok: boolean; content?: string; error?: string };
-	if (!res.ok || !json.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return json.content ?? "";
+export function readPage(kbPath: string, relPath: string): Promise<string> {
+	return readPageMigrated(kbPath, relPath);
 }
 
 function kbQuery(kbPath: string): string {
@@ -456,23 +434,16 @@ export async function putGraphLayout(kbPath: string, pins: PinMap): Promise<Grap
 	return json;
 }
 
-export async function listArtifacts(conversationId?: string): Promise<ArtifactManifest[]> {
-	const suffix = conversationId ? `?conversation=${encodeURIComponent(conversationId)}` : "";
-	const res = await fetch(`/api/artifacts${suffix}`);
-	const json = (await res.json()) as { ok: boolean; items?: ArtifactManifest[]; error?: string };
-	if (!res.ok || !json.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return json.items ?? [];
+export function listArtifacts(conversationId?: string): Promise<ArtifactManifest[]> {
+	return listArtifactsMigrated(conversationId);
 }
 
-export async function getArtifactManifest(id: string): Promise<ArtifactManifest> {
-	const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}`);
-	const json = (await res.json()) as { ok: boolean; manifest?: ArtifactManifest; error?: string };
-	if (!res.ok || !json.ok || !json.manifest) throw new Error(json.error ?? `HTTP ${res.status}`);
-	return json.manifest;
+export function getArtifactManifest(id: string): Promise<ArtifactManifest> {
+	return getArtifactManifestMigrated(id);
 }
 
 export function getArtifactFileUrl(id: string, filename: string): string {
-	return `/api/artifacts/${encodeURIComponent(id)}/files/${encodeURIComponent(filename)}`;
+	return getArtifactFileUrlMigrated(id, filename);
 }
 
 const EXPORT_LABELS: Record<ExportKind, { skillName: string; kindLabel: string; ext: string }> = {

--- a/workbench/web/src/lib/api/artifacts.ts
+++ b/workbench/web/src/lib/api/artifacts.ts
@@ -1,0 +1,28 @@
+import {
+	ArtifactListDataSchema,
+	ArtifactManifestDataSchema,
+	type ArtifactManifest,
+} from "@llm-wiki/workbench-contracts";
+
+import { request } from "./client";
+
+export function listArtifacts(
+	conversationId?: string,
+): Promise<ArtifactManifest[]> {
+	return request("/api/artifacts", {
+		responseSchema: ArtifactListDataSchema,
+		query: { conversation: conversationId },
+	});
+}
+
+export function getArtifactManifest(id: string): Promise<ArtifactManifest> {
+	return request("/api/artifacts/:id", {
+		responseSchema: ArtifactManifestDataSchema,
+		pathParams: { id },
+	});
+}
+
+/** file-download endpoint：成功响应是文件，不进入普通 JSON client。 */
+export function getArtifactFileUrl(id: string, filename: string): string {
+	return `/api/artifacts/${encodeURIComponent(id)}/files/${encodeURIComponent(filename)}`;
+}

--- a/workbench/web/src/lib/api/client.ts
+++ b/workbench/web/src/lib/api/client.ts
@@ -47,6 +47,10 @@ export interface RequestOptions<T> {
 	responseSchema: z.ZodType<T>;
 	method?: HttpMethod;
 	body?: unknown;
+	/** query 参数由 client 编码，避免领域 module 绕过 registry path。 */
+	query?: Record<string, string | number | undefined>;
+	/** 替换 registry path 中的动态段（如 `:id`），不能改变 endpoint 结构。 */
+	pathParams?: Record<string, string>;
 	signal?: AbortSignal;
 }
 
@@ -75,7 +79,8 @@ export async function request<T>(
 		init.signal = options.signal;
 	}
 
-	const res = await fetch(path, init);
+	const fetchPath = buildFetchPath(path, options.pathParams, options.query);
+	const res = await fetch(fetchPath, init);
 	const json: unknown = await res.json();
 
 	const failureParse = FailureEnvelopeSchema.safeParse(json);
@@ -90,4 +95,25 @@ export async function request<T>(
 		throw new ContractMismatchError(path, res.status);
 	}
 	return successParse.data.data;
+}
+
+function buildFetchPath(
+	path: MigratedJsonPath,
+	pathParams: Record<string, string> | undefined,
+	query: Record<string, string | number | undefined> | undefined,
+): string {
+	const resolvedPath = path.replace(/:([A-Za-z0-9_]+)/g, (_match, key: string) => {
+		const value = pathParams?.[key];
+		if (value === undefined) {
+			throw new Error(`缺少 endpoint path 参数：${key}`);
+		}
+		return encodeURIComponent(value);
+	});
+	if (!query) return resolvedPath;
+	const search = new URLSearchParams();
+	for (const [key, value] of Object.entries(query)) {
+		if (value !== undefined) search.set(key, String(value));
+	}
+	const suffix = search.toString();
+	return suffix ? `${resolvedPath}?${suffix}` : resolvedPath;
 }

--- a/workbench/web/src/lib/api/pages.ts
+++ b/workbench/web/src/lib/api/pages.ts
@@ -1,0 +1,29 @@
+import {
+	PageReadDataSchema,
+	PageRefsDataSchema,
+	type PageRef,
+} from "@llm-wiki/workbench-contracts";
+
+import { request } from "./client";
+
+export async function listRefs(
+	kbPath: string,
+	query: string,
+	limit = 20,
+): Promise<PageRef[]> {
+	return request("/api/refs", {
+		responseSchema: PageRefsDataSchema,
+		query: { kb: kbPath, q: query, limit },
+	});
+}
+
+export async function readPage(
+	kbPath: string,
+	relPath: string,
+): Promise<string> {
+	const data = await request("/api/page", {
+		responseSchema: PageReadDataSchema,
+		query: { kb: kbPath, path: relPath },
+	});
+	return data.content;
+}

--- a/workbench/web/test/pages-artifacts-api.test.ts
+++ b/workbench/web/test/pages-artifacts-api.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import type { MigratedJsonPath } from "@llm-wiki/workbench-contracts";
+
+import { ApiError, ContractMismatchError } from "../src/lib/api/client";
+import { getArtifactFileUrl, getArtifactManifest, listArtifacts } from "../src/lib/api/artifacts";
+import { listRefs, readPage } from "../src/lib/api/pages";
+
+const artifactId = "11111111-1111-4111-8111-111111111111";
+const manifest = {
+	id: artifactId,
+	kind: "html" as const,
+	renderer: "iframe" as const,
+	metadata: {
+		title: "研究报告",
+		createdAt: "2026-07-10T00:00:00.000Z",
+		sourceConversationId: "conversation-1",
+		sourceKbPath: "/kb/registered",
+		sourceSkill: "html",
+		sizeBytes: 12,
+	},
+	files: [{ name: "report.html", sizeBytes: 12, mimeType: "text/html; charset=utf-8" }],
+	primaryFile: "report.html",
+};
+
+function stubFetch(body: unknown, status = 200) {
+	const calls: Array<{ url: string; init?: RequestInit }> = [];
+	globalThis.fetch = ((input: URL | string, init?: RequestInit) => {
+		calls.push({ url: String(input), init });
+		return Promise.resolve(
+			new Response(JSON.stringify(body), {
+				status,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	}) as typeof globalThis.fetch;
+	return calls;
+}
+
+describe("pages / artifacts API module", () => {
+	const originalFetch = globalThis.fetch;
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("页面读取与引用列表通过 migrated JSON client 解析 data", async () => {
+		let calls = stubFetch({ ok: true, data: { content: "# 页面" } });
+		assert.equal(await readPage("/kb/registered", "wiki/topics/a.md"), "# 页面");
+		assert.equal(calls[0]?.url, "/api/page?kb=%2Fkb%2Fregistered&path=wiki%2Ftopics%2Fa.md");
+
+		calls = stubFetch({
+			ok: true,
+			data: [{ path: "wiki/topics/a.md", name: "a", category: "topics", title: "A" }],
+		});
+		assert.equal((await listRefs("/kb/registered", "A", 20))[0]?.title, "A");
+		assert.equal(calls[0]?.url, "/api/refs?kb=%2Fkb%2Fregistered&q=A&limit=20");
+	});
+
+	it("artifact list 与 manifest 通过 migrated JSON client 解析 data", async () => {
+		let calls = stubFetch({ ok: true, data: [manifest] });
+		assert.deepEqual(await listArtifacts("conversation-1"), [manifest]);
+		assert.equal(calls[0]?.url, "/api/artifacts?conversation=conversation-1");
+
+		calls = stubFetch({ ok: true, data: manifest });
+		assert.deepEqual(await getArtifactManifest(artifactId), manifest);
+		assert.equal(calls[0]?.url, `/api/artifacts/${artifactId}`);
+	});
+
+	it("统一错误透出 code，旧 top-level shape 被拒绝", async () => {
+		stubFetch({ ok: false, code: "NOT_FOUND", message: "wiki 页面不存在" }, 404);
+		await assert.rejects(
+			() => readPage("/kb/registered", "wiki/topics/missing.md"),
+			(err) => err instanceof ApiError && err.code === "NOT_FOUND",
+		);
+
+		stubFetch({ ok: true, items: [manifest] });
+		await assert.rejects(
+			() => listArtifacts(),
+			(err) => err instanceof ContractMismatchError,
+		);
+	});
+
+	it("文件下载只构造 URL，不调用普通 JSON client", () => {
+		let called = false;
+		globalThis.fetch = (() => {
+			called = true;
+			throw new Error("不应调用 fetch");
+		}) as typeof globalThis.fetch;
+		assert.equal(
+			getArtifactFileUrl(artifactId, "报告 final.html"),
+			`/api/artifacts/${artifactId}/files/%E6%8A%A5%E5%91%8A%20final.html`,
+		);
+		assert.equal(called, false);
+	});
+
+	it("普通 JSON client 的 path 类型不包含 file-download endpoint", () => {
+		// @ts-expect-error file-download path 不属于 MigratedJsonPath
+		const downloadPath: MigratedJsonPath = "/api/artifacts/:id/files/:filename";
+		assert.equal(downloadPath, "/api/artifacts/:id/files/:filename");
+	});
+});


### PR DESCRIPTION
## Summary

- Migrate page reads and reference-page listing to shared request/response schemas and the unified JSON envelope.
- Reuse the #171 active knowledge-base context resolver, registered-KB validation, path boundary, and redacted error semantics.
- Migrate artifact list and manifest reads to shared contracts and the frontend artifacts domain API.
- Keep artifact file delivery as an explicit `file-download` endpoint: successful requests return the file `Response`; failures return the unified JSON error envelope.
- Extend the typed JSON client with registry-backed query and dynamic-path construction while keeping file downloads outside that client.

### Endpoint classification

**migrated-json**
- `GET /api/refs`
- `GET /api/page`
- `GET /api/artifacts`
- `GET /api/artifacts/:id`

**file-download**
- `GET /api/artifacts/:id/files/:filename`

File-download failures return `{ ok: false, code, message, details? }`. Missing manifest entries and files removed from disk return `404 NOT_FOUND` with `message: "产物文件不存在"`; raw filesystem errors, absolute paths, and stacks are not exposed.

## Scope

- Does not migrate graph, prompt, or conversation routes.
- Does not change artifact preview/download UI or user experience.
- Does not redefine knowledge-base path resolution.

## Test Coverage

- Contracts schemas and endpoint registry classification.
- Route tests for page found, not found, forbidden path, invalid request, active-context fallback, and unregistered KB.
- Artifact list/manifest success and invalid/not-found cases.
- File download success, missing manifest file, and on-disk `ENOENT` failure.
- Frontend pages/artifacts API envelope parsing, legacy-shape rejection, and file-download client isolation.

## Verification

- [x] `npm run test -w @llm-wiki/workbench-contracts` (30 passed)
- [x] `node --import tsx --test "workbench/server/src/**/*.test.ts"` (96 passed)
- [x] `npm run test -w @llm-wiki-agent/web`
- [x] `npm run typecheck`
- [x] `npm run lint -w @llm-wiki-agent/web`
- [x] `git diff --check`

## Linked issue

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
