### PR TITLE
test: 修复 browser-main-flows 图谱失败旅程竞态

### DIFF
--- a/workbench/web/test/browser/browser-main-flows.test.ts
+++ b/workbench/web/test/browser/browser-main-flows.test.ts
@@ -149,6 +149,7 @@ test("seven browser main flows cross the real frontend and backend", { timeout: 
 		page = await context.newPage();
 		const apiRequests = new Set<string>();
 		let graphEventsSeen = false;
+		const graphEventReceipts: Array<{ type: string; kbPath?: string; seq: number }> = [];
 		page.on("request", (request) => {
 			const url = new URL(request.url());
 			if (url.pathname.startsWith("/api/")) apiRequests.add(url.pathname);
@@ -257,28 +258,64 @@ test("seven browser main flows cross the real frontend and backend", { timeout: 
 		await page.getByRole("tab", { name: "图谱" }).click();
 		await page.locator("[data-graph-status='ready']").waitFor({ timeout: START_TIMEOUT_MS });
 		await page.getByText("1 节点 · 0 关联", { exact: true }).waitFor();
-		const rebuildRequest = page.waitForRequest((request) => new URL(request.url()).pathname === "/api/graph/rebuild" && request.method() === "POST");
-		const rebuildClick = page.getByRole("button", { name: "重构" }).click();
-		await rebuildRequest;
-		const busyResponses = await page.evaluate((kbPath) => Promise.all([0, 1].map(() => fetch(`/api/graph/rebuild?kb=${encodeURIComponent(kbPath)}`, { method: "POST" }).then(async (response) => ({ status: response.status, body: await response.text() })))), kbA);
-		await rebuildClick;
+		await page.evaluate(() => {
+			const receipts: Array<{ type: string; kbPath?: string; seq: number }> = [];
+			const source = new EventSource("/api/events");
+			source.onmessage = (message) => receipts.push(JSON.parse(message.data));
+			Object.assign(window, { __graphEventReceipts: receipts });
+		});
+		await waitForGraphEvent(page, graphEventReceipts, (event) => event.type === "graph_stream_ready");
+		const firstResponsePromise = waitForGraphRebuildResponse(page, kbA);
+		await page.getByRole("button", { name: "重构" }).click();
+		assert.equal((await firstResponsePromise).status, "started");
+		const busyResponses = await page.evaluate((kbPath) => Promise.all([0, 1].map(() => fetch(`/api/graph/rebuild?kb=${encodeURIComponent(kbPath)}`, { method: "POST" }).then(async (response) => ({ status: response.status, body: await response.json() })))), kbA);
 		assert.equal(busyResponses.every((response) => response.status === 200), true);
-		assert.equal(busyResponses.some((response) => /queued/.test(response.body)), true);
+		assert.equal(busyResponses.some((response) => response.body.data.status === "queued"), true);
 		await assertBrowserJson(page, `/api/graph?kb=${encodeURIComponent(join(home, "missing-kb"))}`, 404, /知识库/);
-		await waitUntil(() => graphEventsSeen, OPERATION_TIMEOUT_MS, "browser did not open graph events");
 		await page.locator("[data-graph-status='ready']").waitFor({ timeout: START_TIMEOUT_MS });
+		await page.goto("about:blank");
+		await rm(serverNetworkProbe, { force: true });
+		server = await restartBackend(server, home, backendPort, kbB, serverNetworkProbe);
+		await waitForFile(serverNetworkProbe);
+		assert.equal(await readFile(serverNetworkProbe, "utf8"), "BLOCKED");
+		graphEventsSeen = false;
+		await page.goto(webOrigin, { waitUntil: "domcontentloaded", timeout: START_TIMEOUT_MS });
+		await page.getByLabel("当前知识库").getByText("atlas-notes").waitFor({ timeout: START_TIMEOUT_MS });
+		await page.getByRole("tab", { name: "图谱" }).click();
+		await page.locator("[data-graph-status='ready']").waitFor({ timeout: START_TIMEOUT_MS });
+		await page.evaluate(() => {
+			const receipts: Array<{ type: string; kbPath?: string; seq: number }> = [];
+			const source = new EventSource("/api/events");
+			source.onmessage = (message) => receipts.push(JSON.parse(message.data));
+			Object.assign(window, { __graphEventReceipts: receipts });
+		});
+		await waitForGraphEvent(page, graphEventReceipts, (event) => event.type === "graph_stream_ready");
 		const graphDataPath = join(kbA, "wiki", "graph-data.json");
 		const graphData = await readFile(graphDataPath, "utf8");
 		await rm(graphDataPath, { force: true });
 		await mkdir(graphDataPath);
 		try {
+			await refreshGraphEventReceipts(page, graphEventReceipts);
+			const failureBaseline = graphEventReceipts.length;
+			const failureResponsePromise = waitForGraphRebuildResponse(page, kbA);
 			await page.getByRole("button", { name: "重构" }).click();
+			assert.equal((await failureResponsePromise).status, "started");
+			await waitForGraphEvent(page, graphEventReceipts, (event, index) => (
+				index >= failureBaseline && event.type === "graph_error" && event.kbPath === kbA
+			));
 			await page.locator("[data-graph-status='error']").waitFor({ timeout: START_TIMEOUT_MS });
 		} finally {
 			await rm(graphDataPath, { recursive: true, force: true });
 			await writeFile(graphDataPath, graphData);
 		}
+		await refreshGraphEventReceipts(page, graphEventReceipts);
+		const recoveryBaseline = graphEventReceipts.length;
+		const recoveryResponsePromise = waitForGraphRebuildResponse(page, kbA);
 		await page.getByRole("button", { name: "重构" }).click();
+		assert.equal((await recoveryResponsePromise).status, "started");
+		await waitForGraphEvent(page, graphEventReceipts, (event, index) => (
+			index >= recoveryBaseline && event.type === "graph_updated" && event.kbPath === kbA
+		));
 		await page.locator("[data-graph-status='ready']").waitFor({ timeout: START_TIMEOUT_MS });
 
 		// Messages: normal send, duplicate while busy, cancellation, disconnect recovery, and failure recovery.
@@ -409,6 +446,39 @@ async function createArtifacts(appDir: string, conversationId: string, kbPath: s
 			primaryFile: artifact.primaryFile,
 		}, null, 2)}\n`);
 	}
+}
+
+async function waitForGraphRebuildResponse(page: Page, kbPath: string): Promise<{ status: "started" | "queued" }> {
+	const response = await page.waitForResponse((candidate) => {
+		const request = candidate.request();
+		const url = new URL(candidate.url());
+		return url.pathname === "/api/graph/rebuild"
+			&& url.searchParams.get("kb") === kbPath
+			&& request.method() === "POST";
+	});
+	assert.equal(response.status(), 200);
+	const body = await response.json() as { data: { status: "started" | "queued" } };
+	return body.data;
+}
+
+async function refreshGraphEventReceipts(
+	page: Page,
+	receipts: Array<{ type: string; kbPath?: string; seq: number }>,
+): Promise<void> {
+	receipts.splice(0, receipts.length, ...await page.evaluate(() => (
+		(window as typeof window & { __graphEventReceipts?: Array<{ type: string; kbPath?: string; seq: number }> }).__graphEventReceipts ?? []
+	)));
+}
+
+async function waitForGraphEvent(
+	page: Page,
+	receipts: Array<{ type: string; kbPath?: string; seq: number }>,
+	predicate: (event: { type: string; kbPath?: string; seq: number }, index: number) => boolean,
+): Promise<void> {
+	await waitUntil(async () => {
+		await refreshGraphEventReceipts(page, receipts);
+		return receipts.some(predicate);
+	}, OPERATION_TIMEOUT_MS, "expected graph event did not arrive");
 }
 
 async function sendComposerMessage(page: Page, message: string): Promise<void> {


### PR DESCRIPTION
## Summary

- 用测试专用 SSE 收据明确等待 `graph_stream_ready`，不再把“已发起 `/api/events` 请求”误当成订阅已就绪
- 将每次图谱重建点击绑定到同一知识库的 `/api/graph/rebuild` response，并明确断言失败注入与恢复 operation 都是 `started`
- busy/queued 场景完成后关闭旧页面并重启后端；旧 server 实际退出且图谱子进程组终止后才启动新实例，从物理上隔离旧 queue 与失败注入阶段
- 失败与恢复分别从刷新后的 SSE baseline 观察新的 `graph_error` / `graph_updated`，同时验证 DOM `error -> ready`
- 重启实例使用新鲜网络守卫探针并重新断言 `BLOCKED`

## Root cause

原测试在制造 busy/queued rebuild 后，只等待 UI 再次显示 `ready`。`ready` 只代表某次 `graph_updated` 后前端读取成功，不代表服务端 queue 已 idle。随后错误点击可能返回 `queued`，瞬时 `graph_error` 也可能被旧 operation 的后继 `graph_updated` 清除，因此测试会在无产品回归时超时。

本修复不改产品 API 或状态模型。SSE 断线重连缺少状态校准已作为独立 FIND-022 登记到 #193；既有重启复用陈旧网络探针已作为 FIND-023 登记，不在本 PR 顺手全面修复。

## Verification

针对最终实现和同一逻辑提交：

- `npm run test:browser:main-flows -w @llm-wiki-agent/web` 连续运行 10 次：**10/10 PASS**，所有结果均保留，无选择性丢弃失败
- `npm run typecheck`：PASS
- `npm run quality-and-tests`：PASS，759 tests / 0 failures
- `npm run test:browser:main-flows -w @llm-wiki-agent/web` 最终独立运行：PASS
- 双轴代码审查：Standards 0 findings；Spec 初审发现的 response 错绑和 stale baseline 均已修复
- shutdown 隔离专项复核：确认旧 server 退出及 graph child 进程组终止构成严格隔离屏障
- 最终提交独立复审：0 P1/P2 findings
- diff：仅 `workbench/web/test/browser/browser-main-flows.test.ts`，不含 #196 审计文档或其他无关改动

## After merge

本 PR 保持未合并，等待用户手动合并。合并后再：

1. 回到 `codex/chore-196-main-protection`
2. merge 最新 `origin/main` 并 push
3. 等待 PR #228 最新 SHA 的 `quality-and-tests` 与 `browser-main-flows` 都通过
4. 由用户手动合并 PR #228
5. PR #228 合并后执行 #167，分支 `codex/fix-167-method-path-contract`

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
