### PR TITLE
test(workbench): 修复 #312 主流程测试对瞬态告警横幅的竞态依赖

### DIFF
--- a/workbench/web/test/browser/browser-main-flows.test.ts
+++ b/workbench/web/test/browser/browser-main-flows.test.ts
@@ -499,7 +499,14 @@ test("seven browser main flows cross the real frontend and backend", { timeout: 
 		const tamperBaseline = graphEventReceipts.length;
 		await page.getByRole("tab", { name: "对话" }).click();
 		await page.getByRole("tab", { name: "图谱" }).click();
-		await page.getByText("详情暂不可用，已安排重新构建。摘要和图谱仍可阅读。", { exact: true }).waitFor();
+		// “详情暂不可用”是瞬态：检测到损坏的同一响应会调度后台重建，重建完成的
+		// 权威快照可能先于横幅渲染落地（慢 runner 上稳定复现，#312）。所以只要求
+		// 观察到“瞬态横幅”或“已恢复的查看详情按钮”之一；篡改确实被检测并修复由
+		// 后面的 build_id 不变断言和 tamperBaseline 之后的 graph_updated 事件保证。
+		await page.getByText("详情暂不可用，已安排重新构建。摘要和图谱仍可阅读。", { exact: true })
+			.or(warningBanner.getByRole("button", { name: "查看详情" }))
+			.first()
+			.waitFor();
 		assert.equal(await warningBanner.getByText("wiki/synthesis/browser-warning-source.md", { exact: true }).count(), 0);
 		await page.locator("[data-graph-status='ready']").waitFor();
 		const warningIdentityAfterTamper = await page.evaluate(async (selectedKb) => {


### PR DESCRIPTION
Fixes #312

## 根因

`browser-main-flows.test.ts` 第 3 项在篡改 `graph-warnings.json` 并切回图谱标签后，硬等瞬态横幅「详情暂不可用，已安排重新构建。摘要和图谱仍可阅读。」。但检测到损坏的同一响应会调度后台重建，重建完成的权威快照可能先于横幅渲染落地（GraphPanel 的 authoritativeSnapshot 会作废在途 loadGraph 结果）——慢 runner 上横幅一次都不渲染，只能 30s 超时。#312 已用空 diff 探针（PR #311）证实该失败在与 main 逐字节相同的树上同样发生。

## 修复

等待条件改为二选一：瞬态横幅 **或** 恢复后的「查看详情」按钮（两者在 `GraphWarningsBanner` 里按 `details_status` 互斥渲染）。语义不放松：

- 篡改被检测且被修复，仍由 `build_id`/`details_sha256` 前后 deepEqual 断言 + `tamperBaseline` 之后必须出现的 `graph_updated` 事件保证；
- 泄漏断言（篡改文案不上屏）在两种状态下都成立：瞬态分支详情不可用，恢复分支重挂载后详情默认折叠（`useState(false)`）。

## 验证

- `npm run typecheck -w @llm-wiki-agent/web` 通过。
- 套件本地两次全过（5+4 pass, 0 fail）。
- **分支覆盖实验**：临时把等待条件改成只等恢复态按钮（模拟“横幅被错过”的最坏时序），端到端全过——证明恢复分支的全部下游断言（隐藏详情计数、ready、身份一致、sigma 渲染、泄漏检查、事件、展开详情）都成立；随后还原为正式 `.or()` 写法再跑一遍确认。
- 测试-only 改动，按仓库惯例不更新 CHANGELOG。

🤖 Generated with [Claude Code](https://claude.com/claude-code)