### PR TITLE
[#170] Migrate graph read and layout routes

### DIFF
--- a/packages/workbench-contracts/src/endpoints.ts
+++ b/packages/workbench-contracts/src/endpoints.ts
@@ -204,7 +204,7 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "GET",
 		path: "/api/graph",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "读图谱",
 	},
@@ -218,14 +218,14 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "GET",
 		path: "/api/graph/layout",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "read-only",
 		description: "读图谱布局",
 	},
 	{
 		method: "PUT",
 		path: "/api/graph/layout",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "state-changing",
 		description: "写图谱布局",
 	},
@@ -437,6 +437,6 @@ export function requiresCapabilityToken(method: string, path: string): boolean {
 // "Unused '@ts-expect-error' directive" → 强制更新本护栏。这样"新 client 误
 // 处理 legacy endpoint"在编译期即可被发现。
 //
-// @ts-expect-error /api/graph 是 legacy，MigratedJsonPath 必须拒绝
-const _legacyPathRejectedByClient: MigratedJsonPath = "/api/graph";
+// @ts-expect-error /api/graph/rebuild 是 legacy，MigratedJsonPath 必须拒绝
+const _legacyPathRejectedByClient: MigratedJsonPath = "/api/graph/rebuild";
 void _legacyPathRejectedByClient;

--- a/packages/workbench-contracts/src/graph.ts
+++ b/packages/workbench-contracts/src/graph.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+
+const GraphMetaSchema = z
+	.object({
+		build_date: z.string(),
+		wiki_title: z.string(),
+		total_nodes: z.number(),
+		total_edges: z.number(),
+		initial_view: z.array(z.string()).optional(),
+		degraded: z.boolean().optional(),
+		insights_degraded: z.boolean().optional(),
+	})
+	.passthrough();
+
+const GraphNodeSchema = z
+	.object({
+		id: z.string(),
+		label: z.string(),
+		type: z.string(),
+	})
+	.passthrough();
+
+const GraphEdgeSchema = z
+	.object({
+		id: z.string(),
+		from: z.string(),
+		to: z.string(),
+		type: z.string(),
+	})
+	.passthrough();
+
+const CommunityIdSchema = z.string().nullable();
+
+const GraphInsightsSchema = z.object({
+	surprising_connections: z.array(
+		z.object({
+			from: z.string(),
+			to: z.string(),
+			weight: z.number(),
+			from_community: CommunityIdSchema,
+			to_community: CommunityIdSchema,
+		}),
+	),
+	isolated_nodes: z.array(
+		z.object({
+			id: z.string(),
+			label: z.string(),
+			degree: z.number(),
+			community: CommunityIdSchema,
+		}),
+	),
+	bridge_nodes: z.array(
+		z.object({
+			id: z.string(),
+			label: z.string(),
+			community: CommunityIdSchema,
+			connected_communities: z.array(z.string()),
+			community_count: z.number(),
+		}),
+	),
+	sparse_communities: z.array(
+		z.object({
+			id: z.string(),
+			label: z.string(),
+			node_count: z.number(),
+			density: z.number(),
+			members: z.array(z.string()),
+			internal_edges: z.number(),
+		}),
+	),
+	meta: z.object({
+		degraded: z.boolean(),
+		node_count: z.number(),
+		edge_count: z.number(),
+		max_insight_nodes: z.number(),
+		max_insight_edges: z.number(),
+	}),
+});
+
+const GraphLearningSchema = z.object({
+	version: z.literal(1).optional(),
+	entry: z.object({
+		recommended_start_node_id: z.string().nullable(),
+		recommended_start_reason: z.string().nullable(),
+		default_mode: z.enum(["path", "community", "global"]),
+	}),
+	views: z.object({
+		path: z.object({
+			enabled: z.boolean(),
+			start_node_id: z.string().nullable(),
+			node_ids: z.array(z.string()),
+			degraded: z.boolean(),
+		}),
+		community: z.object({
+			enabled: z.boolean(),
+			community_id: z.string().nullable(),
+			label: z.string().nullable(),
+			node_ids: z.array(z.string()),
+			is_weak: z.boolean(),
+			degraded: z.boolean(),
+		}),
+		global: z.object({
+			enabled: z.boolean(),
+			node_ids: z.array(z.string()),
+			degraded: z.boolean(),
+		}),
+	}),
+	communities: z.array(
+		z.object({
+			id: z.string(),
+			label: z.string(),
+			node_count: z.number(),
+			source_count: z.number().optional(),
+			internal_edge_weight: z.number().optional(),
+			is_primary: z.boolean().optional(),
+			is_weak: z.boolean().optional(),
+			recommended_start_node_id: z.string().nullable().optional(),
+			color_index: z.number().optional(),
+			members: z.array(z.string()).optional(),
+		}),
+	),
+	degraded: z
+		.object({
+			path_to_community: z.boolean(),
+			community_to_global: z.boolean(),
+		})
+		.optional(),
+});
+
+export const GraphDataSchema = z
+	.object({
+		meta: GraphMetaSchema,
+		nodes: z.array(GraphNodeSchema),
+		edges: z.array(GraphEdgeSchema),
+		insights: GraphInsightsSchema.optional(),
+		learning: GraphLearningSchema.optional(),
+	})
+	.passthrough();
+export type GraphDataContract = z.infer<typeof GraphDataSchema>;
+
+export const GraphReadDataSchema = z.discriminatedUnion("needsBuild", [
+	z.object({
+		needsBuild: z.literal(true),
+	}),
+	z.object({
+		needsBuild: z.literal(false),
+		data: GraphDataSchema,
+	}),
+]);
+export type GraphReadData = z.infer<typeof GraphReadDataSchema>;
+
+export const GraphPinPositionSchema = z
+	.object({
+		x: z.coerce.number().finite(),
+		y: z.coerce.number().finite(),
+		coordinateSpace: z.enum(["world", "legacy-percent"]).optional(),
+	})
+	.strict();
+
+export const GraphPinMapSchema = z.record(z.string(), GraphPinPositionSchema);
+
+export const GraphLayoutSchema = z
+	.object({
+		version: z.literal(2),
+		pins: GraphPinMapSchema,
+		updatedAt: z.string(),
+	})
+	.strict();
+export type GraphLayout = z.infer<typeof GraphLayoutSchema>;
+
+export const GraphLayoutDataSchema = GraphLayoutSchema;
+export type GraphLayoutData = z.infer<typeof GraphLayoutDataSchema>;
+
+export const GraphLayoutWriteBodySchema = z
+	.object({
+		kbPath: z.string().trim().min(1).optional(),
+		version: z.literal(2),
+		pins: GraphPinMapSchema,
+	})
+	.strict();
+export type GraphLayoutWriteBody = z.infer<
+	typeof GraphLayoutWriteBodySchema
+>;

--- a/packages/workbench-contracts/src/index.ts
+++ b/packages/workbench-contracts/src/index.ts
@@ -17,5 +17,6 @@ export * from "./config.js";
 export * from "./auth.js";
 export * from "./knowledge-bases.js";
 export * from "./pages.js";
+export * from "./graph.js";
 export * from "./artifacts.js";
 export * from "./endpoints.js";

--- a/packages/workbench-contracts/test/endpoints.test.ts
+++ b/packages/workbench-contracts/test/endpoints.test.ts
@@ -100,8 +100,9 @@ test("isMigratedJsonPath 接受 migrated-json、拒绝 legacy path", () => {
 	assert.equal(isMigratedJsonPath("/api/health"), true);
 	assert.equal(isMigratedJsonPath("/api/knowledge-bases"), true);
 	assert.equal(isMigratedJsonPath("/api/knowledge-base"), true);
-	// 尚未迁移的 endpoint 必须返回 false —— 这是"新 client 不误处理 legacy"的数据层防线
-	assert.equal(isMigratedJsonPath("/api/graph"), false);
+	assert.equal(isMigratedJsonPath("/api/graph"), true);
+	// graph rebuild 不在 #170，必须继续拒绝新 client
+	assert.equal(isMigratedJsonPath("/api/graph/rebuild"), false);
 	assert.equal(isMigratedJsonPath("/api/prompt"), false); // sse，不是 migrated-json
 	assert.equal(
 		isMigratedJsonPath("/api/artifacts/x/files/y.md"),

--- a/packages/workbench-contracts/test/graph.test.ts
+++ b/packages/workbench-contracts/test/graph.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	GraphLayoutDataSchema,
+	GraphLayoutWriteBodySchema,
+	GraphReadDataSchema,
+	findEndpoint,
+	isMigratedJsonPath,
+} from "../src/index.js";
+
+const graphData = {
+	meta: {
+		build_date: "2026-07-10T00:00:00.000Z",
+		wiki_title: "测试知识库",
+		total_nodes: 1,
+		total_edges: 0,
+	},
+	nodes: [
+		{
+			id: "topic-a",
+			label: "主题 A",
+			type: "topic",
+			source_path: "wiki/topics/a.md",
+		},
+	],
+	edges: [],
+};
+
+const layout = {
+	version: 2 as const,
+	pins: {
+		"wiki/topics/a.md": { x: 1, y: 2, coordinateSpace: "world" as const },
+	},
+	updatedAt: "2026-07-10T00:00:00.000Z",
+};
+
+test("graph read 与 layout data schema 接受当前图谱主路径结构", () => {
+	assert.deepEqual(
+		GraphReadDataSchema.parse({
+			needsBuild: false,
+			data: graphData,
+		}),
+		{
+			needsBuild: false,
+			data: graphData,
+		},
+	);
+	assert.deepEqual(
+		GraphReadDataSchema.parse({
+			needsBuild: true,
+		}),
+		{ needsBuild: true },
+	);
+	assert.deepEqual(GraphLayoutDataSchema.parse(layout), layout);
+	assert.equal(
+		GraphReadDataSchema.safeParse({
+			needsBuild: false,
+			data: { ...graphData, insights: { surprising_connections: [] } },
+		}).success,
+		false,
+	);
+});
+
+test("layout 写入 body 复用 kbPath 口径并拒绝 schema mismatch", () => {
+	assert.deepEqual(
+		GraphLayoutWriteBodySchema.parse({
+			kbPath: "/kb/registered",
+			version: 2,
+			pins: layout.pins,
+		}),
+		{ kbPath: "/kb/registered", version: 2, pins: layout.pins },
+	);
+	assert.equal(
+		GraphLayoutWriteBodySchema.safeParse({
+			kb: "/kb/registered",
+			pins: layout.pins,
+		}).success,
+		false,
+	);
+	assert.deepEqual(
+		GraphLayoutWriteBodySchema.parse({
+			kbPath: "/kb/registered",
+			version: 2,
+			pins: { "wiki/a.md": { x: "1", y: "2" } },
+		}),
+		{
+			kbPath: "/kb/registered",
+			version: 2,
+			pins: { "wiki/a.md": { x: 1, y: 2 } },
+		},
+	);
+	assert.equal(
+		GraphLayoutWriteBodySchema.safeParse({
+			kbPath: "/kb/registered",
+			version: 2,
+			pins: { "wiki/a.md": { x: "not-a-number", y: 2 } },
+		}).success,
+		false,
+	);
+});
+
+test("#170 只迁移 graph read/layout，rebuild 保持 legacy", () => {
+	for (const endpoint of [
+		{ method: "GET", path: "/api/graph", safety: "read-only" },
+		{ method: "GET", path: "/api/graph/layout", safety: "read-only" },
+		{ method: "PUT", path: "/api/graph/layout", safety: "state-changing" },
+	] as const) {
+		const entry = findEndpoint(endpoint.method, endpoint.path);
+		assert.equal(entry?.kind, "migrated-json");
+		assert.equal(entry?.safety, endpoint.safety);
+		assert.equal(isMigratedJsonPath(endpoint.path), true);
+	}
+	assert.equal(findEndpoint("POST", "/api/graph/rebuild")?.kind, "legacy");
+	assert.equal(isMigratedJsonPath("/api/graph/rebuild"), false);
+});

--- a/workbench/server/src/app.ts
+++ b/workbench/server/src/app.ts
@@ -11,6 +11,7 @@ import { createArtifactRoutes, defaultArtifactRouteService, type ArtifactRouteSe
 import { createAuthRoutes, defaultAuthRouteService, type AuthRouteService } from "./routes/auth.js";
 import { createConfigRoutes, createModelRoutes, defaultConfigRouteService, type ConfigRouteService } from "./routes/config.js";
 import { createHealthRoutes } from "./routes/health.js";
+import { createGraphRoutes, defaultGraphRouteService, type GraphRouteService } from "./routes/graph.js";
 import { createKnowledgeBaseRoutes, defaultKnowledgeBaseRouteService, type KnowledgeBaseRouteService } from "./routes/knowledge-bases.js";
 import { createPageRoutes, defaultPageRouteService, type PageRouteService } from "./routes/pages.js";
 
@@ -41,6 +42,8 @@ export interface WorkbenchAppDeps {
 	knowledgeBaseService?: KnowledgeBaseRouteService;
 	/** wiki 页面读取 / 引用候选 route 依赖。 */
 	pageService?: PageRouteService;
+	/** 图谱读取与 layout 读写 route 依赖；不包含 rebuild。 */
+	graphService?: GraphRouteService;
 	/** artifact manifest/list/file route 依赖。 */
 	artifactService?: ArtifactRouteService;
 }
@@ -93,6 +96,10 @@ export function createApp(deps: WorkbenchAppDeps = {}): Hono {
 	app.route(
 		"/api",
 		createPageRoutes(deps.pageService ?? defaultPageRouteService),
+	);
+	app.route(
+		"/api",
+		createGraphRoutes(deps.graphService ?? defaultGraphRouteService),
 	);
 	app.route(
 		"/api",

--- a/workbench/server/src/graph-routes.test.ts
+++ b/workbench/server/src/graph-routes.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+	GraphLayoutData,
+	GraphReadData,
+} from "@llm-wiki/workbench-contracts";
+
+import { createApp } from "./app.js";
+import type { GraphRouteService } from "./routes/graph.js";
+
+const kbPath = "/fake/registered";
+const graphData = {
+	meta: {
+		build_date: "2026-07-10T00:00:00.000Z",
+		wiki_title: "测试知识库",
+		total_nodes: 1,
+		total_edges: 0,
+	},
+	nodes: [
+		{
+			id: "topic-a",
+			label: "主题 A",
+			type: "topic",
+			source_path: "wiki/topics/a.md",
+		},
+	],
+	edges: [],
+};
+const emptyLayout = { version: 2 as const, pins: {}, updatedAt: "" };
+
+function createGraphService(
+	overrides: Partial<GraphRouteService> = {},
+): GraphRouteService {
+	return {
+		getActiveKnowledgeBasePath: () => kbPath,
+		assertRegisteredKnowledgeBase: async (requested) => {
+			if (requested === "/fake/private") {
+				throw Object.assign(new Error("/Users/private/secret"), {
+					code: "FORBIDDEN_PATH",
+					details: { reason: "outside-root" },
+				});
+			}
+			if (requested !== kbPath) {
+				throw Object.assign(new Error("missing"), {
+					code: "KB_NOT_REGISTERED",
+				});
+			}
+			return requested;
+		},
+		readGraphData: async (): Promise<GraphReadData> => ({
+			needsBuild: false,
+			data: graphData,
+		}),
+		readGraphLayout: async (): Promise<GraphLayoutData> => emptyLayout,
+		writeGraphLayout: async (_path, input): Promise<GraphLayoutData> => ({
+			...emptyLayout,
+			...input,
+			updatedAt: "2026-07-10T00:00:00.000Z",
+		}),
+		...overrides,
+	};
+}
+
+async function json(res: Response): Promise<Record<string, unknown>> {
+	return (await res.json()) as Record<string, unknown>;
+}
+
+test("graph read 与 layout read/save 返回统一 success envelope", async () => {
+	const writes: Array<{ kbPath: string; input: unknown }> = [];
+	const app = createApp({
+		graphService: createGraphService({
+			writeGraphLayout: async (resolvedPath, input) => {
+				writes.push({ kbPath: resolvedPath, input });
+				return {
+					version: 2,
+					pins: input.pins,
+					updatedAt: "2026-07-10T00:00:00.000Z",
+				};
+			},
+		}),
+	});
+
+	const graph = await app.request("/api/graph");
+	assert.equal(graph.status, 200);
+	assert.deepEqual(await json(graph), {
+		ok: true,
+		data: { needsBuild: false, data: graphData },
+	});
+
+	const layout = await app.request("/api/graph/layout");
+	assert.equal(layout.status, 200);
+	assert.deepEqual(await json(layout), {
+		ok: true,
+		data: emptyLayout,
+	});
+
+	const saved = await app.request("/api/graph/layout", {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			kbPath,
+			version: 2,
+			pins: { "wiki/topics/a.md": { x: 1, y: 2 } },
+		}),
+	});
+	assert.equal(saved.status, 200);
+	assert.equal((await json(saved)).ok, true);
+	assert.deepEqual(writes, [
+		{
+			kbPath,
+			input: {
+				version: 2,
+				pins: { "wiki/topics/a.md": { x: 1, y: 2 } },
+			},
+		},
+	]);
+});
+
+test("layout PUT 的 query kb 优先于 body kbPath", async () => {
+	const writes: string[] = [];
+	const queryKb = "/fake/query";
+	const app = createApp({
+		graphService: createGraphService({
+			assertRegisteredKnowledgeBase: async (requested) => requested,
+			writeGraphLayout: async (resolvedPath, input) => {
+				writes.push(resolvedPath);
+				return { version: 2, pins: input.pins, updatedAt: "now" };
+			},
+		}),
+	});
+	const res = await app.request(
+		`/api/graph/layout?kb=${encodeURIComponent(queryKb)}`,
+		{
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				kbPath: "/fake/body",
+				version: 2,
+				pins: {},
+			}),
+		},
+	);
+	assert.equal(res.status, 200);
+	assert.deepEqual(writes, [queryKb]);
+});
+
+test("graph route 复用 active context 的 no active 与 registered KB 错误语义", async () => {
+	let app = createApp({
+		graphService: createGraphService({ getActiveKnowledgeBasePath: () => null }),
+	});
+	let res = await app.request("/api/graph");
+	assert.equal(res.status, 400);
+	assert.equal((await json(res)).code, "NO_ACTIVE_KB");
+
+	app = createApp({ graphService: createGraphService() });
+	res = await app.request("/api/graph/layout?kb=%2Ffake%2Funregistered");
+	assert.equal(res.status, 404);
+	assert.equal((await json(res)).code, "KB_NOT_REGISTERED");
+
+	res = await app.request("/api/graph?kb=%2Ffake%2Fprivate");
+	assert.equal(res.status, 403);
+	const payload = await json(res);
+	assert.deepEqual(payload, {
+		ok: false,
+		code: "FORBIDDEN_PATH",
+		message: "路径不在允许的知识库边界内",
+		details: { reason: "outside-root" },
+	});
+	assert.equal(JSON.stringify(payload).includes("/Users/"), false);
+});
+
+test("graph not found 与 layout schema mismatch 返回稳定 failure envelope", async () => {
+	let app = createApp({
+		graphService: createGraphService({
+			readGraphData: async () => {
+				throw Object.assign(new Error("ENOENT /Users/private/graph-data.json"), {
+					code: "ENOENT",
+				});
+			},
+		}),
+	});
+	let res = await app.request("/api/graph");
+	assert.equal(res.status, 404);
+	assert.deepEqual(await json(res), {
+		ok: false,
+		code: "NOT_FOUND",
+		message: "图谱数据不存在",
+	});
+
+	app = createApp({ graphService: createGraphService() });
+	res = await app.request("/api/graph/layout", {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ kbPath, version: 2, pins: { "wiki/a.md": { x: "bad", y: 2 } } }),
+	});
+	assert.equal(res.status, 400);
+	assert.equal((await json(res)).code, "INVALID_REQUEST");
+});
+
+test("graph service response schema mismatch 由统一兜底拒绝", async () => {
+	const app = createApp({
+		mode: "test",
+		graphService: createGraphService({
+			readGraphLayout: async () =>
+				({ version: 2, pins: "bad", updatedAt: "" }) as never,
+		}),
+	});
+	const res = await app.request("/api/graph/layout");
+	assert.equal(res.status, 500);
+	assert.equal((await json(res)).code, "INTERNAL_ERROR");
+});

--- a/workbench/server/src/index.ts
+++ b/workbench/server/src/index.ts
@@ -48,14 +48,11 @@ import {
 	setPendingKnowledgeContext,
 } from "./extensions/knowledge-base.js";
 import {
-	readGraphData,
-	readGraphLayout,
 	resumeGraphWatcher,
 	subscribeGraphEvents,
 	suspendGraphWatcher,
 	triggerGraphRebuild,
 	watchKnowledgeBaseGraph,
-	writeGraphLayout,
 } from "./graph.js";
 import {
 	assertRegisteredKnowledgeBase,
@@ -109,15 +106,6 @@ function requestedKnowledgeBasePath(queryValue: string | undefined, body?: unkno
 		if (typeof bodyPath === "string" && bodyPath.trim()) return bodyPath.trim();
 	}
 	return getActive()?.kb.path ?? null;
-}
-
-async function requestedRegisteredKnowledgeBasePath(
-	queryValue: string | undefined,
-	body?: unknown,
-): Promise<string | null> {
-	const requestedPath = requestedKnowledgeBasePath(queryValue, body);
-	if (!requestedPath) return null;
-	return assertRegisteredKnowledgeBase(requestedPath);
 }
 
 function errorStatus(err: unknown, fallback: 400 | 500 = 500): 400 | 403 | 500 {
@@ -246,58 +234,14 @@ app.post("/api/knowledge-bases/init-existing", async (c) => {
 	}
 });
 
-// ============= 图谱（指定知识库；未传时回退当前知识库） =============
-
-app.get("/api/graph", async (c) => {
-	try {
-		const kbPath = await requestedRegisteredKnowledgeBasePath(c.req.query("kb"));
-		if (!kbPath) return c.json({ ok: false, error: "请先选择一个知识库" }, 400);
-		return c.json(await readGraphData(kbPath));
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			errorStatus(err),
-		);
-	}
-});
+// ============= 图谱重建（指定知识库；未传时回退当前知识库） =============
 
 app.post("/api/graph/rebuild", async (c) => {
 	try {
-		const kbPath = await requestedRegisteredKnowledgeBasePath(c.req.query("kb"));
-		if (!kbPath) return c.json({ ok: false, error: "请先选择一个知识库" }, 400);
+		const requestedPath = requestedKnowledgeBasePath(c.req.query("kb"));
+		if (!requestedPath) return c.json({ ok: false, error: "请先选择一个知识库" }, 400);
+		const kbPath = await assertRegisteredKnowledgeBase(requestedPath);
 		return c.json(triggerGraphRebuild(kbPath));
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			errorStatus(err),
-		);
-	}
-});
-
-app.get("/api/graph/layout", async (c) => {
-	try {
-		const kbPath = await requestedRegisteredKnowledgeBasePath(c.req.query("kb"));
-		if (!kbPath) return c.json({ ok: false, error: "请先选择一个知识库" }, 400);
-		return c.json(await readGraphLayout(kbPath));
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			errorStatus(err),
-		);
-	}
-});
-
-app.put("/api/graph/layout", async (c) => {
-	let body: unknown;
-	try {
-		body = await c.req.json();
-	} catch {
-		return c.json({ ok: false, error: "Invalid JSON body" }, 400);
-	}
-	try {
-		const kbPath = await requestedRegisteredKnowledgeBasePath(c.req.query("kb"), body);
-		if (!kbPath) return c.json({ ok: false, error: "请先选择一个知识库" }, 400);
-		return c.json(await writeGraphLayout(kbPath, body));
 	} catch (err) {
 		return c.json(
 			{ ok: false, error: err instanceof Error ? err.message : String(err) },

--- a/workbench/server/src/routes/graph.ts
+++ b/workbench/server/src/routes/graph.ts
@@ -1,0 +1,143 @@
+import { Hono } from "hono";
+
+import {
+	GraphLayoutDataSchema,
+	GraphLayoutWriteBodySchema,
+	GraphReadDataSchema,
+	type GraphLayoutData,
+	type GraphReadData,
+} from "@llm-wiki/workbench-contracts";
+
+import { getActive } from "../agent.js";
+import {
+	mapKnowledgeBaseError,
+	resolveKnowledgeBaseContext,
+} from "../http/knowledge-base-context.js";
+import {
+	HttpContractError,
+	parseValidatedBody,
+} from "../http/request.js";
+import { jsonOk } from "../http/response.js";
+import {
+	readGraphData,
+	readGraphLayout,
+	writeGraphLayout,
+} from "../graph.js";
+import { assertRegisteredKnowledgeBase } from "../knowledge-bases.js";
+
+export interface GraphRouteService {
+	getActiveKnowledgeBasePath: () => string | null;
+	assertRegisteredKnowledgeBase: (kbPath: string) => Promise<string>;
+	readGraphData: (kbPath: string) => Promise<GraphReadData>;
+	readGraphLayout: (kbPath: string) => Promise<GraphLayoutData>;
+	writeGraphLayout: (
+		kbPath: string,
+		input: { version: 2; pins: GraphLayoutData["pins"] },
+	) => Promise<GraphLayoutData>;
+}
+
+export const defaultGraphRouteService: GraphRouteService = {
+	getActiveKnowledgeBasePath: () => getActive()?.kb.path ?? null,
+	assertRegisteredKnowledgeBase,
+	readGraphData: async (kbPath) => {
+		const result = await readGraphData(kbPath);
+		return GraphReadDataSchema.parse(
+			result.needsBuild
+				? { needsBuild: true }
+				: {
+						needsBuild: false,
+						data: result.data,
+					},
+		);
+	},
+	readGraphLayout: async (kbPath) => {
+		const result = await readGraphLayout(kbPath);
+		return GraphLayoutDataSchema.parse(result.layout);
+	},
+	writeGraphLayout: async (kbPath, input) => {
+		const result = await writeGraphLayout(kbPath, input);
+		return GraphLayoutDataSchema.parse(result.layout);
+	},
+};
+
+export function createGraphRoutes(service: GraphRouteService): Hono {
+	const router = new Hono();
+
+	router.get("/graph", async (c) => {
+		const kbPath = await resolveGraphKnowledgeBase(c.req.query("kb"), service);
+		try {
+			return jsonOk(
+				c,
+				GraphReadDataSchema.parse(await service.readGraphData(kbPath)),
+			);
+		} catch (err) {
+			throw mapGraphError(err);
+		}
+	});
+
+	router.get("/graph/layout", async (c) => {
+		const kbPath = await resolveGraphKnowledgeBase(c.req.query("kb"), service);
+		try {
+			return jsonOk(
+				c,
+				GraphLayoutDataSchema.parse(await service.readGraphLayout(kbPath)),
+			);
+		} catch (err) {
+			throw mapGraphError(err);
+		}
+	});
+
+	router.put("/graph/layout", async (c) => {
+		const body = await parseValidatedBody(c, GraphLayoutWriteBodySchema);
+		const kbPath = await resolveKnowledgeBaseContext(
+			{
+				queryKb: c.req.query("kb"),
+				...(body.kbPath ? { body: { kbPath: body.kbPath } } : {}),
+			},
+			{
+				getActiveKnowledgeBasePath: service.getActiveKnowledgeBasePath,
+				assertRegisteredKnowledgeBase: service.assertRegisteredKnowledgeBase,
+			},
+		);
+		try {
+			return jsonOk(
+				c,
+				GraphLayoutDataSchema.parse(
+					await service.writeGraphLayout(kbPath, {
+						version: body.version,
+						pins: body.pins,
+					}),
+				),
+			);
+		} catch (err) {
+			throw mapGraphError(err);
+		}
+	});
+
+	return router;
+}
+
+function resolveGraphKnowledgeBase(
+	queryKb: string | undefined,
+	service: GraphRouteService,
+): Promise<string> {
+	return resolveKnowledgeBaseContext(
+		{ queryKb },
+		{
+			getActiveKnowledgeBasePath: service.getActiveKnowledgeBasePath,
+			assertRegisteredKnowledgeBase: service.assertRegisteredKnowledgeBase,
+		},
+	);
+}
+
+function mapGraphError(err: unknown): HttpContractError {
+	if (err instanceof HttpContractError) return err;
+	const source = err as { code?: unknown; statusCode?: unknown };
+	if (source.code === "ENOENT") {
+		return new HttpContractError("NOT_FOUND", "图谱数据不存在");
+	}
+	if (source.code === "FORBIDDEN_PATH" || source.statusCode === 403) {
+		return mapKnowledgeBaseError(err);
+	}
+	return new HttpContractError("INTERNAL_ERROR", "服务器内部错误");
+}

--- a/workbench/web/src/components/GraphPanel.tsx
+++ b/workbench/web/src/components/GraphPanel.tsx
@@ -376,7 +376,7 @@ export function GraphPanel({
 		try {
 			const [result, layout] = await Promise.all([getGraphData(kbPath), getGraphLayout(kbPath)]);
 			if (loadRequestRef.current !== requestId || activeKbPathRef.current !== kbPath) return false;
-			const nextPins = { ...layout.layout.pins, ...layoutPinsRef.current };
+			const nextPins = { ...layout.pins, ...layoutPinsRef.current };
 			applyLayoutPins(nextPins);
 			if (result.needsBuild) {
 				setData(null);

--- a/workbench/web/src/lib/api.ts
+++ b/workbench/web/src/lib/api.ts
@@ -22,6 +22,11 @@ import {
 	listArtifacts as listArtifactsMigrated,
 } from "./api/artifacts";
 import {
+	getGraphData as getGraphDataMigrated,
+	getGraphLayout as getGraphLayoutMigrated,
+	putGraphLayout as putGraphLayoutMigrated,
+} from "./api/graph";
+import {
 	listRefs as listRefsMigrated,
 	readPage as readPageMigrated,
 } from "./api/pages";
@@ -84,10 +89,10 @@ export type BatchDigestEvent =
 	| { type: "done"; total: number; completed: number; failed: number; outputDir: string };
 
 export type GraphApiResult =
-	| { ok: true; needsBuild: true; graphPath: string }
-	| { ok: true; needsBuild: false; graphPath: string; data: GraphData };
+	| { needsBuild: true }
+	| { needsBuild: false; data: GraphData };
 
-export type GraphLayoutApiResult = { ok: true; layoutPath: string; layout: GraphLayoutFile };
+export type GraphLayoutApiResult = GraphLayoutFile;
 
 export type GraphEvent =
 	| {
@@ -402,11 +407,8 @@ function kbQuery(kbPath: string): string {
 	return `kb=${encodeURIComponent(kbPath)}`;
 }
 
-export async function getGraphData(kbPath: string): Promise<GraphApiResult> {
-	const res = await fetch(`/api/graph?${kbQuery(kbPath)}`);
-	const json = (await res.json()) as GraphApiResult | { ok: false; error?: string };
-	if (!res.ok || !json.ok) throw new Error(("error" in json && json.error) || `HTTP ${res.status}`);
-	return json;
+export function getGraphData(kbPath: string): Promise<GraphApiResult> {
+	return getGraphDataMigrated(kbPath);
 }
 
 export async function rebuildGraph(kbPath: string): Promise<"started" | "queued"> {
@@ -416,22 +418,15 @@ export async function rebuildGraph(kbPath: string): Promise<"started" | "queued"
 	return json.status;
 }
 
-export async function getGraphLayout(kbPath: string): Promise<GraphLayoutApiResult> {
-	const res = await fetch(`/api/graph/layout?${kbQuery(kbPath)}`);
-	const json = (await res.json()) as GraphLayoutApiResult | { ok: false; error?: string };
-	if (!res.ok || !json.ok) throw new Error(("error" in json && json.error) || `HTTP ${res.status}`);
-	return json;
+export function getGraphLayout(kbPath: string): Promise<GraphLayoutApiResult> {
+	return getGraphLayoutMigrated(kbPath);
 }
 
-export async function putGraphLayout(kbPath: string, pins: PinMap): Promise<GraphLayoutApiResult> {
-	const res = await fetch(`/api/graph/layout?${kbQuery(kbPath)}`, {
-		method: "PUT",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ version: 2, pins }),
-	});
-	const json = (await res.json()) as GraphLayoutApiResult | { ok: false; error?: string };
-	if (!res.ok || !json.ok) throw new Error(("error" in json && json.error) || `HTTP ${res.status}`);
-	return json;
+export function putGraphLayout(
+	kbPath: string,
+	pins: PinMap,
+): Promise<GraphLayoutApiResult> {
+	return putGraphLayoutMigrated(kbPath, pins);
 }
 
 export function listArtifacts(conversationId?: string): Promise<ArtifactManifest[]> {

--- a/workbench/web/src/lib/api/graph.ts
+++ b/workbench/web/src/lib/api/graph.ts
@@ -1,0 +1,38 @@
+import {
+	GraphLayoutDataSchema,
+	GraphReadDataSchema,
+} from "@llm-wiki/workbench-contracts";
+import type { GraphData, GraphLayoutFile, PinMap } from "@llm-wiki/graph-engine";
+
+import { request } from "./client";
+
+export type GraphApiResult =
+	| { needsBuild: true }
+	| { needsBuild: false; data: GraphData };
+
+export async function getGraphData(kbPath: string): Promise<GraphApiResult> {
+	return (await request("/api/graph", {
+		responseSchema: GraphReadDataSchema,
+		query: { kb: kbPath },
+	})) as GraphApiResult;
+}
+
+export async function getGraphLayout(
+	kbPath: string,
+): Promise<GraphLayoutFile> {
+	return (await request("/api/graph/layout", {
+		responseSchema: GraphLayoutDataSchema,
+		query: { kb: kbPath },
+	})) as GraphLayoutFile;
+}
+
+export async function putGraphLayout(
+	kbPath: string,
+	pins: PinMap,
+): Promise<GraphLayoutFile> {
+	return (await request("/api/graph/layout", {
+		responseSchema: GraphLayoutDataSchema,
+		method: "PUT",
+		body: { kbPath, version: 2, pins },
+	})) as GraphLayoutFile;
+}

--- a/workbench/web/test/api.test.ts
+++ b/workbench/web/test/api.test.ts
@@ -18,10 +18,10 @@ describe("graph API helpers", () => {
 	it("binds graph reads, rebuilds, and layout writes to the requested knowledge base", async () => {
 		const requests: Array<{ url: string; method: string; body?: BodyInit | null }> = [];
 		const responses: unknown[] = [
-			{ ok: true, needsBuild: true, graphPath: "/kb/wiki/graph-data.json" },
-			{ ok: true, layoutPath: "/kb/.wiki-graph-layout.json", layout: { version: 1, pins: {}, updatedAt: "" } },
+			{ ok: true, data: { needsBuild: true } },
+			{ ok: true, data: { version: 2, pins: {}, updatedAt: "" } },
 			{ ok: true, status: "started" },
-			{ ok: true, layoutPath: "/kb/.wiki-graph-layout.json", layout: { version: 1, pins: {}, updatedAt: "" } },
+			{ ok: true, data: { version: 2, pins: {}, updatedAt: "" } },
 		];
 		globalThis.fetch = (async (input, init) => {
 			requests.push({
@@ -43,10 +43,10 @@ describe("graph API helpers", () => {
 		assert.deepEqual(
 			requests.map((request) => request.url),
 			[
-				"/api/graph?kb=%2Ftmp%2FKnowledge%20Base",
-				"/api/graph/layout?kb=%2Ftmp%2FKnowledge%20Base",
+				"/api/graph?kb=%2Ftmp%2FKnowledge+Base",
+				"/api/graph/layout?kb=%2Ftmp%2FKnowledge+Base",
 				"/api/graph/rebuild?kb=%2Ftmp%2FKnowledge%20Base",
-				"/api/graph/layout?kb=%2Ftmp%2FKnowledge%20Base",
+				"/api/graph/layout",
 			],
 		);
 		assert.deepEqual(
@@ -54,6 +54,7 @@ describe("graph API helpers", () => {
 			["GET", "GET", "POST", "PUT"],
 		);
 		assert.deepEqual(JSON.parse(String(requests[3]?.body)), {
+			kbPath,
 			version: 2,
 			pins: { "wiki/a.md": { x: 1, y: 2 } },
 		});

--- a/workbench/web/test/graph-api.test.ts
+++ b/workbench/web/test/graph-api.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { ApiError, ContractMismatchError } from "../src/lib/api/client";
+import { getGraphData, getGraphLayout, putGraphLayout } from "../src/lib/api/graph";
+
+function stubFetch(body: unknown, status = 200) {
+	const calls: Array<{ url: string; init?: RequestInit }> = [];
+	globalThis.fetch = ((input: URL | string, init?: RequestInit) => {
+		calls.push({ url: String(input), init });
+		return Promise.resolve(
+			new Response(JSON.stringify(body), {
+				status,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	}) as typeof globalThis.fetch;
+	return calls;
+}
+
+describe("graph API module", () => {
+	const originalFetch = globalThis.fetch;
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("graph read 与 layout read/save 通过 migrated JSON client", async () => {
+		let calls = stubFetch({
+			ok: true,
+			data: { needsBuild: true },
+		});
+		assert.equal((await getGraphData("/kb/registered")).needsBuild, true);
+		assert.equal(calls[0]?.url, "/api/graph?kb=%2Fkb%2Fregistered");
+
+		calls = stubFetch({
+			ok: true,
+			data: { version: 2, pins: {}, updatedAt: "" },
+		});
+		assert.deepEqual((await getGraphLayout("/kb/registered")).pins, {});
+		assert.equal(calls[0]?.url, "/api/graph/layout?kb=%2Fkb%2Fregistered");
+
+		calls = stubFetch({
+			ok: true,
+			data: { version: 2, pins: {}, updatedAt: "2026-07-10T00:00:00.000Z" },
+		});
+		await putGraphLayout("/kb/registered", {
+			"wiki/topics/a.md": { x: 1, y: 2 },
+		});
+		assert.equal(calls[0]?.url, "/api/graph/layout");
+		assert.equal(calls[0]?.init?.method, "PUT");
+		assert.deepEqual(JSON.parse(String(calls[0]?.init?.body)), {
+			kbPath: "/kb/registered",
+			version: 2,
+			pins: { "wiki/topics/a.md": { x: 1, y: 2 } },
+		});
+	});
+
+	it("统一错误透出 code，响应 schema mismatch 被拒绝", async () => {
+		stubFetch({ ok: false, code: "NO_ACTIVE_KB", message: "当前没有选择知识库" }, 400);
+		await assert.rejects(
+			() => getGraphData(""),
+			(err) => err instanceof ApiError && err.code === "NO_ACTIVE_KB",
+		);
+
+		stubFetch({ ok: true, data: { needsBuild: false, graphPath: "/kb/graph.json" } });
+		await assert.rejects(
+			() => getGraphData("/kb/registered"),
+			(err) => err instanceof ContractMismatchError,
+		);
+	});
+});

--- a/workbench/web/test/graph-panel-paper.test.tsx
+++ b/workbench/web/test/graph-panel-paper.test.tsx
@@ -259,36 +259,42 @@ function mockGraphFetch(options: { needsBuild?: boolean } = {}) {
 		if (url.startsWith("/api/graph/layout")) {
 			return jsonResponse({
 				ok: true,
-				layout: { version: 1, pins: {}, updatedAt: "2026-06-20T00:00:00.000Z" },
+				data: { version: 2, pins: {}, updatedAt: "2026-06-20T00:00:00.000Z" },
 			});
 		}
 		if (url.startsWith("/api/graph?")) {
 			if (options.needsBuild) {
 				return jsonResponse({
 					ok: true,
-					needsBuild: true,
-					graphPath: "/kb/.llm-wiki/graph.json",
+					data: { needsBuild: true },
 				});
 			}
 			return jsonResponse({
 				ok: true,
-				needsBuild: false,
 				data: {
-					meta: { build_date: "2026-06-20T00:00:00.000Z" },
-					nodes: [
-						{
-							id: "wiki/paper.md",
-							label: "Paper",
-							title: "Paper",
-							type: "topic",
-							community: "paper",
-							path: "wiki/paper.md",
+					needsBuild: false,
+					data: {
+						meta: {
+							build_date: "2026-06-20T00:00:00.000Z",
+							wiki_title: "AI 学习库",
+							total_nodes: 1,
+							total_edges: 0,
 						},
-					],
-					edges: [],
-					communities: [],
+						nodes: [
+							{
+								id: "wiki/paper.md",
+								label: "Paper",
+								title: "Paper",
+								type: "topic",
+								community: "paper",
+								path: "wiki/paper.md",
+							},
+						],
+						edges: [],
+						communities: [],
+					},
 				},
-				});
+			});
 			}
 		if (url.startsWith("/api/graph/rebuild")) {
 			return jsonResponse({ ok: true, status: "started" });

--- a/workbench/web/test/visual/paper-ui.ts
+++ b/workbench/web/test/visual/paper-ui.ts
@@ -603,17 +603,14 @@ async function fulfillMockApi(route: Route, url: URL, method: string) {
 	if (pathname === "/api/graph") {
 		await json({
 			ok: true,
-			needsBuild: false,
-			graphPath: `${visualKbPath}/.llm-wiki/graph.json`,
-			data: visualGraphData(),
+			data: { needsBuild: false, data: visualGraphData() },
 		});
 		return;
 	}
 	if (pathname === "/api/graph/layout") {
 		await json({
 			ok: true,
-			layoutPath: `${visualKbPath}/.llm-wiki/graph-layout.json`,
-			layout: { version: 1, pins: {}, updatedAt: "2026-06-20T00:00:00.000Z" },
+			data: { version: 2, pins: {}, updatedAt: "2026-06-20T00:00:00.000Z" },
 		});
 		return;
 	}


### PR DESCRIPTION
## Summary
- Migrate `GET /api/graph`, `GET /api/graph/layout`, and `PUT /api/graph/layout` to the shared `{ ok, data }` / failure envelope.
- Reuse #171 `resolveKnowledgeBaseContext()` and registered-KB path checks; `kb` query remains higher priority than body `kbPath`.
- Add shared graph/layout Zod contracts, a server graph route module, and a frontend graph domain API module.
- Keep `POST /api/graph/rebuild` legacy and state-changing for follow-up #172.

## Failure coverage
- `NO_ACTIVE_KB`, `KB_NOT_REGISTERED`, `FORBIDDEN_PATH`, `NOT_FOUND` route mapping
- invalid request/schema mismatch and malformed service responses
- query-over-body context precedence and response path redaction

## Verification
- [x] `npm run typecheck`
- [x] contracts tests: 33 passed
- [x] server tests: 101 passed
- [x] web unit + DOM tests: passed (108 DOM tests)
- [x] graph-engine tests: passed
- [x] web lint
- [x] `git diff --check`
- [x] live dev smoke: graph read returned 88 nodes / 217 edges; layout read/save returned v2 and preserved pins
- [x] Paper graph visual cases produced screenshots at 1440/1024/768
- [ ] Full Paper visual suite later timed out in the unrelated search-result scenario after graph cases completed

## Scope
- No graph visual behavior changes.
- No graph-engine semantic changes.
- No graph rebuild migration.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
