### PR TITLE
fix(upgrade): /llm-wiki-upgrade 自适应探测 project/vault 级安装 #263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.6.73 (2026-07-16)
+
+### 修复
+
+- `/llm-wiki-upgrade` 现在自适应探测 llm-wiki 的实际安装目录：优先用 `CLAUDE_PROJECT_DIR`，再从当前工作目录逐级向上查找最近的 `.claude/skills/llm-wiki`，最后回退 user 级 `$HOME`，并把探测到的路径作为 `install.sh --upgrade --target-dir` 传入；装在 project/vault 级（如 Obsidian 仓库、团队共享仓库）时不再静默升级到 `$HOME` 那份。`CLAUDE_PROJECT_DIR` 为空或 project 级无副本时回退 `$HOME`，user 级行为保持不变。
+
 ## v3.6.72 (2026-07-15)
 
 ### 修复

--- a/platforms/claude/companions/llm-wiki-upgrade/SKILL.md
+++ b/platforms/claude/companions/llm-wiki-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-wiki-upgrade
-version: 1.1.0
+version: 1.1.1
 description: |
   升级 llm-wiki 到最新版本。从 GitHub 拉取最新代码并通过官方 install.sh 升级核心主线。
   网页、X、微信公众号、YouTube、知乎自动提取依赖默认不刷新；需要时再显式开启。
@@ -16,15 +16,37 @@ allowed-tools:
 
 ## 升级流程
 
-### Step 1：读取当前版本
+### Step 1：探测实际安装目录并读取当前版本
+
+llm-wiki 可能装在 user 级（`$HOME/.claude/skills/llm-wiki`）或 project/vault 级（`<项目根>/.claude/skills/llm-wiki`，如 Obsidian 仓库、团队共享仓库）。这里自适应探测真实路径，后续所有步骤都基于它。`CLAUDE_PROJECT_DIR` 在 agent 的 Bash 工具里通常为空，所以用「从当前工作目录逐级向上查找」兜底，找不到再回退 user 级。
 
 ```bash
-SKILL_DIR="$HOME/.claude/skills/llm-wiki"
+SKILL_DIR=""
+# 1) Claude Code 注入的项目根（hooks/MCP 等场景）优先
+if [ -n "$CLAUDE_PROJECT_DIR" ] && [ -f "$CLAUDE_PROJECT_DIR/.claude/skills/llm-wiki/CHANGELOG.md" ]; then
+  SKILL_DIR="$CLAUDE_PROJECT_DIR/.claude/skills/llm-wiki"
+fi
+# 2) 从当前工作目录逐级向上查找最近的 .claude/skills/llm-wiki（覆盖会话在 vault 子目录的场景）
+if [ -z "$SKILL_DIR" ]; then
+  _d="$PWD"
+  while [ "$_d" != "/" ]; do
+    if [ -f "$_d/.claude/skills/llm-wiki/CHANGELOG.md" ]; then
+      SKILL_DIR="$_d/.claude/skills/llm-wiki"
+      break
+    fi
+    _d="$(dirname "$_d")"
+  done
+fi
+# 3) 回退 user 级
+if [ -z "$SKILL_DIR" ] && [ -f "$HOME/.claude/skills/llm-wiki/CHANGELOG.md" ]; then
+  SKILL_DIR="$HOME/.claude/skills/llm-wiki"
+fi
 OLD_VERSION=$(grep -m1 "^## v" "$SKILL_DIR/CHANGELOG.md" 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
 echo "CURRENT_VERSION=$OLD_VERSION"
+echo "SKILL_DIR=$SKILL_DIR"
 ```
 
-如果 `SKILL_DIR` 不存在，告知用户尚未安装 llm-wiki，停止流程。
+如果 `SKILL_DIR` 为空（三个候选都没找到带 `CHANGELOG.md` 的 llm-wiki），告知用户尚未安装 llm-wiki，停止流程。
 
 ### Step 2：Clone 最新版本到临时目录
 
@@ -56,7 +78,7 @@ rm -rf "$TMP_DIR"
 注意：默认升级只更新知识库核心主线，不主动刷新网页、X、微信公众号、YouTube、知乎自动提取所需的可选依赖。
 
 ```bash
-bash "$TMP_DIR/llm-wiki-skill/install.sh" --upgrade --platform claude 2>&1
+bash "$TMP_DIR/llm-wiki-skill/install.sh" --upgrade --target-dir "$SKILL_DIR" --platform claude 2>&1
 echo "UPGRADE_EXIT=$?"
 ```
 
@@ -70,7 +92,7 @@ rm -rf "$TMP_DIR"
 
 ### Step 6：展示更新内容
 
-读取 `$HOME/.claude/skills/llm-wiki/CHANGELOG.md`，提取 `OLD_VERSION` 到 `NEW_VERSION` 之间的变更，提炼 3-5 条用户最关心的变化。
+读取 `$SKILL_DIR/CHANGELOG.md`，提取 `OLD_VERSION` 到 `NEW_VERSION` 之间的变更，提炼 3-5 条用户最关心的变化。
 
 如果新版包含“默认只装核心主线 / 可选提取器显式开启”这类变化，要明确告诉用户：
 
@@ -78,7 +100,7 @@ rm -rf "$TMP_DIR"
 - 如果用户需要这些自动提取能力，可以继续执行：
 
 ```bash
-bash "$HOME/.claude/skills/llm-wiki/install.sh" --upgrade --platform claude --with-optional-adapters
+bash "$SKILL_DIR/install.sh" --upgrade --target-dir "$SKILL_DIR" --platform claude --with-optional-adapters
 ```
 
 输出格式：


### PR DESCRIPTION
Refs #263

## 问题

`/llm-wiki-upgrade` companion 假设 user 级 `\$HOME/.claude/skills/llm-wiki`。装在 project/vault 级（Obsidian vault、团队共享仓库）时静默失效：
- Step 1 `SKILL_DIR="\$HOME/.claude/skills/llm-wiki"` → 目录不存在 → 判定"未安装"直接停。
- Step 4 `install.sh --upgrade --platform claude` 不带 `--target-dir` → 解析回 `\$HOME` 那份，project 版永不升级。
- Step 6 读 changelog / optional-adapters 提示也走 `\$HOME`。

## ⚠️ 先验证了 CLAUDE_PROJECT_DIR（issue patch 的命门）

issue 给的 patch 用 `CLAUDE_PROJECT_DIR` 探测 project 级目录。**实测该变量在 agent 的 Bash 工具环境里为空**（真实 CC 会话 `CLAUDECODE=1` 下 `CLAUDE_PROJECT_DIR=`），与官方文档把它限定在 hooks / MCP / LSP 一致（且有 plugin 场景传播 bug #9447）。skill 的 bash 片段正是跑在这个 Bash 工具里的，所以 issue 的 patch 照搬过来 project/vault 用户仍会落回 `\$HOME`，bug 没真正修掉。

经用户拍板，改用**不依赖单一环境变量**的探测方案。

## 改动（只动 companion 一个文件）

`platforms/claude/companions/llm-wiki-upgrade/SKILL.md`，三处自适应 + 版本号：
- **Step 1** 探测真实 `SKILL_DIR`（存在性以 `CHANGELOG.md` 为准），三候选按优先级：
  1. `\$CLAUDE_PROJECT_DIR/.claude/skills/llm-wiki`（有值时；hooks/MCP 场景仍能用）
  2. 从 `\$PWD` 逐级向上查找最近的 `.claude/skills/llm-wiki`（覆盖会话 cwd 在 vault 子目录的场景）
  3. 回退 `\$HOME/.claude/skills/llm-wiki`
- **Step 4** + **Step 6** 两个 `install.sh --upgrade` 调用都加 `--target-dir "\$SKILL_DIR"`；所有命令路径里 `\$HOME/.claude/skills/llm-wiki` 换成 `\$SKILL_DIR`。
- frontmatter `version: 1.1.0 → 1.1.1`。

**硬约束满足**：`CLAUDE_PROJECT_DIR` 无值且 project 级无副本时回退 `\$HOME`，user 级行为零变化。不动 `install.sh`（L602 起已支持 `--target-dir`），不动其它平台 companion。

## 端到端验证（11/0 全过）

抽取 SKILL.md 里逐字一致的 Step 1 探测块，构造临时环境实跑：

| 场景 | 结果 |
|---|---|
| A user 级回退（`CLAUDE_PROJECT_DIR` 空，PWD 在 /tmp 不在 \$HOME 树下）→ 候选3 | ✅ 落 `\$HOME` 版 |
| B 向上查找（会话在 vault 子目录，`CLAUDE_PROJECT_DIR` 空） | ✅ 找到 vault 根 project 副本，读其 v9.9.9 而非 \$HOME |
| B' `CLAUDE_PROJECT_DIR` 注入（PWD 在别处） | ✅ 候选1 生效，v8.8.8 |
| C 优先级 `CLAUDE_PROJECT_DIR` > 向上查找 | ✅ 候选1 胜出，v7.7.7 |
| D 三候选皆无（含 \$HOME 也无） | ✅ `SKILL_DIR` 空 → "尚未安装"停止 |
| install.sh `--target-dir` 接线（`--dry-run` 零写入） | ✅ 目标路由到 project 目录，不回退 \$HOME |

## skill-maintenance 检查

- `bash install.sh --dry-run --platform codex` → exit 0 ✅
- `bash install.sh --dry-run --platform claude` → exit 0 ✅
- `grep -r '本机用户路径\|真实姓名\|私有素材路径' scripts/ templates/ tests/ SKILL.md` → 无命中 ✅
- 隐私自查（本机绝对路径 / 真实姓名）→ 改动文件与文档入口均无泄漏 ✅

## 文档

- CHANGELOG 顶部加 v3.6.73 fix 条目。
- README 未改：其升级说明未涉及 project/vault 级（按"否则不动"）；如需在 README 升级段补一句"支持 project/vault 级自动探测"，可后续追加。

## Git

- 分支 `fix/263-upgrade-project-target-dir`，两个 commit：实现（含 companion 1.1.1）/ 文档（CHANGELOG）。
- 不主动合并，等人工 review。如方案（向上查找兜底）可接受，合并即修复 #263。