### PR TITLE
test(graph): 固定特殊社区名称的防回退检查

### DIFF
--- a/packages/graph-engine/test/initial-layout.test.ts
+++ b/packages/graph-engine/test/initial-layout.test.ts
@@ -4,6 +4,53 @@ import { describe, it } from "node:test";
 import { buildAtlasModel, deriveAtlasLayout } from "../src";
 
 describe("initial graph layout", () => {
+  it("lays out nodes in object-prototype communities without merging them", () => {
+    const communityIds = ["ordinary", "__proto__", "constructor", "toString"] as const;
+    const controlCommunityIds = [
+      "control-ordinary",
+      "control-proto",
+      "control-constructor",
+      "control-to-string"
+    ] as const;
+    const layoutFor = (ids: readonly string[], prefix: string) => deriveAtlasLayout(buildAtlasModel({
+      nodes: ids.map((community, index) => ({
+        id: `${prefix}-${index}`,
+        label: `Node ${index + 1}`,
+        type: "topic",
+        community
+      })),
+      edges: [],
+      learning: {
+        communities: ids.map((id, index) => ({
+          id,
+          label: `Community ${index + 1}`,
+          node_count: 1,
+          is_primary: index === 0
+        }))
+      }
+    }));
+    const layout = layoutFor(communityIds, "special");
+    const controlLayout = layoutFor(controlCommunityIds, "control");
+
+    for (const [index, communityId] of communityIds.entries()) {
+      const nodeId = `special-${index}`;
+      assert.deepEqual(
+        layout.nodes.filter((node) => node.community === communityId).map((node) => node.id),
+        [nodeId]
+      );
+      assert.deepEqual(
+        layout.nodePositions[nodeId],
+        controlLayout.nodePositions[`control-${index}`],
+        `community ${communityId} should keep the same layout slot as a non-reserved id`
+      );
+    }
+    assert.equal(
+      new Set(communityIds.map((_, index) => JSON.stringify(layout.nodePositions[`special-${index}`]))).size,
+      communityIds.length,
+      "each one-node community should occupy its own layout center"
+    );
+  });
+
   it("returns the legacy shape and world bounds without changing the typed model", () => {
     const model = buildAtlasModel({
       nodes: [

--- a/packages/graph-engine/test/renderer-lifecycle.test.ts
+++ b/packages/graph-engine/test/renderer-lifecycle.test.ts
@@ -2,7 +2,16 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import GraphologyGraph from "graphology";
 
-import { createGraphEngine, projectGraphInput, type GraphData, type GraphDiff, type GraphVisibilityState, type SelectionInput } from "../src";
+import {
+  buildAtlasModel,
+  createGraphEngine,
+  deriveAtlasLayout,
+  projectGraphInput,
+  type GraphData,
+  type GraphDiff,
+  type GraphVisibilityState,
+  type SelectionInput
+} from "../src";
 import type {
   SigmaGlobalGraphologyGraph,
   SigmaGlobalRendererRuntime,
@@ -661,6 +670,100 @@ describe("graph renderer lifecycle", () => {
     assert.equal(engine.summarizeGlobal().nodeCount, 2001);
 
     engine.destroy();
+  });
+
+  it("keeps object-prototype community ids distinct through the public engine", () => {
+    const communityIds = ["ordinary", "__proto__", "constructor", "toString"] as const;
+    const data = {
+      nodes: communityIds.map((community, index) => ({
+        id: `node-${community}`,
+        label: `Node ${index + 1}`,
+        type: "topic" as const,
+        community
+      })),
+      edges: [],
+      learning: {
+        communities: communityIds.map((id, index) => ({
+          id,
+          label: `${String.fromCharCode(65 + index)} Community`,
+          node_count: 1,
+          is_primary: index === 0
+        }))
+      }
+    };
+    const model = buildAtlasModel(data);
+
+    assert.deepEqual(model.communities.map((community) => community.id), communityIds);
+    const layout = deriveAtlasLayout(model);
+    for (const communityId of communityIds) {
+      const nodeId = `node-${communityId}`;
+      assert.equal(Object.hasOwn(model.communityById, communityId), true);
+      assert.equal(model.communityById[communityId]?.id, communityId);
+      assert.deepEqual(
+        model.nodes.filter((node) => node.community === communityId).map((node) => node.id),
+        [nodeId]
+      );
+      assert.deepEqual(
+        layout.nodes.filter((node) => node.community === communityId).map((node) => node.id),
+        [nodeId]
+      );
+      const position = layout.nodePositions[nodeId];
+      assert.ok(position);
+    }
+
+    const ownerDocument = new FakeDocument();
+    const container = ownerDocument.createElement("div");
+    const engine = createGraphEngine(container as unknown as HTMLElement, { data });
+    try {
+      for (const communityId of communityIds) {
+        const nodeId = `node-${communityId}`;
+        engine.select({ kind: "community", id: communityId });
+        const summary = engine.summarizeCommunity(communityId);
+        assert.equal(summary.kind, "community-summary");
+        if (summary.kind === "community-summary") {
+          assert.equal(summary.communityId, communityId);
+          assert.equal(summary.nodeCount, 1);
+          assert.deepEqual(summary.coreNodeIds, [nodeId]);
+          assert.deepEqual(summary.selection.selectedCommunityIds, [communityId]);
+          assert.deepEqual(summary.selection.selectedNodeIds, [nodeId]);
+          assert.equal(summary.selection.containsCurrentObject, true);
+        }
+        const focus = engine.focusCommunity(communityId);
+        assert.deepEqual(focus.communityIds, [communityId]);
+        assert.deepEqual(focus.nodeIds, [nodeId]);
+        assert.equal(engine.sourceCommunityId, communityId);
+        engine.resetView();
+        assert.equal(engine.sourceCommunityId, null);
+      }
+    } finally {
+      engine.destroy();
+    }
+  });
+
+  it("derives object-prototype communities from node membership without metadata", () => {
+    const communityIds = ["ordinary", "__proto__", "constructor", "toString"] as const;
+    const data = {
+      nodes: communityIds.flatMap((community) => ["a", "b"].map((suffix) => ({
+        id: `node-${community}-${suffix}`,
+        label: `Node ${suffix}`,
+        type: "topic" as const,
+        community
+      }))),
+      edges: []
+    };
+    const model = buildAtlasModel(data);
+
+    assert.deepEqual(
+      model.communities.map((community) => community.id).sort(),
+      [...communityIds].sort()
+    );
+    for (const communityId of communityIds) {
+      assert.equal(model.communityById[communityId]?.node_count, 2);
+      assert.deepEqual(
+        model.nodes.filter((node) => node.community === communityId).map((node) => node.id),
+        [`node-${communityId}-a`, `node-${communityId}-b`]
+      );
+    }
   });
 
   it("renders a static over-limit notice without aggregation containers or DOM full graph", () => {

--- a/packages/graph-engine/test/renderer-lifecycle.test.ts
+++ b/packages/graph-engine/test/renderer-lifecycle.test.ts
@@ -3,9 +3,7 @@ import assert from "node:assert/strict";
 import GraphologyGraph from "graphology";
 
 import {
-  buildAtlasModel,
   createGraphEngine,
-  deriveAtlasLayout,
   projectGraphInput,
   type GraphData,
   type GraphDiff,
@@ -672,56 +670,22 @@ describe("graph renderer lifecycle", () => {
     engine.destroy();
   });
 
-  it("keeps object-prototype community ids distinct through the public engine", () => {
-    const communityIds = ["ordinary", "__proto__", "constructor", "toString"] as const;
-    const data = {
-      nodes: communityIds.map((community, index) => ({
-        id: `node-${community}`,
-        label: `Node ${index + 1}`,
-        type: "topic" as const,
-        community
-      })),
-      edges: [],
-      learning: {
-        communities: communityIds.map((id, index) => ({
-          id,
-          label: `${String.fromCharCode(65 + index)} Community`,
-          node_count: 1,
-          is_primary: index === 0
-        }))
-      }
-    };
-    const model = buildAtlasModel(data);
-
-    assert.deepEqual(model.communities.map((community) => community.id), communityIds);
-    const layout = deriveAtlasLayout(model);
-    for (const communityId of communityIds) {
-      const nodeId = `node-${communityId}`;
-      assert.equal(Object.hasOwn(model.communityById, communityId), true);
-      assert.equal(model.communityById[communityId]?.id, communityId);
-      assert.deepEqual(
-        model.nodes.filter((node) => node.community === communityId).map((node) => node.id),
-        [nodeId]
-      );
-      assert.deepEqual(
-        layout.nodes.filter((node) => node.community === communityId).map((node) => node.id),
-        [nodeId]
-      );
-      const position = layout.nodePositions[nodeId];
-      assert.ok(position);
-    }
+  it("handles object-prototype community ids through the public engine", () => {
+    const communityIds = OBJECT_PROTOTYPE_COMMUNITY_IDS;
+    const data = objectPrototypeCommunityInput();
 
     const ownerDocument = new FakeDocument();
     const container = ownerDocument.createElement("div");
-    const engine = createGraphEngine(container as unknown as HTMLElement, { data });
+    const engine = createGraphEngine(container as unknown as HTMLElement, { data, theme: "shan-shui" });
     try {
-      for (const communityId of communityIds) {
+      for (const [index, communityId] of communityIds.entries()) {
         const nodeId = `node-${communityId}`;
         engine.select({ kind: "community", id: communityId });
         const summary = engine.summarizeCommunity(communityId);
         assert.equal(summary.kind, "community-summary");
         if (summary.kind === "community-summary") {
           assert.equal(summary.communityId, communityId);
+          assert.equal(summary.label, `${String.fromCharCode(65 + index)} Community`);
           assert.equal(summary.nodeCount, 1);
           assert.deepEqual(summary.coreNodeIds, [nodeId]);
           assert.deepEqual(summary.selection.selectedCommunityIds, [communityId]);
@@ -740,29 +704,65 @@ describe("graph renderer lifecycle", () => {
     }
   });
 
-  it("derives object-prototype communities from node membership without metadata", () => {
-    const communityIds = ["ordinary", "__proto__", "constructor", "toString"] as const;
-    const data = {
-      nodes: communityIds.flatMap((community) => ["a", "b"].map((suffix) => ({
-        id: `node-${community}-${suffix}`,
-        label: `Node ${suffix}`,
-        type: "topic" as const,
-        community
-      }))),
-      edges: []
-    };
-    const model = buildAtlasModel(data);
+  it("mounts object-prototype community ids through Sigma selection and focus flows", async () => {
+    const communityIds = OBJECT_PROTOTYPE_COMMUNITY_IDS;
+    const data = objectPrototypeCommunityInput();
+    const ownerDocument = new FakeDocument();
+    const container = ownerDocument.createElement("div");
+    const runtime = fakeSigmaRouteRuntime();
+    const manager = createGraphFacadeRouteManager(container as unknown as HTMLElement, {
+      state: {
+        ...projectGraphInput(data),
+        pins: {},
+        theme: "shan-shui",
+        focus: null,
+        typeFilters: {},
+        aggregationMarkers: [],
+        selection: null,
+        sourceCommunityId: null,
+        searchQuery: "",
+        searchResultIds: [],
+        temporaryObject: null
+      },
+      factories: {
+        createSigmaGlobal: (input) => createSigmaGlobalFacadeRenderer({ ...input, sigmaRuntime: runtime })
+      }
+    });
 
-    assert.deepEqual(
-      model.communities.map((community) => community.id).sort(),
-      [...communityIds].sort()
-    );
-    for (const communityId of communityIds) {
-      assert.equal(model.communityById[communityId]?.node_count, 2);
+    try {
+      await Promise.resolve();
+
+      assert.equal(runtime.instances.length, 1, "Sigma should mount before the lifecycle assertions run");
+      const sigma = runtime.instances[0];
+      assert.ok(sigma);
+      assert.deepEqual(sigma.getGraph().nodes(), communityIds.map((id) => `node-${id}`));
       assert.deepEqual(
-        model.nodes.filter((node) => node.community === communityId).map((node) => node.id),
-        [`node-${communityId}-a`, `node-${communityId}-b`]
+        sigma.getGraph().getAttribute("communities").map((community: { id: string }) => community.id),
+        communityIds
       );
+      for (const communityId of communityIds) {
+        const nodeId = `node-${communityId}`;
+        assert.equal(sigma.getGraph().getNodeAttribute(nodeId, "communityId"), communityId);
+
+        manager.select({ kind: "community", id: communityId });
+        assert.deepEqual(sigma.getGraph().getAttribute("selection").selectedCommunityIds, [communityId]);
+
+        manager.focusCommunity(communityId);
+        const sigmaRoot = findByClass(container, "sigma-global-renderer")[0];
+        assert.equal(manager.sourceCommunityId, communityId);
+        assert.equal(sigmaRoot?.dataset.sourceCommunityId, communityId);
+        assert.equal(sigmaRoot?.dataset.communityFocusId, communityId);
+        assert.deepEqual(sigma.getGraph().nodes(), [nodeId]);
+
+        manager.resetView();
+        assert.equal(manager.sourceCommunityId, null);
+        assert.equal(sigmaRoot?.dataset.sourceCommunityId, "");
+        assert.equal(sigmaRoot?.dataset.communityFocusId, "");
+        assert.deepEqual(sigma.getGraph().nodes(), communityIds.map((id) => `node-${id}`));
+        assert.deepEqual(sigma.getGraph().getAttribute("selection").selectedCommunityIds, []);
+      }
+    } finally {
+      manager.destroy();
     }
   });
 
@@ -2317,6 +2317,28 @@ describe("graph renderer lifecycle", () => {
     renderer.destroy();
   });
 });
+
+const OBJECT_PROTOTYPE_COMMUNITY_IDS = ["ordinary", "__proto__", "constructor", "toString"] as const;
+
+function objectPrototypeCommunityInput() {
+  return {
+    nodes: OBJECT_PROTOTYPE_COMMUNITY_IDS.map((community, index) => ({
+      id: `node-${community}`,
+      label: `Node ${index + 1}`,
+      type: "topic" as const,
+      community
+    })),
+    edges: [],
+    learning: {
+      communities: OBJECT_PROTOTYPE_COMMUNITY_IDS.map((id, index) => ({
+        id,
+        label: `${String.fromCharCode(65 + index)} Community`,
+        node_count: 1,
+        is_primary: index === 0
+      }))
+    }
+  };
+}
 
 function graphData(ids: string[]): GraphData {
   return graphDataWithCommunities(ids.map((id) => [id, "community-a"]));

--- a/packages/graph-engine/test/typed-graph-model.test.ts
+++ b/packages/graph-engine/test/typed-graph-model.test.ts
@@ -4,6 +4,70 @@ import { describe, it } from "node:test";
 import { buildAtlasModel, projectGraphInput } from "../src/model/atlas";
 
 describe("typed graph model", () => {
+  it("indexes object-prototype community metadata without losing labels or order", () => {
+    const communityIds = ["ordinary", "__proto__", "constructor", "toString"] as const;
+    const model = buildAtlasModel({
+      nodes: communityIds.map((community, index) => ({
+        id: `node-${community}`,
+        label: `Node ${index + 1}`,
+        type: "topic",
+        community
+      })),
+      edges: [],
+      learning: {
+        communities: communityIds.map((id, index) => ({
+          id,
+          label: `${String.fromCharCode(65 + index)} Community`,
+          node_count: 1,
+          is_primary: index === 0
+        }))
+      }
+    });
+
+    assert.deepEqual(model.communities.map((community) => community.id), communityIds);
+    for (const [index, communityId] of communityIds.entries()) {
+      assert.equal(Object.hasOwn(model.communityById, communityId), true);
+      assert.equal(model.communityById[communityId]?.id, communityId);
+      assert.equal(
+        model.communityById[communityId]?.label,
+        `${String.fromCharCode(65 + index)} Community`
+      );
+    }
+  });
+
+  it("derives object-prototype communities from node membership without metadata", () => {
+    const communityCases = [
+      { id: "ordinary", topicLabel: "Ordinary Topic", sourceCount: 0 },
+      { id: "__proto__", topicLabel: "Proto Topic", sourceCount: 1 },
+      { id: "constructor", topicLabel: "Constructor Topic", sourceCount: 2 },
+      { id: "toString", topicLabel: "ToString Topic", sourceCount: 3 }
+    ] as const;
+    const model = buildAtlasModel({
+      nodes: communityCases.flatMap(({ id, topicLabel, sourceCount }) => [
+        { id: `topic-${id}`, label: topicLabel, type: "topic", community: id },
+        ...Array.from({ length: sourceCount }, (_, index) => ({
+          id: `source-${id}-${index + 1}`,
+          label: `Source ${id} ${index + 1}`,
+          type: "source",
+          community: id
+        }))
+      ]),
+      edges: []
+    });
+
+    assert.deepEqual(
+      model.communities.map((community) => community.id).sort(),
+      communityCases.map(({ id }) => id).sort()
+    );
+    for (const { id, topicLabel, sourceCount } of communityCases) {
+      assert.equal(Object.hasOwn(model.communityById, id), true);
+      assert.equal(model.communityById[id]?.id, id);
+      assert.equal(model.communityById[id]?.label, topicLabel);
+      assert.equal(model.communityById[id]?.node_count, sourceCount + 1);
+      assert.equal(model.communityById[id]?.source_count, sourceCount);
+    }
+  });
+
   it("preserves sparse node array holes without inventing graph facts", () => {
     const nodes: unknown[] = [];
     nodes.length = 3;


### PR DESCRIPTION
## 说明

- #289 描述的崩溃已被后续的图谱模型和布局迁移修好，本次不重复修改现有产品逻辑。
- 增加 5 项专门的防回退检查，让普通社区名与 `__proto__`、`constructor`、`toString` 同时出现。
- 检查社区顺序、独立成员、说明文字、成员与来源数量、布局、公开入口、真实 Sigma 挂载、选择、进入社区和返回全局。
- 无预设社区信息时，各社区使用不同的成员数量和内容，避免错误串组仍然蒙混过关。

## 审查修正

- 收紧布局检查，错误分组不再能靠兜底位置通过。
- 等真实图谱挂载后再检查，并确认进入社区时图内节点真的收窄、返回后完整恢复。
- 检查社区说明文字和不同成员组，避免只看编号或数量造成误判。
- 将模型与布局检查放回各自负责的测试文件，生命周期文件只保留公开入口和真实图谱流程。

## 验证

- 专项检查：68 项全部通过，其中本次新增 5 项。
- 临时换回不安全的社区分组和索引方式后，本次新增检查会稳定失败。
- Node 22.19.0 下运行完整 `quality-and-tests`：全部通过；图谱引擎 814 项全部通过。
- 多轮独立复核已完成；最后一轮复核建议合并。

Closes #289

Parent tracking continues in #269.
