### PR TITLE
test(graph): 修复 #291 图谱交互回归夹具被后台重建换掉

### DIFF
--- a/tests/graph-workbench-interactions.regression-1.sh
+++ b/tests/graph-workbench-interactions.regression-1.sh
@@ -195,6 +195,8 @@ cat > "$workbench_kb/wiki/entities/$id.md" <<EOF
 这是节点$id 的正文。
 EOF
 done
+make_graph_fixture_warning_aware "$workbench_kb"
+fixture_build_id="$(graph_fixture_build_id "$workbench_kb")"
 cat > "$tmp_dir/home/.llm-wiki-agent/config.json" <<JSON
 {
   "version": 1,
@@ -242,6 +244,10 @@ GRAPH_WORKBENCH_CHROME_EXECUTABLE="$chrome_executable" \
 NODE_PATH="$playwright_node_path" \
 node "$REPO_ROOT/tests/browser/graph-workbench-interactions.mjs" \
     || { dump_dev_logs; fail "workbench graph interaction browser regression should pass"; }
+
+# 夹具被后台重建换掉时，上面的断言会在一份不同的图谱上通过或失败，问题很难看出来。
+[ "$(graph_fixture_build_id "$workbench_kb")" = "$fixture_build_id" ] \
+    || { dump_dev_logs; fail "workbench should not rebuild the fixture graph during the interaction regression"; }
 
 echo "Artifacts: $artifact_dir"
 echo "PASS: graph workbench interaction regression"

--- a/tests/lib/graph-html-engine-helpers.sh
+++ b/tests/lib/graph-html-engine-helpers.sh
@@ -77,6 +77,39 @@ graph_browser_playwright_node_path() {
     npx --yes -p playwright -c 'node -e "const path=require(\"path\"); console.log(path.dirname(process.env.PATH.split(\":\")[0]))"'
 }
 
+# 工作台把缺少 meta.warning_summary 的 graph-data.json 判定为过期产物，会在后台强制重建，
+# 把夹具换成真实构建结果（节点 id 变成页面路径、坐标丢失）。用真实成对产物写入夹具，
+# 浏览器断言才能一直落在同一份图谱上（#291）。
+make_graph_fixture_warning_aware() {
+    local kb_root="$1"
+
+    node - "$REPO_ROOT" "$kb_root" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const [repoRoot, kbRoot] = process.argv.slice(2);
+const { assembleGraphArtifactPair, commitGraphArtifactPair } = require(path.join(repoRoot, "scripts/lib/graph-warning-bundle"));
+const graphPath = path.join(kbRoot, "wiki/graph-data.json");
+const graphData = JSON.parse(fs.readFileSync(graphPath, "utf8"));
+if (graphData.meta) delete graphData.meta.warning_summary;
+(async () => {
+  const pair = assembleGraphArtifactPair({ graphData, groups: [], candidateSets: [] });
+  await commitGraphArtifactPair({
+    kbRoot,
+    graphPath,
+    warningPath: path.join(kbRoot, "wiki/graph-warnings.json"),
+    pair
+  });
+})().catch((error) => { console.error(error); process.exit(1); });
+NODE
+}
+
+graph_fixture_build_id() {
+    local kb_root="$1"
+
+    node -e 'const data = require(process.argv[1]); process.stdout.write(String(data.meta.warning_summary.build_id));' \
+        "$kb_root/wiki/graph-data.json"
+}
+
 build_graph_html_fixture_with_layout() {
     local tmp_dir="$1"
 


### PR DESCRIPTION
Fixes #291（follow-up tracker #269）

## 根因（有证据）

工作台把**缺少 `meta.warning_summary`** 的 `graph-data.json` 判定为过期产物（`readGraphWarningContext` → `legacy_without_summary`），会在后台强制重建。图谱交互回归的夹具正好缺这一段，于是浏览器还在跑断言时，夹具被真实重建结果替换：

- 节点 id 从 `A` 变成 `wiki/entities/A.md`
- x/y 坐标丢失、社区归属和边全部改变（13 节点只剩 1 条边）
- 磁盘上多出 `wiki/graph-warnings.json`

测试刷新后按旧 id 找 `[data-node-id='A']` 自然找不到，诊断里读到的就是 `data-pinned` 为空/false —— 这正是 #291 记录的现象。固定位置本身没有丢：`PUT /api/graph/layout` 返回 200，`.wiki-graph-layout.json` 里 `wiki/entities/A.md` 的 pin 一直在，刷新后路径 id 的节点 `data-pinned=true`。

同一个根因还解释了这条回归在 main 上**第一项缩放归属检查就失败**（重建落地时相机重新 fit，缩放测量失真）。

## 改动

- `tests/lib/graph-html-engine-helpers.sh`：新增 `make_graph_fixture_warning_aware`（用 `scripts/lib/graph-warning-bundle` 的 `assembleGraphArtifactPair` / `commitGraphArtifactPair` 写入成对产物）和 `graph_fixture_build_id`。
- `tests/graph-workbench-interactions.regression-1.sh`：启动前补齐成对产物；跑完核对 `build_id` 未变，夹具被换掉时直接失败，而不是静默换一份图谱继续断言。

## 验证

- `bash tests/graph-workbench-interactions.regression-1.sh` → PASS（修复前在缩放归属检查即失败，从未跑到固定/刷新断言）。
- 状态保持证据（同一次通过的运行）：`beforeDrag data-pinned=false` → `afterDrag true` → 社区返回 `true` → **刷新后 `true`**，布局读取仍带 `wiki/entities/A.md` 的固定位置。
- 逐节点对比确认刷新前后 13 个节点位置满足同一个仿射变换（scale 1.2715），即固定位置在世界坐标里被精确还原，只是相机重新 fit。
- `bash tests/graph-path-identity-build.regression-1.sh` → PASS（验证共享 helper 被其他脚本 source 后未受影响）。

## 说明

- 纯测试基建改动，按仓库惯例（如 `e7b5c93c`、`7dd71f45`）不加 CHANGELOG / README 条目。
- 未改动产品代码：工作台对旧知识库强制重建是既有设计，重建后 `migrateGraphLayoutPinsForIdentity` 会按页面路径迁移固定位置，用户侧固定状态不丢。
- 另发现 `tests/graph-community-reading-experience.regression-1.sh` 夹具有同一个缺陷（已实测被强制重建、测试失败）。补上同样两行后测试能跑得更远，但仍在另一处超时失败，属于另一个问题，本 PR 不含该改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)