### PR TITLE
docs: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,4 +333,4 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=sdyckjq-lab/llm-wiki-skill&type=date)](https://www.star-history.com/?repos=sdyckjq-lab%2Fllm-wiki-skill&type=date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sdyckjq-lab/llm-wiki-skill&type=date)](https://star-history.dera.page/#sdyckjq-lab/llm-wiki-skill&type=date)


### PR DESCRIPTION
README 中的 Star History 图表目前已经失效，无法加载。原因是原图表服务因 GitHub 数据接口限制而不可用，继续使用会一直显示空白。

本次改动把图表镜像地址和链接切换到可用的新服务，图表端点使用 /svg，外层链接改为哈希形式，恢复图表显示。该方案已在大量仓库验证可用，无需任何额外配置。