### PR TITLE
feat(workbench): migrate graph rebuild route (#172)

### DIFF
--- a/packages/workbench-contracts/src/endpoints.ts
+++ b/packages/workbench-contracts/src/endpoints.ts
@@ -211,7 +211,7 @@ export const ENDPOINT_REGISTRY = [
 	{
 		method: "POST",
 		path: "/api/graph/rebuild",
-		kind: "legacy",
+		kind: "migrated-json",
 		safety: "state-changing",
 		description: "重建图谱，触发后台任务 / 写缓存",
 	},
@@ -437,6 +437,6 @@ export function requiresCapabilityToken(method: string, path: string): boolean {
 // "Unused '@ts-expect-error' directive" → 强制更新本护栏。这样"新 client 误
 // 处理 legacy endpoint"在编译期即可被发现。
 //
-// @ts-expect-error /api/graph/rebuild 是 legacy，MigratedJsonPath 必须拒绝
-const _legacyPathRejectedByClient: MigratedJsonPath = "/api/graph/rebuild";
-void _legacyPathRejectedByClient;
+// 编译期证明 graph rebuild 已迁移，可由 typed client 调用。
+const _graphRebuildAcceptedByClient: MigratedJsonPath = "/api/graph/rebuild";
+void _graphRebuildAcceptedByClient;

--- a/packages/workbench-contracts/src/endpoints.ts
+++ b/packages/workbench-contracts/src/endpoints.ts
@@ -431,12 +431,7 @@ export function requiresCapabilityToken(method: string, path: string): boolean {
 
 // ============= 静态自检（编译期护栏，被 typecheck 覆盖） =============
 //
-// 证明 MigratedJsonPath 不含 legacy path：把一个 legacy path 赋给
-// MigratedJsonPath 应触发类型错误，由 @ts-expect-error 吸收。
-// 若未来该 endpoint 被迁移为 migrated-json，赋值不再报错 → tsc 报
-// "Unused '@ts-expect-error' directive" → 强制更新本护栏。这样"新 client 误
-// 处理 legacy endpoint"在编译期即可被发现。
-//
-// 编译期证明 graph rebuild 已迁移，可由 typed client 调用。
+// 编译期证明 graph rebuild 已迁移，可由 typed client 调用。若 endpoint
+// 退回 legacy-json，赋值会触发类型错误，强制同步更新 client 与契约。
 const _graphRebuildAcceptedByClient: MigratedJsonPath = "/api/graph/rebuild";
 void _graphRebuildAcceptedByClient;

--- a/packages/workbench-contracts/src/graph.ts
+++ b/packages/workbench-contracts/src/graph.ts
@@ -149,6 +149,13 @@ export const GraphReadDataSchema = z.discriminatedUnion("needsBuild", [
 ]);
 export type GraphReadData = z.infer<typeof GraphReadDataSchema>;
 
+export const GraphRebuildDataSchema = z
+	.object({
+		status: z.enum(["started", "queued"]),
+	})
+	.strict();
+export type GraphRebuildData = z.infer<typeof GraphRebuildDataSchema>;
+
 export const GraphPinPositionSchema = z
 	.object({
 		x: z.coerce.number().finite(),

--- a/packages/workbench-contracts/test/endpoints.test.ts
+++ b/packages/workbench-contracts/test/endpoints.test.ts
@@ -101,8 +101,7 @@ test("isMigratedJsonPath 接受 migrated-json、拒绝 legacy path", () => {
 	assert.equal(isMigratedJsonPath("/api/knowledge-bases"), true);
 	assert.equal(isMigratedJsonPath("/api/knowledge-base"), true);
 	assert.equal(isMigratedJsonPath("/api/graph"), true);
-	// graph rebuild 不在 #170，必须继续拒绝新 client
-	assert.equal(isMigratedJsonPath("/api/graph/rebuild"), false);
+	assert.equal(isMigratedJsonPath("/api/graph/rebuild"), true);
 	assert.equal(isMigratedJsonPath("/api/prompt"), false); // sse，不是 migrated-json
 	assert.equal(
 		isMigratedJsonPath("/api/artifacts/x/files/y.md"),

--- a/packages/workbench-contracts/test/graph.test.ts
+++ b/packages/workbench-contracts/test/graph.test.ts
@@ -5,6 +5,7 @@ import {
 	GraphLayoutDataSchema,
 	GraphLayoutWriteBodySchema,
 	GraphReadDataSchema,
+	GraphRebuildDataSchema,
 	findEndpoint,
 	isMigratedJsonPath,
 } from "../src/index.js";
@@ -100,9 +101,20 @@ test("layout 写入 body 复用 kbPath 口径并拒绝 schema mismatch", () => {
 	);
 });
 
-test("#170 只迁移 graph read/layout，rebuild 保持 legacy", () => {
+test("graph rebuild data schema 只接受明确的异步排队状态", () => {
+	assert.deepEqual(GraphRebuildDataSchema.parse({ status: "started" }), {
+		status: "started",
+	});
+	assert.deepEqual(GraphRebuildDataSchema.parse({ status: "queued" }), {
+		status: "queued",
+	});
+	assert.equal(GraphRebuildDataSchema.safeParse({ status: "done" }).success, false);
+});
+
+test("#172 单独迁移 graph rebuild，并保持 read/layout 的安全分类", () => {
 	for (const endpoint of [
 		{ method: "GET", path: "/api/graph", safety: "read-only" },
+		{ method: "POST", path: "/api/graph/rebuild", safety: "state-changing" },
 		{ method: "GET", path: "/api/graph/layout", safety: "read-only" },
 		{ method: "PUT", path: "/api/graph/layout", safety: "state-changing" },
 	] as const) {
@@ -111,6 +123,4 @@ test("#170 只迁移 graph read/layout，rebuild 保持 legacy", () => {
 		assert.equal(entry?.safety, endpoint.safety);
 		assert.equal(isMigratedJsonPath(endpoint.path), true);
 	}
-	assert.equal(findEndpoint("POST", "/api/graph/rebuild")?.kind, "legacy");
-	assert.equal(isMigratedJsonPath("/api/graph/rebuild"), false);
 });

--- a/workbench/server/src/app.ts
+++ b/workbench/server/src/app.ts
@@ -45,7 +45,7 @@ export interface WorkbenchAppDeps {
 	conversationService?: ConversationRouteService;
 	/** wiki 页面读取 / 引用候选 route 依赖。 */
 	pageService?: PageRouteService;
-	/** 图谱读取与 layout 读写 route 依赖；不包含 rebuild。 */
+	/** 图谱读取、rebuild 与 layout 读写 route 依赖。 */
 	graphService?: GraphRouteService;
 	/** artifact manifest/list/file route 依赖。 */
 	artifactService?: ArtifactRouteService;

--- a/workbench/server/src/graph-routes.test.ts
+++ b/workbench/server/src/graph-routes.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import type {
 	GraphLayoutData,
 	GraphReadData,
+	GraphRebuildData,
 } from "@llm-wiki/workbench-contracts";
 
 import { createApp } from "./app.js";
@@ -48,6 +49,7 @@ function createGraphService(
 			}
 			return requested;
 		},
+		triggerGraphRebuild: (): GraphRebuildData => ({ status: "started" }),
 		readGraphData: async (): Promise<GraphReadData> => ({
 			needsBuild: false,
 			data: graphData,
@@ -65,6 +67,93 @@ function createGraphService(
 async function json(res: Response): Promise<Record<string, unknown>> {
 	return (await res.json()) as Record<string, unknown>;
 }
+
+test("graph rebuild 返回统一任务状态并复用 active context", async () => {
+	const triggered: string[] = [];
+	const app = createApp({
+		graphService: createGraphService({
+			triggerGraphRebuild: (resolvedPath) => {
+				triggered.push(resolvedPath);
+				return { status: triggered.length === 1 ? "started" : "queued" };
+			},
+		}),
+	});
+
+	let res = await app.request("/api/graph/rebuild", { method: "POST" });
+	assert.equal(res.status, 200);
+	assert.deepEqual(await json(res), { ok: true, data: { status: "started" } });
+
+	res = await app.request("/api/graph/rebuild", { method: "POST" });
+	assert.equal(res.status, 200);
+	assert.deepEqual(await json(res), { ok: true, data: { status: "queued" } });
+	assert.deepEqual(triggered, [kbPath, kbPath]);
+});
+
+test("graph rebuild 并发 BUSY 与触发失败返回稳定 failure envelope", async () => {
+	let app = createApp({
+		graphService: createGraphService({
+			triggerGraphRebuild: () => {
+				throw Object.assign(new Error("already running /Users/private"), {
+					code: "BUSY",
+				});
+			},
+		}),
+	});
+	let res = await app.request("/api/graph/rebuild", { method: "POST" });
+	assert.equal(res.status, 409);
+	assert.deepEqual(await json(res), {
+		ok: false,
+		code: "BUSY",
+		message: "图谱正在重建",
+	});
+
+	app = createApp({
+		graphService: createGraphService({
+			triggerGraphRebuild: () => {
+				throw new Error("spawn failed /Users/private/build.sh");
+			},
+		}),
+	});
+	res = await app.request("/api/graph/rebuild", { method: "POST" });
+	assert.equal(res.status, 500);
+	assert.equal((await json(res)).code, "INTERNAL_ERROR");
+	const graphResponse = await app.request("/api/graph");
+	assert.equal(JSON.stringify(await json(graphResponse)).includes("/Users/"), false);
+});
+
+test("graph rebuild 拒绝 no active KB 与 forbidden path，且不会触发任务", async () => {
+	let calls = 0;
+	let app = createApp({
+		graphService: createGraphService({
+			getActiveKnowledgeBasePath: () => null,
+			triggerGraphRebuild: () => {
+				calls++;
+				return { status: "started" };
+			},
+		}),
+	});
+	let res = await app.request("/api/graph/rebuild", { method: "POST" });
+	assert.equal(res.status, 400);
+	assert.equal((await json(res)).code, "NO_ACTIVE_KB");
+
+	app = createApp({
+		graphService: createGraphService({
+			triggerGraphRebuild: () => {
+				calls++;
+				return { status: "started" };
+			},
+		}),
+	});
+	res = await app.request("/api/graph/rebuild?kb=%2Ffake%2Fprivate", {
+		method: "POST",
+	});
+	assert.equal(res.status, 403);
+	const payload = await json(res);
+	assert.equal(payload.code, "FORBIDDEN_PATH");
+	assert.equal(JSON.stringify(payload).includes("/Users/"), false);
+	assert.equal(calls, 0);
+});
+
 
 test("graph read 与 layout read/save 返回统一 success envelope", async () => {
 	const writes: Array<{ kbPath: string; input: unknown }> = [];

--- a/workbench/server/src/graph-routes.test.ts
+++ b/workbench/server/src/graph-routes.test.ts
@@ -116,9 +116,9 @@ test("graph rebuild 并发 BUSY 与触发失败返回稳定 failure envelope", a
 	});
 	res = await app.request("/api/graph/rebuild", { method: "POST" });
 	assert.equal(res.status, 500);
-	assert.equal((await json(res)).code, "INTERNAL_ERROR");
-	const graphResponse = await app.request("/api/graph");
-	assert.equal(JSON.stringify(await json(graphResponse)).includes("/Users/"), false);
+	const failure = await json(res);
+	assert.equal(failure.code, "INTERNAL_ERROR");
+	assert.equal(JSON.stringify(failure).includes("/Users/"), false);
 });
 
 test("graph rebuild 拒绝 no active KB 与 forbidden path，且不会触发任务", async () => {

--- a/workbench/server/src/graph-watcher.test.ts
+++ b/workbench/server/src/graph-watcher.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+	graphRebuildFailureMessage,
 	GraphRebuildQueue,
 	KnowledgeBaseGraphWatcher,
 	shouldIgnoreGraphWatchPath,
@@ -119,6 +120,56 @@ test("graph rebuild queue merges triggers into one pending rebuild while running
 	gates[1]?.resolve();
 	await queue.waitForIdle();
 	assert.deepEqual(calls, ["run", "run"]);
+});
+
+test("graph rebuild failure message is stable and does not expose build paths", () => {
+	assert.equal(
+		graphRebuildFailureMessage(new Error("spawn failed /Users/private/build.sh")),
+		"图谱重建失败",
+	);
+});
+test("graph rebuild queue recovers to started after a failed run", async () => {
+	let attempts = 0;
+	const errors: unknown[] = [];
+	const queue = new GraphRebuildQueue({
+		run: async () => {
+			attempts++;
+			if (attempts === 1) throw new Error("build failed");
+		},
+		onError: (err) => errors.push(err),
+	});
+
+	assert.equal(queue.trigger().status, "started");
+	await queue.waitForIdle();
+	assert.equal(errors.length, 1);
+	assert.equal(queue.trigger().status, "started");
+	await queue.waitForIdle();
+	assert.equal(attempts, 2);
+});
+
+test("graph rebuild queue runs a queued request after failure and then becomes idle", async () => {
+	const firstRun = deferred<void>();
+	let attempts = 0;
+	const errors: unknown[] = [];
+	const queue = new GraphRebuildQueue({
+		run: async () => {
+			attempts++;
+			if (attempts === 1) {
+				await firstRun.promise;
+				throw new Error("first build failed");
+			}
+		},
+		onError: (err) => errors.push(err),
+	});
+
+	assert.equal(queue.trigger().status, "started");
+	assert.equal(queue.trigger().status, "queued");
+	firstRun.resolve();
+	await queue.waitForIdle();
+	assert.equal(attempts, 2);
+	assert.equal(errors.length, 1);
+	assert.equal(queue.trigger().status, "started");
+	await queue.waitForIdle();
 });
 
 class FakeWatchSource {

--- a/workbench/server/src/graph.ts
+++ b/workbench/server/src/graph.ts
@@ -288,6 +288,11 @@ async function findRepoRoot(): Promise<string> {
 	throw new Error("Cannot locate repository root from server module path");
 }
 
+export function graphRebuildFailureMessage(_err: unknown): string {
+	return "图谱重建失败";
+}
+
+
 function emitGraphEvent(event: GraphEvent): void {
 	eventBus.emit("graph", event);
 }
@@ -314,7 +319,7 @@ function createDefaultRebuildQueue(kbPath: string): GraphRebuildQueue {
 			emitGraphEvent({
 				type: "graph_error",
 				kbPath,
-				message: err instanceof Error ? err.message : String(err),
+				message: graphRebuildFailureMessage(err),
 				rebuiltAt: new Date().toISOString(),
 			});
 		},

--- a/workbench/server/src/graph.ts
+++ b/workbench/server/src/graph.ts
@@ -316,6 +316,9 @@ function createDefaultRebuildQueue(kbPath: string): GraphRebuildQueue {
 			});
 		},
 		onError: (err) => {
+			console.warn(
+				`[graph] rebuild failed for ${kbPath}: ${err instanceof Error ? err.message : String(err)}`,
+			);
 			emitGraphEvent({
 				type: "graph_error",
 				kbPath,

--- a/workbench/server/src/index.ts
+++ b/workbench/server/src/index.ts
@@ -48,12 +48,8 @@ import {
 	resumeGraphWatcher,
 	subscribeGraphEvents,
 	suspendGraphWatcher,
-	triggerGraphRebuild,
 	watchKnowledgeBaseGraph,
 } from "./graph.js";
-import {
-	assertRegisteredKnowledgeBase,
-} from "./knowledge-bases.js";
 import { localHostOnly } from "./security/host.js";
 import { createSecurityMiddleware } from "./security/middleware.js";
 import {
@@ -81,22 +77,6 @@ const promptRuns = new PromptRunRegistry();
 function extractContextWindow(session: AgentSession): number | undefined {
 	const model = (session.state as { model?: { contextWindow?: unknown } }).model;
 	return typeof model?.contextWindow === "number" ? model.contextWindow : undefined;
-}
-
-function requestedKnowledgeBasePath(queryValue: string | undefined, body?: unknown): string | null {
-	if (queryValue?.trim()) return queryValue.trim();
-	if (body && typeof body === "object") {
-		const bodyPath = (body as { kbPath?: unknown }).kbPath;
-		if (typeof bodyPath === "string" && bodyPath.trim()) return bodyPath.trim();
-	}
-	return getActive()?.kb.path ?? null;
-}
-
-function errorStatus(err: unknown, fallback: 400 | 500 = 500): 400 | 403 | 500 {
-	const statusCode = (err as { statusCode?: unknown })?.statusCode;
-	if (statusCode === 403) return 403;
-	if (statusCode === 400) return 400;
-	return fallback;
 }
 
 // 本次启动生成本地 capability token（#166）。token 写入运行期文件，供同机可信
@@ -214,22 +194,6 @@ app.post("/api/knowledge-bases/init-existing", async (c) => {
 		return c.json(
 			{ ok: false, error: err instanceof Error ? err.message : String(err) },
 			400,
-		);
-	}
-});
-
-// ============= 图谱重建（指定知识库；未传时回退当前知识库） =============
-
-app.post("/api/graph/rebuild", async (c) => {
-	try {
-		const requestedPath = requestedKnowledgeBasePath(c.req.query("kb"));
-		if (!requestedPath) return c.json({ ok: false, error: "请先选择一个知识库" }, 400);
-		const kbPath = await assertRegisteredKnowledgeBase(requestedPath);
-		return c.json(triggerGraphRebuild(kbPath));
-	} catch (err) {
-		return c.json(
-			{ ok: false, error: err instanceof Error ? err.message : String(err) },
-			errorStatus(err),
 		);
 	}
 });

--- a/workbench/server/src/routes/graph.ts
+++ b/workbench/server/src/routes/graph.ts
@@ -4,8 +4,10 @@ import {
 	GraphLayoutDataSchema,
 	GraphLayoutWriteBodySchema,
 	GraphReadDataSchema,
+	GraphRebuildDataSchema,
 	type GraphLayoutData,
 	type GraphReadData,
+	type GraphRebuildData,
 } from "@llm-wiki/workbench-contracts";
 
 import { getActive } from "../agent.js";
@@ -21,6 +23,7 @@ import { jsonOk } from "../http/response.js";
 import {
 	readGraphData,
 	readGraphLayout,
+	triggerGraphRebuild,
 	writeGraphLayout,
 } from "../graph.js";
 import { assertRegisteredKnowledgeBase } from "../knowledge-bases.js";
@@ -28,6 +31,7 @@ import { assertRegisteredKnowledgeBase } from "../knowledge-bases.js";
 export interface GraphRouteService {
 	getActiveKnowledgeBasePath: () => string | null;
 	assertRegisteredKnowledgeBase: (kbPath: string) => Promise<string>;
+	triggerGraphRebuild: (kbPath: string) => GraphRebuildData;
 	readGraphData: (kbPath: string) => Promise<GraphReadData>;
 	readGraphLayout: (kbPath: string) => Promise<GraphLayoutData>;
 	writeGraphLayout: (
@@ -39,6 +43,10 @@ export interface GraphRouteService {
 export const defaultGraphRouteService: GraphRouteService = {
 	getActiveKnowledgeBasePath: () => getActive()?.kb.path ?? null,
 	assertRegisteredKnowledgeBase,
+	triggerGraphRebuild: (kbPath) => {
+		const result = triggerGraphRebuild(kbPath);
+		return GraphRebuildDataSchema.parse({ status: result.status });
+	},
 	readGraphData: async (kbPath) => {
 		const result = await readGraphData(kbPath);
 		return GraphReadDataSchema.parse(
@@ -69,6 +77,18 @@ export function createGraphRoutes(service: GraphRouteService): Hono {
 			return jsonOk(
 				c,
 				GraphReadDataSchema.parse(await service.readGraphData(kbPath)),
+			);
+		} catch (err) {
+			throw mapGraphError(err);
+		}
+	});
+
+	router.post("/graph/rebuild", async (c) => {
+		const kbPath = await resolveGraphKnowledgeBase(c.req.query("kb"), service);
+		try {
+			return jsonOk(
+				c,
+				GraphRebuildDataSchema.parse(service.triggerGraphRebuild(kbPath)),
 			);
 		} catch (err) {
 			throw mapGraphError(err);
@@ -133,6 +153,9 @@ function resolveGraphKnowledgeBase(
 function mapGraphError(err: unknown): HttpContractError {
 	if (err instanceof HttpContractError) return err;
 	const source = err as { code?: unknown; statusCode?: unknown };
+	if (source.code === "BUSY") {
+		return new HttpContractError("BUSY", "图谱正在重建");
+	}
 	if (source.code === "ENOENT") {
 		return new HttpContractError("NOT_FOUND", "图谱数据不存在");
 	}

--- a/workbench/web/src/lib/api.ts
+++ b/workbench/web/src/lib/api.ts
@@ -30,6 +30,7 @@ import {
 	getGraphData as getGraphDataMigrated,
 	getGraphLayout as getGraphLayoutMigrated,
 	putGraphLayout as putGraphLayoutMigrated,
+	rebuildGraph as rebuildGraphMigrated,
 } from "./api/graph";
 import {
 	listRefs as listRefsMigrated,
@@ -372,19 +373,12 @@ export function readPage(kbPath: string, relPath: string): Promise<string> {
 	return readPageMigrated(kbPath, relPath);
 }
 
-function kbQuery(kbPath: string): string {
-	return `kb=${encodeURIComponent(kbPath)}`;
-}
-
 export function getGraphData(kbPath: string): Promise<GraphApiResult> {
 	return getGraphDataMigrated(kbPath);
 }
 
-export async function rebuildGraph(kbPath: string): Promise<"started" | "queued"> {
-	const res = await fetch(`/api/graph/rebuild?${kbQuery(kbPath)}`, { method: "POST" });
-	const json = (await res.json()) as { ok: true; status: "started" | "queued" } | { ok: false; error?: string };
-	if (!res.ok || !json.ok) throw new Error(("error" in json && json.error) || `HTTP ${res.status}`);
-	return json.status;
+export function rebuildGraph(kbPath: string): Promise<"started" | "queued"> {
+	return rebuildGraphMigrated(kbPath);
 }
 
 export function getGraphLayout(kbPath: string): Promise<GraphLayoutApiResult> {

--- a/workbench/web/src/lib/api/graph.ts
+++ b/workbench/web/src/lib/api/graph.ts
@@ -1,6 +1,7 @@
 import {
 	GraphLayoutDataSchema,
 	GraphReadDataSchema,
+	GraphRebuildDataSchema,
 } from "@llm-wiki/workbench-contracts";
 import type { GraphData, GraphLayoutFile, PinMap } from "@llm-wiki/graph-engine";
 
@@ -15,6 +16,17 @@ export async function getGraphData(kbPath: string): Promise<GraphApiResult> {
 		responseSchema: GraphReadDataSchema,
 		query: { kb: kbPath },
 	})) as GraphApiResult;
+}
+
+export async function rebuildGraph(
+	kbPath: string,
+): Promise<"started" | "queued"> {
+	const data = await request("/api/graph/rebuild", {
+		responseSchema: GraphRebuildDataSchema,
+		method: "POST",
+		query: { kb: kbPath },
+	});
+	return data.status;
 }
 
 export async function getGraphLayout(

--- a/workbench/web/test/api.test.ts
+++ b/workbench/web/test/api.test.ts
@@ -20,7 +20,7 @@ describe("graph API helpers", () => {
 		const responses: unknown[] = [
 			{ ok: true, data: { needsBuild: true } },
 			{ ok: true, data: { version: 2, pins: {}, updatedAt: "" } },
-			{ ok: true, status: "started" },
+			{ ok: true, data: { status: "started" } },
 			{ ok: true, data: { version: 2, pins: {}, updatedAt: "" } },
 		];
 		globalThis.fetch = (async (input, init) => {
@@ -45,7 +45,7 @@ describe("graph API helpers", () => {
 			[
 				"/api/graph?kb=%2Ftmp%2FKnowledge+Base",
 				"/api/graph/layout?kb=%2Ftmp%2FKnowledge+Base",
-				"/api/graph/rebuild?kb=%2Ftmp%2FKnowledge%20Base",
+				"/api/graph/rebuild?kb=%2Ftmp%2FKnowledge+Base",
 				"/api/graph/layout",
 			],
 		);

--- a/workbench/web/test/graph-api.test.ts
+++ b/workbench/web/test/graph-api.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 
 import { ApiError, ContractMismatchError } from "../src/lib/api/client";
-import { getGraphData, getGraphLayout, putGraphLayout } from "../src/lib/api/graph";
+import { getGraphData, getGraphLayout, putGraphLayout, rebuildGraph } from "../src/lib/api/graph";
 
 function stubFetch(body: unknown, status = 200) {
 	const calls: Array<{ url: string; init?: RequestInit }> = [];
@@ -53,6 +53,27 @@ describe("graph API module", () => {
 			version: 2,
 			pins: { "wiki/topics/a.md": { x: 1, y: 2 } },
 		});
+	});
+
+	it("graph rebuild 通过 migrated JSON client 返回异步任务状态", async () => {
+		const calls = stubFetch({ ok: true, data: { status: "queued" } });
+		assert.equal(await rebuildGraph("/kb/registered"), "queued");
+		assert.equal(calls[0]?.url, "/api/graph/rebuild?kb=%2Fkb%2Fregistered");
+		assert.equal(calls[0]?.init?.method, "POST");
+	});
+
+	it("rebuild 透出 BUSY code，并拒绝旧响应格式", async () => {
+		stubFetch({ ok: false, code: "BUSY", message: "图谱正在重建" }, 409);
+		await assert.rejects(
+			() => rebuildGraph("/kb/registered"),
+			(err) => err instanceof ApiError && err.code === "BUSY",
+		);
+
+		stubFetch({ ok: true, status: "started" });
+		await assert.rejects(
+			() => rebuildGraph("/kb/registered"),
+			(err) => err instanceof ContractMismatchError,
+		);
 	});
 
 	it("统一错误透出 code，响应 schema mismatch 被拒绝", async () => {

--- a/workbench/web/test/graph-panel-paper.test.tsx
+++ b/workbench/web/test/graph-panel-paper.test.tsx
@@ -297,7 +297,7 @@ function mockGraphFetch(options: { needsBuild?: boolean } = {}) {
 			});
 			}
 		if (url.startsWith("/api/graph/rebuild")) {
-			return jsonResponse({ ok: true, status: "started" });
+			return jsonResponse({ ok: true, data: { status: "started" } });
 		}
 		return jsonResponse({ ok: false, error: `Unexpected request: ${url}` }, 500);
 	}) as typeof fetch;

--- a/workbench/web/test/visual/paper-ui.ts
+++ b/workbench/web/test/visual/paper-ui.ts
@@ -613,7 +613,7 @@ async function fulfillMockApi(route: Route, url: URL, method: string) {
 		return;
 	}
 	if (pathname === "/api/graph/rebuild") {
-		await json({ ok: true, status: "started" });
+		await json({ ok: true, data: { status: "started" } });
 		return;
 	}
 	await json({ ok: false, error: `Unhandled visual mock route: ${method} ${pathname}` }, 404);


### PR DESCRIPTION
## Summary

- migrate `POST /api/graph/rebuild` to the shared migrated JSON contract while retaining state-changing capability-token enforcement
- reuse registered knowledge-base context resolution and route the frontend through the typed graph API client
- preserve `started` / `queued` queue semantics, stable error envelopes, and redacted client-facing background failures
- retain real rebuild diagnostics in server logs without exposing local paths to clients
- align the compile-time contract guard documentation with the migrated endpoint

## Test Coverage

AI-assessed coverage: **84% (16/19 changed paths)**, above the 80% target. Covered contracts, route success/error behavior, queueing and recovery, typed client validation, and UI mocks. Remaining gaps are cross-layer browser E2E scenarios rather than uncovered core branches.

## Pre-Landing Review

Two informational findings were fixed:

- corrected the stale compile-time guard comment
- corrected the failure-response redaction test and preserved server-side diagnostics

Claude and Codex adversarial reviews found no remaining blocking issue. Codex structured review passed after the fixes.

## Design Review

Design Review (lite): no findings. The frontend change is limited to the typed API client and test mocks; no UI styling changed.

## Eval Results

No prompt-related files changed; evals skipped.

## Greptile Review

No Greptile comments.

## Scope Drift

Scope Check: **CLEAN**. Changes remain limited to the graph rebuild HTTP-contract migration and its tests.

## Plan Completion

No relevant plan file detected; completion audit skipped.

## Verification

- `npm run typecheck`
- `npm run lint -w @llm-wiki-agent/web`
- `npm run test -w @llm-wiki-agent/web`
- `npm run test -w @llm-wiki/graph-engine`
- `node --import tsx --test "workbench/server/src/**/*.test.ts"` (113 passed)
- `npm run build -w @llm-wiki-agent/server`
- `npm run build -w @llm-wiki-agent/web`
- `git diff --check`

The web production build completed with its existing chunk-size warning and no errors.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
