### PR TITLE
fix: make graph/lint usable on large wikis (ARG_MAX, missing graph engine, lint scope)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,7 @@ MANAGED_ITEMS=(
   "templates"
   "deps"
   "platforms"
+  "packages/graph-engine/dist"
 )
 
 DEP_SKILLS=()
@@ -218,6 +219,7 @@ copy_item() {
   fi
 
   rm -rf "$target_path"
+  mkdir -p "$(dirname "$target_path")"
   cp -R "$source_path" "$target_path"
 }
 
@@ -283,9 +285,39 @@ install_companion_skills() {
   done < <(list_companion_skill_sources "$platform")
 }
 
+# build-graph-html.sh needs packages/graph-engine/dist/engine.iife.js, but the
+# engine is not committed -- so a fresh clone could not build the interactive
+# graph at all. Build it here if it is missing.
+ensure_graph_engine() {
+  local engine="$SCRIPT_DIR/packages/graph-engine/dist/engine.iife.js"
+
+  [ -f "$engine" ] && return 0
+  [ "$DRY_RUN" -eq 1 ] && { printf '[dry-run] build graph-engine\n'; return 0; }
+
+  if ! command -v npm >/dev/null 2>&1 || ! command -v node >/dev/null 2>&1; then
+    warn "未找到 node/npm：跳过图谱引擎构建。"
+    warn "  交互式图谱（build-graph-html.sh）将无法使用；其余功能不受影响。"
+    warn "  安装 node 后重跑本脚本即可补上。"
+    return 0
+  fi
+
+  printf '正在构建图谱引擎（首次安装需要，约需 1 分钟）...\n'
+  if ( cd "$SCRIPT_DIR" \
+        && npm install --silent --no-audit --no-fund >/dev/null 2>&1 \
+        && npm run build -w @llm-wiki/graph-engine >/dev/null 2>&1 ) \
+     && [ -f "$engine" ]; then
+    ok "图谱引擎已构建"
+  else
+    warn "图谱引擎构建失败：交互式图谱将无法使用，其余功能不受影响"
+    warn "  可手动重试：npm install && npm run build -w @llm-wiki/graph-engine"
+  fi
+}
+
 install_bundle() {
   local target_dir="$1"
   local item source_path target_path
+
+  ensure_graph_engine
 
   for item in "${MANAGED_ITEMS[@]}"; do
     source_path="$SCRIPT_DIR/$item"

--- a/scripts/build-graph-data.sh
+++ b/scripts/build-graph-data.sh
@@ -327,9 +327,10 @@ else
 fi
 
 INITIAL_VIEW=$(jq \
-  --argjson nodes "$(cat "$TMPDIR/nodes.sorted.json")" \
+  --slurpfile nodes_f "$TMPDIR/nodes.sorted.json" \
   '
-  . as $edges
+  ($nodes_f[0]) as $nodes
+  | . as $edges
   | (
       reduce $edges[] as $e (
         {};
@@ -356,16 +357,19 @@ INSIGHTS_DEGRADED=$(jq '.insights.meta.degraded == true' "$ANALYSIS_JSON")
 mkdir -p "$(dirname "$OUTPUT")"
 OUTPUT_TMP="$TMPDIR/graph-data.final.json"
 
+jq '.insights' "$ANALYSIS_JSON" > "$TMPDIR/insights.json"
+jq '.learning' "$ANALYSIS_JSON" > "$TMPDIR/learning.json"
+
 jq -n \
   --arg build_date "$BUILD_DATE" \
   --arg wiki_title "$WIKI_TITLE" \
   --argjson total_nodes "$NODE_COUNT" \
   --argjson total_edges "$EDGE_COUNT" \
   --argjson initial_view "$INITIAL_VIEW" \
-  --argjson nodes "$(cat "$TMPDIR/nodes.sorted.json")" \
-  --argjson edges "$(cat "$TMPDIR/edges.sorted.json")" \
-  --argjson insights "$(jq '.insights' "$ANALYSIS_JSON")" \
-  --argjson learning "$(jq '.learning' "$ANALYSIS_JSON")" \
+  --slurpfile nodes_f "$TMPDIR/nodes.sorted.json" \
+  --slurpfile edges_f "$TMPDIR/edges.sorted.json" \
+  --slurpfile insights_f "$TMPDIR/insights.json" \
+  --slurpfile learning_f "$TMPDIR/learning.json" \
   --argjson degraded "$DEGRADE" \
   --argjson insights_degraded "$INSIGHTS_DEGRADED" \
   '{
@@ -378,10 +382,10 @@ jq -n \
       degraded: ($degraded == 1),
       insights_degraded: $insights_degraded
     },
-    nodes: $nodes,
-    edges: $edges,
-    insights: $insights,
-    learning: $learning
+    nodes: $nodes_f[0],
+    edges: $edges_f[0],
+    insights: $insights_f[0],
+    learning: $learning_f[0]
   }' > "$OUTPUT_TMP"
 
 mv "$OUTPUT_TMP" "$OUTPUT"

--- a/scripts/lint-runner.sh
+++ b/scripts/lint-runner.sh
@@ -54,7 +54,7 @@ echo ""
 # 定义：wiki/ 下的页面里有 [[X]] 链接（支持 [[X|别名]] 语法），但 wiki/ 任意子目录找不到 X.md
 echo "--- 断链（被链接但不存在的页面） ---"
 _TMP_BROKEN=$(mktemp)
-grep -rohE "\[\[[^]]+\]\]" "$WIKI_DIR" 2>/dev/null | \
+grep -rohE --include='*.md' "\[\[[^]]+\]\]" "$WIKI_DIR" 2>/dev/null | \
   sed -e 's/\[\[//g' -e 's/\]\]//g' -e 's/|.*//' | \
   sort -u | \
   while read -r LINK; do


### PR DESCRIPTION
## 问题

在一个 **449 节点 / 10,296 条关联**的知识库（325 篇 source 页 + 106 个实体页）上，`graph` 与 `lint` 两个工作流**完全不可用** —— 不是变慢，是直接失败。三个 bug 各自独立，每个 commit 可单独 cherry-pick。

环境：macOS 15，jq 1.7.1，node 25。

### 1. `build-graph-data.sh` 撞破 ARG_MAX → 图谱完全建不出来

```
jq: Argument list too long
```

脚本把**整份 nodes/edges JSON 当成 argv 参数**传给 jq：

```bash
--argjson nodes "$(cat "$TMPDIR/nodes.sorted.json")"
```

知识库到几百页时这串就超过 `ARG_MAX`，图谱构建直接死。

**修法**：改用 `--slurpfile` 从文件读，不让大 JSON 经过 argv。
（`--argfile` 本来最合适，但 jq 1.7 已移除。）

### 2. `install.sh` 不安装 graph engine → 交互式图谱建不出来

```
ERROR: 找不到graph-engine IIFE 产物 .../packages/graph-engine/dist/engine.iife.js
```

`build-graph-html.sh` 需要 `engine.iife.js`，但它是构建产物、未进版本控制，而 `install.sh` 既不构建也不复制它。**全新 clone 根本做不出交互式图谱。**

旁证：`tests/graph-build-failures.regression-1.sh` 在**全新 clone 上就会失败**（它 `rm` 这个并不存在的文件）—— 测试本身已假设该产物存在，但仓库里没有任何东西会生成它。本 PR 修好后该测试通过。

**修法**：`install.sh` 在产物缺失时自动构建，并把 `packages/graph-engine/dist` 加入 `MANAGED_ITEMS`。
无 node/npm 时**优雅降级** —— 核心知识库照常安装，仅交互式图谱不可用。

### 3. `lint-runner.sh` 报幻影断链

```
断链: [[^[\]]
断链: [[^\]]
```

断链检查 grep 了 `wiki/` 下**所有文件**，包括生成的 `knowledge-graph.html` —— 其中内嵌的压缩版 marked.js，正则字面量含有 `[[` 序列。**只要跑过 graph 工作流，lint 就开始说谎。**

**修法**：把 grep 限定在 `*.md`（孤立页检查本来就是这么做的）。

> `'*.md'` 的**引号是必需的**：该脚本设了 `shopt -s nullglob`，未加引号的 `--include=*.md` 会被 glob 展开成空、整个参数消失，过滤器静默失效。

## 验证

从**干净的 clone**（无 `node_modules`、无 `dist`）安装到全新 skill 目录，再对真实的 449 节点知识库实跑：

| | 修补前 | 修补后 |
|---|---|---|
| `build-graph-data.sh` | `jq: Argument list too long` | ✅ 449 节点 · 10,296 关联 |
| `build-graph-html.sh` | `ERROR: 找不到 engine.iife.js` | ✅ 产出离线 HTML |
| `lint-runner.sh` | 2 个幻影断链 | ✅ 无断链 |

相关回归测试全部通过：

```
PASS  lint-output
PASS  graph-build-failures      (构建 engine 后；见上文 #2)
PASS  graph-data-source-paths
PASS  graph-analysis-helper
PASS  graph-data-confidence-merge
```

### 已知的既有失败（与本 PR 无关）

`tests/regression.sh` 会在 `Expected AGENTS.md to contain: --with-optional-adapters` 处中止。该失败在**未修改的上游 `main`（bc35bcb）上同样出现**，已单独确认。由于该套件遇错即停，它跑不到后面的 graph 测试 —— 所以上面的图谱/lint 测试是单独执行的。

## 备注

三个 commit 互相独立、可分开 cherry-pick。若只想合一个，建议先合 **#1（ARG_MAX）** —— 它是唯一让功能**完全不能用**的 bug，另两个只是体验问题。

感谢这个 skill，用起来很顺手 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
